### PR TITLE
Update comment after removal of inner resource

### DIFF
--- a/opentelemetry/proto/agent/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/agent/trace/v1/trace_service.proto
@@ -49,9 +49,8 @@ message ResourceSpans {
   // A list of Spans that originate from a resource.
   repeated opentelemetry.proto.trace.v1.Span spans = 1;
 
-  // The resource for the spans in this message that do not have an explicit
-  // Span.resource field set. If neither this field nor Span.resource are set then no
-  // resource info is known.
+  // The resource for the spans in this message.
+  // If this field is not set then no resource info is known.
   opentelemetry.proto.resource.v1.Resource resource = 2;
 }
 


### PR DESCRIPTION
#71 removed the inner Resource message in Span, but the comment on ResourceSpan.resource still referred to it.