### PR TITLE
Use fixed64 instead of sfixed64 for timestsamps

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -257,11 +257,11 @@ message Int64Value {
   // compact encoding on the wire.
   // If the value of 0 occurs for the first data point in the timeseries it means that
   // the timestamp is unspecified. In that case the timestamp may be decided by the backend.
-  sfixed64 start_time_unixnano = 1;
+  fixed64 start_time_unixnano = 1;
 
   // timestamp_unixnano is the moment when this value was recorded.
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-  sfixed64 timestamp_unixnano = 2;
+  fixed64 timestamp_unixnano = 2;
 
   // value itself.
   int64 value = 3;
@@ -282,11 +282,11 @@ message DoubleValue {
   // compact encoding on the wire.
   // If the value of 0 occurs for the first data point in the timeseries it means that
   // the timestamp is unspecified. In that case the timestamp may be decided by the backend.
-  sfixed64 start_time_unixnano = 1;
+  fixed64 start_time_unixnano = 1;
 
   // timestamp_unixnano is the moment when this value was recorded.
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-  sfixed64 timestamp_unixnano = 2;
+  fixed64 timestamp_unixnano = 2;
 
   // value itself.
   double value = 3;
@@ -306,11 +306,11 @@ message HistogramValue {
   // If the value of 0 occurs for the first data point in the timeseries it means that
   // the timestamp is unspecified. In that case the timestamp may be decided by the backend.
   // Note: this field is always unspecified and ignored if MetricDescriptor.type==GAUGE_HISTOGRAM.
-  sfixed64 start_time_unixnano = 1;
+  fixed64 start_time_unixnano = 1;
 
   // timestamp_unixnano is the moment when this value was recorded.
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-  sfixed64 timestamp_unixnano = 2;
+  fixed64 timestamp_unixnano = 2;
 
   // count is the number of values in the population. Must be non-negative. This value
   // must be equal to the sum of the "count" fields in buckets if a histogram is
@@ -339,7 +339,7 @@ message HistogramValue {
 
       // timestamp_unixnano is the moment when this exemplar was recorded.
       // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-      sfixed64 timestamp_unixnano = 2;
+      fixed64 timestamp_unixnano = 2;
 
       // exemplar_attachments are contextual information about the example value.
       // Keys in this list must be unique.
@@ -386,11 +386,11 @@ message SummaryValue {
   // compact encoding on the wire.
   // If the value of 0 occurs for the first data point in the timeseries it means that
   // the timestamp is unspecified. In that case the timestamp may be decided by the backend.
-  sfixed64 start_time_unixnano = 1;
+  fixed64 start_time_unixnano = 1;
 
   // timestamp_unixnano is the moment when this value was recorded.
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-  sfixed64 timestamp_unixnano = 2;
+  fixed64 timestamp_unixnano = 2;
 
   // The total number of recorded values since start_time. Optional since
   // some systems don't expose this.

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -141,7 +141,7 @@ message Span {
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
   // This field is semantically required and it is expected that end_time >= start_time.
-  sfixed64 start_time_unixnano = 8;
+  fixed64 start_time_unixnano = 8;
 
   // end_time_unixnano is the end time of the span. On the client side, this is the time
   // kept by the local machine where the span execution ends. On the server side, this
@@ -149,7 +149,7 @@ message Span {
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
   // This field is semantically required and it is expected that end_time >= start_time.
-  sfixed64 end_time_unixnano = 9;
+  fixed64 end_time_unixnano = 9;
 
   // attributes is a collection of key/value pairs. The value can be a string,
   // an integer, a double or the Boolean values `true` or `false`. Note, global attributes
@@ -170,7 +170,7 @@ message Span {
   message TimedEvent {
     // time_unixnano is the time the event occurred.
     // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-    sfixed64 time_unixnano = 1;
+    fixed64 time_unixnano = 1;
 
     // A text annotation with a set of attributes.
     message Event {


### PR DESCRIPTION
fixed64 is more suitable for timestamps since we don't really care about
timestamps before Unix epoch.

There is no performance difference but semantically unsigned integer is
a better representation.