### PR TITLE
Implement Result Code as required by OTLP

### DIFF
--- a/opentelemetry/proto/agent/common/v1/common.proto
+++ b/opentelemetry/proto/agent/common/v1/common.proto
@@ -95,3 +95,20 @@ message ServiceInfo {
 
   // TODO(songya): add more fields as needed.
 }
+
+// ExportResultCode is the result code returned in the export responses.
+enum ExportResultCode {
+  // Telemetry data is successfully processed by the server.
+  Success = 0;
+
+  // processing of telemetry data failed. The client MUST NOT retry
+  // sending the same telemetry data. The telemetry data MUST be dropped.
+  // This for example can happen when the request contains bad data and
+  // cannot be deserialized or otherwise processed by the server.
+  FailedNotRetryable = 1;
+
+  // Processing of telemetry data failed. The client SHOULD record the
+  // error and may retry exporting the same data after some time. This
+  // for example can happen when the server is overloaded.
+  FailedRetryable = 2;
+}

--- a/opentelemetry/proto/agent/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/agent/metrics/v1/metrics_service.proto
@@ -51,4 +51,6 @@ message ExportMetricsServiceRequest {
 }
 
 message ExportMetricsServiceResponse {
+  // result_code indicates the result of processing the export request.
+  opentelemetry.proto.agent.common.v1.ExportResultCode result_code = 1;
 }

--- a/opentelemetry/proto/agent/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/agent/trace/v1/trace_service.proto
@@ -80,4 +80,6 @@ message ExportTraceServiceRequest {
 }
 
 message ExportTraceServiceResponse {
+  // result_code indicates the result of processing the export request.
+  opentelemetry.proto.agent.common.v1.ExportResultCode result_code = 1;
 }


### PR DESCRIPTION
This change implements OTLP requirement of Result Code. OTLP describes
how it is used in the export responses:
https://github.com/open-telemetry/oteps/blob/master/text/0035-opentelemetry-protocol.md#result-code