### PR TITLE
Allow SummaryValue percentile of 0.0

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -391,7 +391,7 @@ message SummaryValue {
   // Represents the value at a given percentile of a distribution.
   message ValueAtPercentile {
     // The percentile of a distribution. Must be in the interval
-    // (0.0, 100.0].
+    // [0.0, 100.0].
     double percentile = 1;
 
     // The value at the given percentile of a distribution.


### PR DESCRIPTION
A percentile of 0.0 is useful for representing the minimum value in a Summary.