### PR TITLE
Move StringKeyValue and AttributeKeyValue to a common.proto

### DIFF
--- a/opentelemetry/proto/common/v1/common.proto
+++ b/opentelemetry/proto/common/v1/common.proto
@@ -1,0 +1,54 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.common.v1;
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.common.v1";
+option java_outer_classname = "CommonProto";
+
+// AttributeKeyValue is a key-value pair that is used to store Span attributes, Link
+// attributes, etc.
+message AttributeKeyValue {
+  // ValueType is the enumeration of possible types that value can have.
+  enum ValueType {
+    STRING  = 0;
+    INT   = 1;
+    DOUBLE  = 2;
+    BOOL    = 3;
+  };
+
+  // key part of the key-value pair.
+  string key = 1;
+
+  // type of the value.
+  ValueType type = 2;
+
+  // Only one of the following fields is supposed to contain data (determined by `type` field).
+  // This is deliberately not using Protobuf `oneof` for performance reasons (verified by benchmarks).
+
+  string string_value = 3;
+  int64 int_value = 4;
+  double double_value = 5;
+  bool bool_value = 6;
+}
+
+// StringKeyValue is a pair of key/value strings. This is the simpler (and faster) version
+// of AttributeKeyValue that only supports string values.
+message StringKeyValue {
+  string key = 1;
+  string value = 2;
+}

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package opentelemetry.proto.metrics.v1;
 
 import "google/protobuf/wrappers.proto";
+import "opentelemetry/proto/common/v1/common.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
 option java_multiple_files = true;
@@ -344,7 +345,7 @@ message HistogramValue {
 
       // exemplar_attachments are contextual information about the example value.
       // Keys in this list must be unique.
-      repeated StringKeyValuePair attachments = 3;
+      repeated opentelemetry.proto.common.v1.StringKeyValue attachments = 3;
     }
 
     // exemplar is an optional representative value of the bucket.
@@ -363,13 +364,6 @@ message HistogramValue {
   // must also be present and number of elements in this field must be equal to the
   // number of buckets defined by bucket_options.
   repeated Bucket buckets = 5;
-}
-
-// StringKeyValuePair is a pair of key/value strings.
-// TODO: consider unifying this with Resource and Span Attribute key/value pairs.
-message StringKeyValuePair {
-  string key = 1;
-  string value = 2;
 }
 
 // The start_timestamp only applies to the count and sum in the SummaryValue.

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package opentelemetry.proto.trace.v1;
 
 import "google/protobuf/wrappers.proto";
+import "opentelemetry/proto/common/v1/common.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
 option java_multiple_files = true;
@@ -159,7 +160,7 @@ message Span {
   //     "/http/server_latency": 300
   //     "abc.com/myattribute": true
   //     "abc.com/score": 10.239
-  repeated AttributeKeyValue attributes = 10;
+  repeated opentelemetry.proto.common.v1.AttributeKeyValue attributes = 10;
 
   // dropped_attributes_count is the number of attributes that were discarded. Attributes
   // can be discarded because their keys are too long or because there are too many
@@ -178,7 +179,7 @@ message Span {
       string name = 1;
 
       // attributes is a collection of attribute key/value pairs on the event.
-      repeated AttributeKeyValue attributes = 2;
+      repeated opentelemetry.proto.common.v1.AttributeKeyValue attributes = 2;
 
       // dropped_attributes_count is the number of dropped attributes. If the value is 0,
       // then no attributes were dropped.
@@ -219,7 +220,7 @@ message Span {
     Tracestate tracestate = 3;
 
     // attributes is a collection of attribute key/value pairs on the link.
-    repeated AttributeKeyValue attributes = 4;
+    repeated opentelemetry.proto.common.v1.AttributeKeyValue attributes = 4;
 
     // dropped_attributes_count is the number of dropped attributes. If the value is 0,
     // then no attributes were dropped.
@@ -248,32 +249,6 @@ message Span {
   // An optional number of child spans that were generated while this span
   // was active. If set, allows an implementation to detect missing child spans.
   google.protobuf.UInt32Value child_span_count = 15;
-}
-
-// AttributeKeyValue is a key-value pair that is used to store Span attributes, Link
-// attributes, etc.
-message AttributeKeyValue {
-  // ValueType is the enumeration of possible types that value can have.
-  enum ValueType {
-    STRING  = 0;
-    INT   = 1;
-    DOUBLE  = 2;
-    BOOL    = 3;
-  };
-
-  // key part of the key-value pair.
-  string key = 1;
-
-  // type of the value.
-  ValueType type = 2;
-
-  // Only one of the following fields is supposed to contain data (determined by `type` field).
-  // This is deliberately not using Protobuf `oneof` for performance reasons (verified by benchmarks).
-
-  string string_value = 3;
-  int64 int_value = 4;
-  double double_value = 5;
-  bool bool_value = 6;
 }
 
 // The Status type defines a logical error model that is suitable for different


### PR DESCRIPTION
Moved StringKeyValue and AttributeKeyValue into a common.proto file so that
they can be used from other proto files if necessary.