### PR TITLE
Ubuntu 14.04 is EOLd, use 16.04 instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: required
-dist: trusty
+dist: xenial
 
 matrix:
   include:
   - language: java
-    jdk: oraclejdk8
+    jdk: openjdk8
 
 script:
   - ./gradlew clean assemble --stacktrace


### PR DESCRIPTION
This PR switches Travis CI from Ubuntu 14.04 Trusty to Ubuntu 16.04 Xenial. Ubuntu 14.04 support [ended 2 months ago](https://endoflife.date/ubuntu).