### PR TITLE
Use fixed64 fields instead of []byte for trace and span ids

### DIFF
--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -24,49 +24,64 @@ option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.trace.v1";
 option java_outer_classname = "TraceProto";
 
-// A span represents a single operation within a trace. Spans can be
+// Span represents a single operation within a trace. Spans can be
 // nested to form a trace tree. Spans may also be linked to other spans
-// from the same or different trace. And form graphs. Often, a trace
+// from the same or different trace and form graphs. Often, a trace
 // contains a root span that describes the end-to-end latency, and one
 // or more subspans for its sub-operations. A trace can also contain
 // multiple root spans, or none at all. Spans do not need to be
 // contiguous - there may be gaps or overlaps between spans in a trace.
 //
-// The next id is 17.
+// The next field id is 18.
 message Span {
-  // A unique identifier for a trace. All spans from the same trace share
-  // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes
-  // is considered invalid.
+  // trace_id is the unique identifier of a trace. All spans from the same trace share
+  // the same `trace_id`.
   //
-  // This field is semantically required. Receiver should generate new
-  // random trace_id if empty or invalid trace_id was received.
+  // This field is semantically required. If an invalid trace ID was received:
+  // - The receiver MAY reject the invalid data and respond with the appropriate error
+  //   code to the sender.
+  // - The receiver MAY accept the invalid data and attempt to correct it.
   //
-  // This field is required.
-  bytes trace_id = 1;
+  // The ID is a 16-byte value represented using two fixed64 fields. An ID with
+  // value of 0 for all bytes is considered invalid.
+  // To convert this pair of fixed64 fields to an ID represented as a 16-byte array put
+  // trace_id_high in big-endian order in the first 8 bytes and trace_id_low in the
+  // last 8 bytes. Go example code:
+  //    var traceIDBytes [16]byte
+  // 	binary.BigEndian.PutUint64(traceIDBytes[:], trace_id_high)
+  //	binary.BigEndian.PutUint64(traceIDBytes[8:], trace_id_low)
+  fixed64 trace_id_high = 1;
+  fixed64 trace_id_low = 2;
 
-  // A unique identifier for a span within a trace, assigned when the span
-  // is created. The ID is an 8-byte array. An ID with all zeroes is considered
-  // invalid.
+  // span_id is a unique identifier for a span within a trace, assigned when the span
+  // is created.
   //
-  // This field is semantically required. Receiver should generate new
-  // random span_id if empty or invalid span_id was received.
+  // This field is semantically required. If an invalid span ID was received:
+  // - The receiver MAY reject the invalid data and respond with the appropriate error
+  //   code to the sender.
+  // - The receiver MAY accept the invalid data and attempt to correct it.
   //
-  // This field is required.
-  bytes span_id = 2;
+  // The ID is an 8-byte value represented as a fixed64 field. An ID with value of 0
+  // for all bytes is considered invalid.
+  // To convert this field to an ID represented as an 8-byte array put span_id in big-endian
+  // order in the byte array. Go example code:
+  //    var spanIDBytes [8]byte
+  // 	binary.BigEndian.PutUint64(traceIDBytes[:], span_id)
+  fixed64 span_id = 3;
 
   // tracestate conveys information about request position in multiple distributed tracing graphs.
   // It is a tracestate in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
   // See also https://github.com/w3c/distributed-tracing for more details about this field.
-  string tracestate = 3;
+  string tracestate = 4;
 
-  // The `span_id` of this span's parent span. If this is a root span, then this
-  // field must be empty. The ID is an 8-byte array.
-  bytes parent_span_id = 4;
+  // parent_span_id is the `span_id` of this span's parent span. If this is a root span, then this
+  // field must be 0. See span_id for ID value byte order explanation.
+  fixed64 parent_span_id = 5;
 
   // An optional resource that is associated with this span. If not set, this span
   // should be part of a ResourceSpans that does include the resource information, unless
   // resource information is unknown.
-  opentelemetry.proto.resource.v1.Resource resource = 5;
+  opentelemetry.proto.resource.v1.Resource resource = 6;
 
   // A description of the span's operation.
   //
@@ -81,7 +96,7 @@ message Span {
   // receiver to fix the empty span name.
   //
   // This field is required.
-  string name = 6;
+  string name = 7;
 
   // Type of span. Can be used to specify additional relationships between spans
   // in addition to a parent/child relationship.
@@ -115,7 +130,7 @@ message Span {
   // Distinguishes between spans generated in a particular context. For example,
   // two spans with the same name may be distinguished using `CLIENT` (caller)
   // and `SERVER` (callee) to identify queueing latency associated with the span.
-  SpanKind kind = 7;
+  SpanKind kind = 8;
 
   // start_time_unixnano is the start time of the span. On the client side, this is the time
   // kept by the local machine where the span execution starts. On the server side, this
@@ -123,7 +138,7 @@ message Span {
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
   // This field is semantically required and it is expected that end_time >= start_time.
-  fixed64 start_time_unixnano = 8;
+  fixed64 start_time_unixnano = 9;
 
   // end_time_unixnano is the end time of the span. On the client side, this is the time
   // kept by the local machine where the span execution ends. On the server side, this
@@ -131,7 +146,7 @@ message Span {
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
   // This field is semantically required and it is expected that end_time >= start_time.
-  fixed64 end_time_unixnano = 9;
+  fixed64 end_time_unixnano = 10;
 
   // attributes is a collection of key/value pairs. The value can be a string,
   // an integer, a double or the Boolean values `true` or `false`. Note, global attributes
@@ -141,12 +156,12 @@ message Span {
   //     "/http/server_latency": 300
   //     "abc.com/myattribute": true
   //     "abc.com/score": 10.239
-  repeated opentelemetry.proto.common.v1.AttributeKeyValue attributes = 10;
+  repeated opentelemetry.proto.common.v1.AttributeKeyValue attributes = 11;
 
   // dropped_attributes_count is the number of attributes that were discarded. Attributes
   // can be discarded because their keys are too long or because there are too many
   // attributes. If this value is 0, then no attributes were dropped.
-  int32 dropped_attributes_count = 11;
+  int32 dropped_attributes_count = 12;
 
   // Event is a time-stamped annotation of the span, consisting of user-supplied
   // text description and key-value pairs.
@@ -166,33 +181,35 @@ message Span {
   }
 
   // events is a collection of Event items.
-  repeated Event events = 12;
+  repeated Event events = 13;
 
   // dropped_events_count is the number of dropped events. If the value is 0, then no
   // events were dropped.
-  uint32 dropped_events_count = 13;
+  uint32 dropped_events_count = 14;
 
   // A pointer from the current span to another span in the same trace or in a
   // different trace. For example, this can be used in batching operations,
   // where a single batch handler processes multiple requests from different
   // traces or when the handler receives a request from a different project.
   message Link {
-    // A unique identifier of a trace that this linked span is part of. The ID is a
-    // 16-byte array.
-    bytes trace_id = 1;
+    // trace_id is a unique identifier of a trace that this linked span is part of.
+    // See Span.trace_id for trace ID value byte order explanation.
+    fixed64 trace_id_high = 1;
+    fixed64 trace_id_low = 2;
 
-    // A unique identifier for the linked span. The ID is an 8-byte array.
-    bytes span_id = 2;
+    // span_id is a unique identifier for the linked span.
+    // See Span.span_id for span ID value byte order explanation.
+    fixed64 span_id = 3;
 
     // The tracestate associated with the link.
-    string tracestate = 3;
+    string tracestate = 4;
 
     // attributes is a collection of attribute key/value pairs on the link.
-    repeated opentelemetry.proto.common.v1.AttributeKeyValue attributes = 4;
+    repeated opentelemetry.proto.common.v1.AttributeKeyValue attributes = 5;
 
     // dropped_attributes_count is the number of dropped attributes. If the value is 0,
     // then no attributes were dropped.
-    int32 dropped_attributes_count = 5;
+    int32 dropped_attributes_count = 6;
   }
 
   // A collection of links, which are references from this span to a span
@@ -207,16 +224,16 @@ message Span {
   }
 
   // The included links.
-  Links links = 14;
+  Links links = 15;
 
   // An optional final status for this span. Semantically when Status
   // wasn't set it is means span ended without errors and assume
   // Status.Ok (code = 0).
-  Status status = 15;
+  Status status = 16;
 
   // An optional number of child spans that were generated while this span
   // was active. If set, allows an implementation to detect missing child spans.
-  google.protobuf.UInt32Value child_span_count = 16;
+  google.protobuf.UInt32Value child_span_count = 17;
 }
 
 // The Status type defines a logical error model that is suitable for different


### PR DESCRIPTION
This reduces CPU and memory usage, as well as wire size.

```
===== Encoded sizes
Encoding                       Uncompressed  Improved        Compressed  Improved
Baseline/Trace/Attribs          18791 bytes  [1.000], gziped 4027 bytes  [1.000]
Proposed/Trace/Attribs          17591 bytes  [1.068], gziped 3932 bytes  [1.024]

Encoding                       Uncompressed  Improved        Compressed  Improved
Baseline/Trace/Events           14089 bytes  [1.000], gziped 1730 bytes  [1.000]
Proposed/Trace/Events           12489 bytes  [1.128], gziped 1616 bytes  [1.071]

goos: darwin
goarch: amd64
pkg: github.com/tigrannajaryan/exp-otelproto/encodings
BenchmarkEncode/Baseline/Trace/Attribs-8      	      86	  63775703 ns/op
BenchmarkEncode/Proposed/Trace/Attribs-8      	      99	  60474051 ns/op

BenchmarkEncode/Baseline/Trace/Events-8       	      74	  78882425 ns/op
BenchmarkEncode/Proposed/Trace/Events-8       	      81	  75893047 ns/op

BenchmarkDecode/Baseline/Trace/Attribs-8      	      66	 102103922 ns/op	82618718 B/op	 1416925 allocs/op
BenchmarkDecode/Proposed/Trace/Attribs-8      	      70	  91743212 ns/op	76888944 B/op	 1216925 allocs/op

BenchmarkDecode/Baseline/Trace/Events-8       	      45	 134349730 ns/op	103504028 B/op	 1924000 allocs/op
BenchmarkDecode/Proposed/Trace/Events-8       	      54	 118756653 ns/op	97704014 B/op	 1724000 allocs/op
```

`Trace/Attribs` is 1000 batches, each containing 100 spans, each span containing 3 attributes (2 int64, 1 string) and 0 TimedEvents.

`Trace/Events` is 1000 batches, each containing 100 spans, each span containing 0 attributes and 3 TimedEvents, each TimedEvent containing 1 int64 attribute.