### PR TITLE
Eliminate unneeded inner Resource field

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -17,7 +17,6 @@ syntax = "proto3";
 package opentelemetry.proto.metrics.v1;
 
 import "opentelemetry/proto/common/v1/common.proto";
-import "opentelemetry/proto/resource/v1/resource.proto";
 
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.metrics.v1";
@@ -79,18 +78,13 @@ message Metric {
   // The descriptor of the Metric.
   MetricDescriptor metric_descriptor = 1;
 
-  // An optional resource that is associated with this metric. If not set, this metric
-  // should be part of a ResourceMetrics that does include the resource information, unless
-  // resource information is unknown.
-  opentelemetry.proto.resource.v1.Resource resource = 2;
-
   // data is a list of one or more TimeSeries for a single metric, where each timeseries has
   // one or more points. Only one of the following fields is used for the data, depending on
   // the type of the metric defined by MetricDescriptor.type field.
-  repeated Int64TimeSeries int64_timeseries = 3;
-  repeated DoubleTimeSeries double_timeseries = 4;
-  repeated HistogramTimeSeries histogram_timeseries = 5;
-  repeated SummaryTimeSeries summary_timeseries = 6;
+  repeated Int64TimeSeries int64_timeseries = 2;
+  repeated DoubleTimeSeries double_timeseries = 3;
+  repeated HistogramTimeSeries histogram_timeseries = 4;
+  repeated SummaryTimeSeries summary_timeseries = 5;
 }
 
 // Defines a metric type and its schema.

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -18,7 +18,6 @@ package opentelemetry.proto.trace.v1;
 
 import "google/protobuf/wrappers.proto";
 import "opentelemetry/proto/common/v1/common.proto";
-import "opentelemetry/proto/resource/v1/resource.proto";
 
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.trace.v1";
@@ -32,7 +31,7 @@ option java_outer_classname = "TraceProto";
 // multiple root spans, or none at all. Spans do not need to be
 // contiguous - there may be gaps or overlaps between spans in a trace.
 //
-// The next field id is 19.
+// The next field id is 18.
 message Span {
   // trace_id is the unique identifier of a trace. All spans from the same trace share
   // the same `trace_id`.
@@ -78,11 +77,6 @@ message Span {
   // field must be 0. See span_id for ID value byte order explanation.
   fixed64 parent_span_id = 5;
 
-  // An optional resource that is associated with this span. If not set, this span
-  // should be part of a ResourceSpans that does include the resource information, unless
-  // resource information is unknown.
-  opentelemetry.proto.resource.v1.Resource resource = 6;
-
   // A description of the span's operation.
   //
   // For example, the name can be a qualified method name or a file name
@@ -96,7 +90,7 @@ message Span {
   // receiver to fix the empty span name.
   //
   // This field is required.
-  string name = 7;
+  string name = 6;
 
   // SpanKind is the type of span. Can be used to specify additional relationships between spans
   // in addition to a parent/child relationship.
@@ -131,7 +125,7 @@ message Span {
   // Distinguishes between spans generated in a particular context. For example,
   // two spans with the same name may be distinguished using `CLIENT` (caller)
   // and `SERVER` (callee) to identify queueing latency associated with the span.
-  SpanKind kind = 8;
+  SpanKind kind = 7;
 
   // start_time_unixnano is the start time of the span. On the client side, this is the time
   // kept by the local machine where the span execution starts. On the server side, this
@@ -139,7 +133,7 @@ message Span {
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
   // This field is semantically required and it is expected that end_time >= start_time.
-  fixed64 start_time_unixnano = 9;
+  fixed64 start_time_unixnano = 8;
 
   // end_time_unixnano is the end time of the span. On the client side, this is the time
   // kept by the local machine where the span execution ends. On the server side, this
@@ -147,7 +141,7 @@ message Span {
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
   // This field is semantically required and it is expected that end_time >= start_time.
-  fixed64 end_time_unixnano = 10;
+  fixed64 end_time_unixnano = 9;
 
   // attributes is a collection of key/value pairs. The value can be a string,
   // an integer, a double or the Boolean values `true` or `false`. Note, global attributes
@@ -157,12 +151,12 @@ message Span {
   //     "/http/server_latency": 300
   //     "abc.com/myattribute": true
   //     "abc.com/score": 10.239
-  repeated opentelemetry.proto.common.v1.AttributeKeyValue attributes = 11;
+  repeated opentelemetry.proto.common.v1.AttributeKeyValue attributes = 10;
 
   // dropped_attributes_count is the number of attributes that were discarded. Attributes
   // can be discarded because their keys are too long or because there are too many
   // attributes. If this value is 0, then no attributes were dropped.
-  uint32 dropped_attributes_count = 12;
+  uint32 dropped_attributes_count = 11;
 
   // Event is a time-stamped annotation of the span, consisting of user-supplied
   // text description and key-value pairs.
@@ -182,11 +176,11 @@ message Span {
   }
 
   // events is a collection of Event items.
-  repeated Event events = 13;
+  repeated Event events = 12;
 
   // dropped_events_count is the number of dropped events. If the value is 0, then no
   // events were dropped.
-  uint32 dropped_events_count = 14;
+  uint32 dropped_events_count = 13;
 
   // A pointer from the current span to another span in the same trace or in a
   // different trace. For example, this can be used in batching operations,
@@ -215,20 +209,20 @@ message Span {
 
   // links is a collection of Links, which are references from this span to a span
   // in the same or different trace.
-  repeated Link links = 15;
+  repeated Link links = 14;
 
   // dropped_links_count is the number of dropped links after the maximum size was
   // enforced. If this value is 0, then no links were dropped.
-  uint32 dropped_links_count = 16;
+  uint32 dropped_links_count = 15;
 
   // An optional final status for this span. Semantically when Status
   // wasn't set it is means span ended without errors and assume
   // Status.Ok (code = 0).
-  Status status = 17;
+  Status status = 16;
 
   // An optional number of child spans that were generated while this span
   // was active. If set, allows an implementation to detect missing child spans.
-  google.protobuf.UInt32Value child_span_count = 18;
+  google.protobuf.UInt32Value child_span_count = 17;
 }
 
 // The Status type defines a logical error model that is suitable for different


### PR DESCRIPTION
Newly added ResourceMetrics and ResourceSpans messages allow to model
individual Resource per Span or per Metric efficiently.

The inner Resource field in the Span and Metric is no longer needed.

Resolves: https://github.com/open-telemetry/opentelemetry-proto/issues/68