### PR TITLE
Add Web JS as a LibraryInfo.Language option

### DIFF
--- a/src/opentelemetry/proto/agent/common/v1/common.proto
+++ b/src/opentelemetry/proto/agent/common/v1/common.proto
@@ -74,6 +74,7 @@ message LibraryInfo {
     PHP = 7;
     PYTHON = 8;
     RUBY = 9;
+    WEB_JS = 10;
   }
 
   // Language of OpenTelemetry Library.


### PR DESCRIPTION
This parallels https://github.com/census-instrumentation/opencensus-proto/pull/198. The [opentelemetry-js](https://github.com/open-telemetry/opentelemetry-js) repo is planning to support both Node and the browser, but there will be platform-specific packages and utilities.

Being able to differentiate between the two platforms in the agent will enable differentiation of the two different platforms as sources of traces (whether for customer filtering or for library usage measurement by vendors).

cc/ @rochdev and @mayurkale22