### PR TITLE
Use AttributeKeyValue for Resource labels

### DIFF
--- a/opentelemetry/proto/resource/v1/resource.proto
+++ b/opentelemetry/proto/resource/v1/resource.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package opentelemetry.proto.resource.v1;
 
+import "opentelemetry/proto/common/v1/common.proto";
+
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.resource.v1";
 option java_outer_classname = "ResourceProto";
@@ -23,5 +25,9 @@ option java_outer_classname = "ResourceProto";
 // Resource information.
 message Resource {
   // Set of labels that describe the resource.
-  map<string,string> labels = 1;
+  repeated opentelemetry.proto.common.v1.AttributeKeyValue labels = 1;
+
+  // dropped_labels_count is the number of dropped labels. If the value is 0, then
+  // no labels were dropped.
+  int32 dropped_labels_count = 2;
 }


### PR DESCRIPTION
This implements requirement of RFC0059:
https://github.com/open-telemetry/oteps/blob/master/text/0059-otlp-trace-data-format.md#resource