### PR TITLE
Change timestamp data type to sfixed64 nanoseconds since Unix epoch

### DIFF
--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -16,7 +16,6 @@ syntax = "proto3";
 
 package opentelemetry.proto.trace.v1;
 
-import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
@@ -136,28 +135,21 @@ message Span {
   // and `SERVER` (callee) to identify queueing latency associated with the span.
   SpanKind kind = 7;
 
-  // The start time of the span. On the client side, this is the time kept by
-  // the local machine where the span execution starts. On the server side, this
+  // start_time_unixnano is the start time of the span. On the client side, this is the time
+  // kept by the local machine where the span execution starts. On the server side, this
   // is the time when the server's application handler starts running.
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
-  // This field is semantically required. When not set on receive -
-  // receiver should set it to the value of end_time field if it was
-  // set. Or to the current time if neither was set. It is important to
-  // keep end_time > start_time for consistency.
-  //
-  // This field is required.
-  google.protobuf.Timestamp start_time = 8;
+  // This field is semantically required and it is expected that end_time >= start_time.
+  sfixed64 start_time_unixnano = 8;
 
-  // The end time of the span. On the client side, this is the time kept by
-  // the local machine where the span execution ends. On the server side, this
+  // end_time_unixnano is the end time of the span. On the client side, this is the time
+  // kept by the local machine where the span execution ends. On the server side, this
   // is the time when the server application handler stops running.
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
-  // This field is semantically required. When not set on receive -
-  // receiver should set it to start_time value. It is important to
-  // keep end_time > start_time for consistency.
-  //
-  // This field is required.
-  google.protobuf.Timestamp end_time = 9;
+  // This field is semantically required and it is expected that end_time >= start_time.
+  sfixed64 end_time_unixnano = 9;
 
   // attributes is a collection of key/value pairs. The value can be a string,
   // an integer, a double or the Boolean values `true` or `false`. Note, global attributes
@@ -176,8 +168,9 @@ message Span {
 
   // A time-stamped event in the Span.
   message TimedEvent {
-    // The time the event occurred.
-    google.protobuf.Timestamp time = 1;
+    // time_unixnano is the time the event occurred.
+    // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+    sfixed64 time_unixnano = 1;
 
     // A text annotation with a set of attributes.
     message Event {


### PR DESCRIPTION
The change to int64 is proposed by RFC0059 [1]. In this commit there is a small deviation from
the RFC: here we use sfixed64 instead of int64 to make it consistent with changes already
done for Metrics proto [2]. Experiments proved sfixed64 to be more suitable for timestamps.

[1] https://github.com/open-telemetry/oteps/blob/master/text/0059-otlp-trace-data-format.md
[2] https://github.com/open-telemetry/opentelemetry-proto/pull/33