### PR TITLE
Remove wrapping of int and double value from SummaryValue message

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -16,7 +16,6 @@ syntax = "proto3";
 
 package opentelemetry.proto.metrics.v1;
 
-import "google/protobuf/wrappers.proto";
 import "opentelemetry/proto/common/v1/common.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
@@ -389,12 +388,11 @@ message SummaryValue {
 
   // The total number of recorded values since start_time. Optional since
   // some systems don't expose this.
-  google.protobuf.Int64Value count = 3;
+  fixed64 count = 3;
 
   // The total sum of recorded values since start_time. Optional since some
   // systems don't expose this. If count is zero then this field must be zero.
-  // This field must be unset if the sum is not available.
-  google.protobuf.DoubleValue sum = 4;
+  double sum = 4;
 
   // Represents the value at a given percentile of a distribution.
   message ValueAtPercentile {


### PR DESCRIPTION
This micro-optimization reduces CPU and memory usage.

```
goos: darwin
goarch: amd64
pkg: github.com/tigrannajaryan/exp-otelproto/encodings
BenchmarkEncode/Baseline/Metric/Summary-8      	     120	  50042473 ns/op
BenchmarkEncode/Proposed/Metric/Summary-8      	     136	  43423088 ns/op

BenchmarkEncode/Baseline/Metric/Mix-8                     	      28	 206595979 ns/op
BenchmarkEncode/Proposed/Metric/Mix-8                     	      30	 199870715 ns/op

BenchmarkEncode/Baseline/Metric/MixSeries-8               	       9	 592705353 ns/op
BenchmarkEncode/Proposed/Metric/MixSeries-8               	      10	 539199628 ns/op

BenchmarkDecode/Baseline/Metric/Summary-8                 	      51	 119929790 ns/op	78696041 B/op	 2024000 allocs/op
BenchmarkDecode/Proposed/Metric/Summary-8                 	      56	 104306363 ns/op	69096032 B/op	 1824000 allocs/op

BenchmarkDecode/Baseline/Metric/Mix-8                     	      10	 545856843 ns/op	328040062 B/op	 9126000 allocs/op
BenchmarkDecode/Proposed/Metric/Mix-8                     	      10	 526862286 ns/op	318440044 B/op	 8926000 allocs/op

BenchmarkDecode/Baseline/Metric/MixSeries-8               	       5	1161078696 ns/op	752040067 B/op	17626000 allocs/op
BenchmarkDecode/Proposed/Metric/MixSeries-8               	       5	1075300086 ns/op	704040064 B/op	16626000 allocs/op
```