### PR TITLE
Implement OTLP requirements for Export request messages

### DIFF
--- a/opentelemetry/proto/agent/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/agent/metrics/v1/metrics_service.proto
@@ -16,7 +16,6 @@ syntax = "proto3";
 
 package opentelemetry.proto.agent.metrics.v1;
 
-import "opentelemetry/proto/agent/common/v1/common.proto";
 import "opentelemetry/proto/metrics/v1/metrics.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
@@ -34,21 +33,25 @@ service MetricsService {
 }
 
 message ExportMetricsServiceRequest {
-  // This is required only in the first message on the stream or if the
-  // previous sent ExportMetricsServiceRequest message has a different Node (e.g.
-  // when the same RPC is used to send Metrics from multiple Applications).
-  opentelemetry.proto.agent.common.v1.Node node = 1;
+  // Metric data. An array of ResourceMetrics.
+  // For data coming from a single resource this array will typically contain one
+  // element. Intermediary nodes (such as OpenTelemetry Collector) that receive
+  // data from multiple origins typically batch the data before forwarding further and
+  // in that case this array will contain multiple elements.
+  repeated ResourceMetrics resource_metrics = 1;
+}
 
-  // A list of metrics that belong to the last received Node.
-  repeated opentelemetry.proto.metrics.v1.Metric metrics = 2;
+// A collection of metrics from a Resource.
+message ResourceMetrics {
+  // A list of metrics that originate from a resource.
+  repeated opentelemetry.proto.metrics.v1.Metric metrics = 1;
 
   // The resource for the metrics in this message that do not have an explicit
-  // resource set.
-  // If unset, the most recently set resource in the RPC stream applies. It is
-  // valid to never be set within a stream, e.g. when no resource info is known
-  // at all or when all sent metrics have an explicit resource set.
-  opentelemetry.proto.resource.v1.Resource resource = 3;
+  // Metric.resource field set. If neither this field nor Metric.resource are set then no
+  // resource info is known.
+  opentelemetry.proto.resource.v1.Resource resource = 2;
 }
+
 
 message ExportMetricsServiceResponse {
 }

--- a/opentelemetry/proto/agent/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/agent/trace/v1/trace_service.proto
@@ -64,19 +64,23 @@ message UpdatedLibraryConfig {
 }
 
 message ExportTraceServiceRequest {
-  // This is required only in the first message on the stream or if the
-  // previous sent ExportTraceServiceRequest message has a different Node (e.g.
-  // when the same RPC is used to send Spans from multiple Applications).
-  opentelemetry.proto.agent.common.v1.Node node = 1;
+  // Span data. An array of ResourceSpans.
+  // For data coming from a single resource this array will typically contain one
+  // element. Intermediary nodes (such as OpenTelemetry Collector) that receive
+  // data from multiple origins typically batch the data before forwarding further and
+  // in that case this array will contain multiple elements.
+  repeated ResourceSpans resource_spans = 1;
+}
 
-  // A list of Spans that belong to the last received Node.
-  repeated opentelemetry.proto.trace.v1.Span spans = 2;
+// A collection of spans from a Resource.
+message ResourceSpans {
+  // A list of Spans that originate from a resource.
+  repeated opentelemetry.proto.trace.v1.Span spans = 1;
 
   // The resource for the spans in this message that do not have an explicit
-  // resource set.
-  // If unset, the most recently set resource in the RPC stream applies. It is
-  // valid to never be set within a stream, e.g. when no resource info is known.
-  opentelemetry.proto.resource.v1.Resource resource = 3;
+  // Span.resource field set. If neither this field nor Span.resource are set then no
+  // resource info is known.
+  opentelemetry.proto.resource.v1.Resource resource = 2;
 }
 
 message ExportTraceServiceResponse {

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -73,14 +73,15 @@ option java_outer_classname = "MetricsProto";
 // time. Each element of TimeSeries array is timestamped.
 //
 // TimeSeries are strongly typed: the element of a TimeSeries array has
-// a specific Protobuf message depending on the value type of the metric and thus
+// a specific ProtoBuf message depending on the value type of the metric and thus
 // there are currently 4 TimeSeries messages, which correspond to the types of metric values.
 message Metric {
   // The descriptor of the Metric.
   MetricDescriptor metric_descriptor = 1;
 
-  // The resource for the metric. If unset, it may be set to a default value
-  // provided for a sequence of messages in an RPC stream.
+  // An optional resource that is associated with this metric. If not set, this metric
+  // should be part of a ResourceMetrics that does include the resource information, unless
+  // resource information is unknown.
   opentelemetry.proto.resource.v1.Resource resource = 2;
 
   // data is a list of one or more TimeSeries for a single metric, where each timeseries has

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -82,8 +82,8 @@ message Span {
   bytes parent_span_id = 4;
 
   // An optional resource that is associated with this span. If not set, this span
-  // should be part of a batch that does include the resource information, unless resource
-  // information is unknown.
+  // should be part of a ResourceSpans that does include the resource information, unless
+  // resource information is unknown.
   opentelemetry.proto.resource.v1.Resource resource = 5;
 
   // A description of the span's operation.


### PR DESCRIPTION
- Eliminated Node field from export requests. This field did not have a clear purpose
  distinct from Resource and has been confusingly used interchangeably with Resource
  in OpenCensus Service.
- Introduced ResourceSpans and ResourceMetrics messages that carry a list of spans
  and metrics from a particular resource.
- Enabled Export requests to carry an array of ResourceSpans or ResourceMetrics to allow a
  single request to carry data from multiple resources (important particularly for Collector,
  but also for telemetry data sources which represent multiple resources).

See OTLP requirements here: https://github.com/open-telemetry/oteps/blob/master/text/0035-opentelemetry-protocol.md#appendix-a---protocol-buffer-definitions