### PR TITLE
Fix Go package name to 'trace'

### DIFF
--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -24,7 +24,7 @@ import "opentelemetry/proto/trace/v1/trace.proto";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.collector.trace.v1";
 option java_outer_classname = "TraceServiceProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/traces/v1";
+option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/trace/v1";
 
 // Service that can be used to push spans between one Application instrumented with
 // OpenTelemetry and an collector, or between an collector and a central collector (in this

--- a/opentelemetry/proto/trace/v1/trace_config.proto
+++ b/opentelemetry/proto/trace/v1/trace_config.proto
@@ -19,7 +19,7 @@ package opentelemetry.proto.trace.v1;
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.trace.v1";
 option java_outer_classname = "TraceConfigProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/traces/v1";
+option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/trace/v1";
 
 // Global configuration of the trace service. All fields must be specified, or
 // the default (zero) values will be used for each type.


### PR DESCRIPTION
Fixes #109, assuming it's a typo.

NOTE: this is a breaking change in the Go library, so we may consider if this change is safe to do. It seems worth doing for consistency at the early stage.