### PR TITLE
Use unary gRPC for export requests

### DIFF
--- a/opentelemetry/proto/agent/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/agent/metrics/v1/metrics_service.proto
@@ -30,7 +30,7 @@ option java_outer_classname = "MetricsServiceProto";
 service MetricsService {
   // For performance reasons, it is recommended to keep this RPC
   // alive for the entire life of the application.
-  rpc Export(stream ExportMetricsServiceRequest) returns (stream ExportMetricsServiceResponse) {}
+  rpc Export(ExportMetricsServiceRequest) returns (ExportMetricsServiceResponse) {}
 }
 
 message ExportMetricsServiceRequest {

--- a/opentelemetry/proto/agent/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/agent/trace/v1/trace_service.proto
@@ -40,7 +40,7 @@ service TraceService {
 
   // For performance reasons, it is recommended to keep this RPC
   // alive for the entire life of the application.
-  rpc Export(stream ExportTraceServiceRequest) returns (stream ExportTraceServiceResponse) {}
+  rpc Export(ExportTraceServiceRequest) returns (ExportTraceServiceResponse) {}
 }
 
 message CurrentLibraryConfig {


### PR DESCRIPTION
This implements RFC0035 requirement to use unary gRPC:
https://github.com/open-telemetry/oteps/blob/master/text/0035-opentelemetry-protocol.md#otlp-over-grpc