### PR TITLE
[WIP] Validate in CI that generated Go files are in sync with protos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ install:
   -  ./install-proto.sh
   - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
   - git fetch --unshallow --tags
-  - git symbolic-ref --short HEAD || git checkout -b ${TRAVIS_BRANCH}-test $TRAVIS_BRANCH
 
 script:
   - make ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: go
 
 install:
   -  ./install-proto.sh
+  - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+  - git fetch --unshallow --tags
+  - git symbolic-ref --short HEAD || git checkout -b ${TRAVIS_BRANCH}-test $TRAVIS_BRANCH
 
 script:
   - make ci

--- a/gen/go/metrics/v1/metrics.pb.go
+++ b/gen/go/metrics/v1/metrics.pb.go
@@ -1077,7 +1077,7 @@ func (m *SummaryValue) GetPercentileValues() []*SummaryValue_ValueAtPercentile {
 // Represents the value at a given percentile of a distribution.
 type SummaryValue_ValueAtPercentile struct {
 	// The percentile of a distribution. Must be in the interval
-	// (0.0, 100.0].
+	// [0.0, 100.0].
 	Percentile float64 `protobuf:"fixed64,1,opt,name=percentile,proto3" json:"percentile,omitempty"`
 	// The value at the given percentile of a distribution.
 	Value                float64  `protobuf:"fixed64,2,opt,name=value,proto3" json:"value,omitempty"`

--- a/makefile
+++ b/makefile
@@ -33,8 +33,8 @@ validate-go: gen-go
 # Generate ProtoBuf implementation for Go.
 .PHONY: gen-go
 gen-go:
-	$(foreach file,$(PROTO_FILES),$(call exec-command,protoc --go_out=plugins=grpc:$(GOPATH)/src $(file)))
 	rm -rf ./$(GENDIR)/go
+	$(foreach file,$(PROTO_FILES),$(call exec-command,protoc --go_out=plugins=grpc:$(GOPATH)/src $(file)))
 	cp -R $(GOPATH)/src/github.com/open-telemetry/opentelemetry-proto/$(GENDIR)/go ./gen/
 
 # Generate ProtoBuf implementation for Java.

--- a/makefile
+++ b/makefile
@@ -21,14 +21,21 @@ then \
 fi
 endef
 
+define print-hash
+find ./gen/go -type f -exec md5sum {} \; | sort -k 2 | md5sum
+endef
+
 # CI build
 .PHONY: ci
 ci: validate-go gen-java gen-swagger
 
 # Validate that generated Go files are up to date.
 .PHONY: validate-go
-validate-go: gen-go-ci
+validate-go: print-hash gen-go-ci
 	$(check-git-status)
+
+.PHONY: print-hash
+	echo $(print-hash)
 
 # Generate ProtoBuf implementation for Go.
 .PHONY: gen-go-ci

--- a/makefile
+++ b/makefile
@@ -27,8 +27,14 @@ ci: validate-go gen-java gen-swagger
 
 # Validate that generated Go files are up to date.
 .PHONY: validate-go
-validate-go: gen-go
+validate-go: gen-go-ci
 	$(check-git-status)
+
+# Generate ProtoBuf implementation for Go.
+.PHONY: gen-go-ci
+gen-go-ci:
+	rm -rf ./$(GENDIR)/go
+	$(foreach file,$(PROTO_FILES),$(call exec-command,protoc --go_out=plugins=grpc:$(GOPATH)/src $(file)))
 
 # Generate ProtoBuf implementation for Go.
 .PHONY: gen-go

--- a/makefile
+++ b/makefile
@@ -12,9 +12,23 @@ $(1)
 
 endef
 
+# Function to make sure that the git directory is clean.
+define check-git-status
+if [[ -n $$(git --no-pager status -s 2> /dev/null) ]] ;\
+then \
+	echo "Git tree is not clean. Did you forget to commit some files?" ;\
+	git --no-pager status ;\
+fi
+endef
+
 # CI build
 .PHONY: ci
-ci: gen-java gen-swagger
+ci: validate-go gen-java gen-swagger
+
+# Validate that generated Go files are up to date.
+.PHONY: validate-go
+validate-go: gen-go
+	$(check-git-status)
 
 # Generate ProtoBuf implementation for Go.
 .PHONY: gen-go

--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@ endef
 
 # Function to make sure that the git directory is clean.
 define check-git-status
-if [[ -n $$(git --no-pager status -s 2> /dev/null) ]] ;\
+if [ -n $$(git --no-pager status -s 2> /dev/null) ] ;\
 then \
 	echo "Git tree is not clean. Did you forget to commit some files?" ;\
 	git --no-pager status ;\


### PR DESCRIPTION
1. Currently in CI `gen-go` doesn't get executed at all.
2. There is no validation that generated Go files are up to date.

This change adds `validate-go` target executed as part of `make ci`.