### PR TITLE
Refine child span count field

### DIFF
--- a/opentelemetry/proto/common/v1/common.proto
+++ b/opentelemetry/proto/common/v1/common.proto
@@ -26,7 +26,7 @@ message AttributeKeyValue {
   // ValueType is the enumeration of possible types that value can have.
   enum ValueType {
     STRING  = 0;
-    INT   = 1;
+    INT     = 1;
     DOUBLE  = 2;
     BOOL    = 3;
   };

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -16,7 +16,6 @@ syntax = "proto3";
 
 package opentelemetry.proto.trace.v1;
 
-import "google/protobuf/wrappers.proto";
 import "opentelemetry/proto/common/v1/common.proto";
 
 option java_multiple_files = true;
@@ -220,9 +219,10 @@ message Span {
   // Status.Ok (code = 0).
   Status status = 16;
 
-  // An optional number of child spans that were generated while this span
-  // was active. If set, allows an implementation to detect missing child spans.
-  google.protobuf.UInt32Value child_span_count = 17;
+  // An optional number of local child spans that were generated while this span
+  // was active. Value of -1 indicates that the number of local child spans is unknown.
+  // If local_child_span_count>=0, allows an implementation to detect missing child spans.
+  sfixed32 local_child_span_count = 17;
 }
 
 // The Status type defines a logical error model that is suitable for different


### PR DESCRIPTION
The field was previously defined ambiguously and it was not clear
whether it was the count of local or all children (including remotely
generated).

This change makes it clear that this is only local children. A counter
of remote children may be added in the future if there is an understanding
about how to obtain this number (open discussion is here:
https://github.com/open-telemetry/opentelemetry-specification/issues/355).

The field type is also changed to a more efficient sfixed32 with
special-casing -1 as "value not known".