### PR TITLE
Remove unnecessary wrapping of int32

### DIFF
--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -245,9 +245,9 @@ message Span {
   // Status.Ok (code = 0).
   Status status = 14;
 
-  // An optional number of child spans that were generated while this span
-  // was active. If set, allows an implementation to detect missing child spans.
-  google.protobuf.UInt32Value child_span_count = 15;
+  // child_span_count is an optional number of local child spans that were generated while this
+  // span was active. If set, allows an implementation to detect missing child spans.
+  uint32 child_span_count = 15;
 }
 
 // AttributeKeyValue is a key-value pair that is used to store Span attributes, Link


### PR DESCRIPTION
Implement change approved in https://github.com/open-telemetry/oteps/blob/master/text/0059-otlp-trace-data-format.md

Minor deviation from the approved change: we use uint32 instead of int32
since child count cannot be a negative number and unsigned number is
semantically a better fit.