### PR TITLE
Optimize LabelValues in metric proto

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -160,20 +160,24 @@ message MetricDescriptor {
 message Int64TimeSeries {
   // The set of label values that uniquely identify this timeseries. Applies to
   // all points. The order of label values must match that of label keys in the
-  // metric descriptor.
-  repeated LabelValue label_values = 1;
+  // metric descriptor. Each element in this array is the value of the key defined at the
+  // corresponding index of MetricDescriptor.label_keys array. The number of elements
+  // in this array and MetricDescriptor.label_keys array must be the same.
+  repeated string label_values = 1;
 
   // The data points of this timeseries.
   repeated Int64Value points = 2;
 }
 
-// eDoubleTimeSeries is a list of data points that describes the time-varying values
+// DoubleTimeSeries is a list of data points that describes the time-varying values
 // of a double metric.
 message DoubleTimeSeries {
   // The set of label values that uniquely identify this timeseries. Applies to
   // all points. The order of label values must match that of label keys in the
-  // metric descriptor.
-  repeated LabelValue label_values = 1;
+  // metric descriptor. Each element in this array is the value of the key defined at the
+  // corresponding index of MetricDescriptor.label_keys array. The number of elements
+  // in this array and MetricDescriptor.label_keys array must be the same.
+  repeated string label_values = 1;
 
   // The data points of this timeseries.
   repeated DoubleValue points = 2;
@@ -184,8 +188,10 @@ message DoubleTimeSeries {
 message HistogramTimeSeries {
   // The set of label values that uniquely identify this timeseries. Applies to
   // all points. The order of label values must match that of label keys in the
-  // metric descriptor.
-  repeated LabelValue label_values = 1;
+  // metric descriptor. Each element in this array is the value of the key defined at the
+  // corresponding index of MetricDescriptor.label_keys array. The number of elements
+  // in this array and MetricDescriptor.label_keys array must be the same.
+  repeated string label_values = 1;
 
   // The data points of this timeseries.
   repeated HistogramValue points = 2;
@@ -227,20 +233,13 @@ message HistogramTimeSeries {
 message SummaryTimeSeries {
   // The set of label values that uniquely identify this timeseries. Applies to
   // all points. The order of label values must match that of label keys in the
-  // metric descriptor.
-  repeated LabelValue label_values = 1;
+  // metric descriptor. Each element in this array is the value of the key defined at the
+  // corresponding index of MetricDescriptor.label_keys array. The number of elements
+  // in this array and MetricDescriptor.label_keys array must be the same.
+  repeated string label_values = 1;
 
   // The data points of this timeseries.
   repeated SummaryValue points = 2;
-}
-
-// Label value or indication that the value is missing
-message LabelValue {
-  // The value for the label.
-  string value = 1;
-  // If false the value field is ignored and considered not set.
-  // This is used to differentiate a missing label from an empty string.
-  bool has_value = 2;
 }
 
 // Int64Value is a timestamped measurement of int64 value.


### PR DESCRIPTION
Optimize LabelValues in metric proto

LabelValues is now a string array.

Benchmarking results are below (Baseline is current `master`, Proposed is after this commit).
This change reduces CPU usage up to 40% for one-data-point timeseries encoding and reduces
memory consumption by about 25%.

```
===== Encoded sizes
Encoding                       Uncompressed  Improved        Compressed  Improved
Baseline/Metric/Histogram       13569 bytes  [1.000], gziped  774 bytes  [1.000]
Proposed/Metric/Histogram       13159 bytes  [1.031], gziped  781 bytes  [0.991]

Encoding                       Uncompressed  Improved        Compressed  Improved
Baseline/Metric/MixOne          48530 bytes  [1.000], gziped 1671 bytes  [1.000]
Proposed/Metric/MixOne          45720 bytes  [1.061], gziped 1677 bytes  [0.996]

Encoding                       Uncompressed  Improved        Compressed  Improved
Baseline/Metric/MixSeries       97867 bytes  [1.000], gziped 6620 bytes  [1.000]
Proposed/Metric/MixSeries       95067 bytes  [1.029], gziped 6587 bytes  [1.005]

goos: darwin
goarch: amd64
pkg: github.com/tigrannajaryan/exp-otelproto/encodings
BenchmarkEncode/Baseline/Metric/Int64-8        	      34	 156113692 ns/op
BenchmarkEncode/Proposed/Metric/Int64-8        	      67	  91936291 ns/op

BenchmarkEncode/Baseline/Metric/Summary-8      	     120	  50891750 ns/op
BenchmarkEncode/Proposed/Metric/Summary-8      	     141	  42172658 ns/op

BenchmarkEncode/Baseline/Metric/Histogram-8    	      91	  64816532 ns/op
BenchmarkEncode/Proposed/Metric/Histogram-8    	     100	  56837230 ns/op

BenchmarkEncode/Baseline/Metric/HistogramSeries-8         	      37	 159643499 ns/op
BenchmarkEncode/Proposed/Metric/HistogramSeries-8         	      40	 149983727 ns/op

BenchmarkEncode/Baseline/Metric/Mix-8                     	      20	 287582195 ns/op
BenchmarkEncode/Proposed/Metric/Mix-8                     	      31	 196378683 ns/op

BenchmarkEncode/Baseline/Metric/MixSeries-8               	       8	 681122815 ns/op
BenchmarkEncode/Proposed/Metric/MixSeries-8               	      10	 540018386 ns/op

BenchmarkDecode/Baseline/Metric/Int64-8                   	      18	 319038450 ns/op	206696040 B/op	 5724000 allocs/op
BenchmarkDecode/Proposed/Metric/Int64-8                   	      22	 265034276 ns/op	154696039 B/op	 4724000 allocs/op

BenchmarkDecode/Baseline/Metric/Summary-8                 	      52	 117972148 ns/op	79496034 B/op	 2024000 allocs/op
BenchmarkDecode/Proposed/Metric/Summary-8                 	      60	 104489249 ns/op	69096035 B/op	 1824000 allocs/op

BenchmarkDecode/Baseline/Metric/Histogram-8               	      36	 161440606 ns/op	104296028 B/op	 2624000 allocs/op
BenchmarkDecode/Proposed/Metric/Histogram-8               	      40	 147001580 ns/op	93896032 B/op	 2424000 allocs/op

BenchmarkDecode/Baseline/Metric/HistogramSeries-8         	      16	 345726946 ns/op	233896053 B/op	 5324000 allocs/op
BenchmarkDecode/Proposed/Metric/HistogramSeries-8         	      16	 333473715 ns/op	223496045 B/op	 5124000 allocs/op

BenchmarkDecode/Baseline/Metric/Mix-8                     	       9	 611361046 ns/op	391240035 B/op	10326000 allocs/op
BenchmarkDecode/Proposed/Metric/Mix-8                     	      10	 531026674 ns/op	318440033 B/op	 8926000 allocs/op

BenchmarkDecode/Baseline/Metric/MixSeries-8               	       5	1179081837 ns/op	776840057 B/op	18026000 allocs/op
BenchmarkDecode/Proposed/Metric/MixSeries-8               	       5	1077597483 ns/op	704040035 B/op	16626000 allocs/op
```