### PR TITLE
Add minimal contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+## Prerequisites
+
+- Protocol Buffers compiler `protoc`.
+- Protocol Buffers Go compiler `protoc-gen-go`.
+ 
+Install manually or use `install-proto.sh` (if on Linux).
+
+## Making changes to the .proto files
+
+Non-backward compatible changes to .proto files are permitted until protocol schema is 
+declared complete.
+
+After making any changes to .proto files make sure to generate Go implementation by 
+running `make gen-go`. Generated files must be included in the same commit as the .proto
+files.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 The proto files can be consumed as GIT submodule or copied over and built directly in the consumer project.
 
 The compiled files are published to central repositories (Maven, NPM...) from OpenTelemetry client libraries.
+
+See [contribution guidelines](CONTRIBUTING.md) if you would like to make any changes.


### PR DESCRIPTION
Guidelines are for current state only. After the protocol is declared complete
we need to ensure guidelines are enhanced and at the minimum include notes
about backwards compatibility of any changes.