### PR TITLE
[WIP] Performance optimize Point protobuf message

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -122,32 +122,51 @@ message LabelValue {
   bool has_value = 2;
 }
 
-// A timestamped measurement.
+// Point is a timestamped measurement.
 message Point {
-  // Must be present for counter/cumulative metrics. The time when the
-  // cumulative value was reset to zero. The cumulative value is over the time
-  // interval (start_timestamp, timestamp]. If not specified, the backend can
-  // use the previous recorded value.
-  google.protobuf.Timestamp start_timestamp = 1;
+  // start_time_unixnano is the time when the cumulative value was reset to zero.
+  // Must be present for counter/cumulative metrics. The cumulative value is over the time
+  // interval (start_time_unixnano, timestamp_unixnano].
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  int64 start_time_unixnano = 1;
 
-  // The moment when this point was recorded.
-  // If not specified, the timestamp will be decided by the backend.
-  google.protobuf.Timestamp timestamp = 2;
+  // timestamp_unixnano is the moment when this point was recorded.
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  int64 timestamp_unixnano = 2;
 
-  // The actual point value.
-  oneof value {
-    // A 64-bit integer.
-    int64 int64_value = 3;
+  // start_time_unspecified must be set to true if start_time_unixnano value is unspecified.
+  // In that case the backend can use the previous recorded value for start_time_unixnano.
+  bool start_time_unspecified = 3;
 
-    // A 64-bit double-precision floating-point number.
-    double double_value = 4;
+  // timestamp_unspecified must be set to true if timestamp_unixnano value is unspecified.
+  // In that case timestamp_unixnano value will be decided by the backend.
+  bool timestamp_unspecified = 4;
 
-    // A histogram value.
-    HistogramValue histogram_value = 5;
+  // ValueType is the enumeration of possible types that Point's value can have.
+  enum ValueType {
+    INT64      = 0;
+    DOUBLE     = 1;
+    HISTOGRAM  = 2;
+    SUMMARY    = 3;
+  };
 
-    // A summary value. This is not recommended, since it cannot be aggregated.
-    SummaryValue summary_value = 6;
-  }
+  // type of the value.
+  ValueType type = 5;
+
+  // Only one of the following fields is supposed to contain data (determined by `type` field value).
+  // This is deliberately not using Protobuf `oneof` for performance reasons (verified by benchmarks).
+
+  // A 64-bit integer.
+  int64 int64_value = 6;
+
+  // A 64-bit double-precision floating-point number.
+  double double_value = 7;
+
+  // A histogram value.
+  HistogramValue histogram_value = 8;
+
+  // A summary value. This is not recommended, since it cannot be aggregated.
+  SummaryValue summary_value = 9;
 }
 
 // Histogram contains summary statistics for a population of values. It may


### PR DESCRIPTION
Changes in Point message:

- Replace google.protobuf.Timestamp by int64 time in unix epoch nanoseconds.
- Replace oneof by a set of fields.

This is part 1 one of overall changes that yield about 2x performance improvement.

Benchmarking
============

Simple Go benchmark of *all* changes that I plan to propose demonstrates the following
improvement compared to OpenCensus Metrics encoding and decoding:

```
BenchmarkEncode/OpenCensus/Metrics-8    8	 660200437 ns/op	80432000 B/op	 1787000 allocs/op
BenchmarkEncode/OTLP/Metrics-8         19	 296717207 ns/op	49152000 B/op	    1000 allocs/op
BenchmarkDecode/OpenCensus/Metrics-8    5	1040309846 ns/op	458263993 B/op	11877000 allocs/op
BenchmarkDecode/OTLP/Metrics-8         12	 501670950 ns/op	346696049 B/op	 7124000 allocs/op
```

Encoding and decoding is about 2 times faster with new format. Memory usage is also
significantly smaller, number of allocations during decoding is roughly half of OpenCensus
which reflects the fact that many messages were eliminated and embedded inside others.

Benchmarks encode and decode 1000 batches of 2 metrics: in each batch 50 int64 Gauges with
5 time series and 50 Histograms of doubles with 1 time series and single bucket. Each time
series for both metrics contains 5 data points. Both metrics have 2 labels.

Benchmark source code is available at:
https://github.com/tigrannajaryan/exp-otelproto/blob/master/encodings/encoding_test.go