### PR TITLE
Flatten data point definitions

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -136,19 +136,19 @@ message MetricDescriptor {
     GAUGE_HISTOGRAM = 3;
 
     // Integer counter measurement. The value cannot decrease; if value is reset then
-    // CounterInt64Value.start_time_unixnano should also be reset.
+    // start_time_unixnano should also be reset.
     // Corresponding values are stored in Int64DataPoint.
     COUNTER_INT64 = 4;
 
     // Floating point counter measurement. The value cannot decrease, if
-    // resets then the CounterDoubleValue.start_time_unixnano should also be reset.
+    // resets then the start_time_unixnano should also be reset.
     // Recorded values are always >= 0.
     // Corresponding values are stored in DoubleDataPoint.
     COUNTER_DOUBLE = 5;
 
     // Histogram cumulative measurement.
     // Corresponding values are stored in HistogramDataPoint. The count and sum of the
-    // histogram cannot decrease; if values are reset then HistogramValue.start_time_unixnano
+    // histogram cannot decrease; if values are reset then start_time_unixnano
     // should also be reset to the new start timestamp.
     CUMULATIVE_HISTOGRAM = 6;
 
@@ -173,8 +173,23 @@ message Int64DataPoint {
   // The set of labels that uniquely identify this timeseries.
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
 
-  // The value of data point.
-  Int64Value value = 2;
+  // start_time_unixnano is the time when the cumulative value was reset to zero.
+  // This is used for Counter type only. For Gauge the value is not specified and
+  // defaults to 0.
+  //
+  // The cumulative value is over the time interval (start_time_unixnano, timestamp_unixnano].
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  //
+  // Value of 0 indicates that the timestamp is unspecified. In that case the timestamp
+  // may be decided by the backend.
+  fixed64 start_time_unixnano = 2;
+
+  // timestamp_unixnano is the moment when this value was recorded.
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  fixed64 timestamp_unixnano = 3;
+
+  // value itself.
+  int64 value = 4;
 }
 
 // DoubleDataPoint is a single data point in a timeseries that describes the time-varying
@@ -183,104 +198,32 @@ message DoubleDataPoint {
   // The set of labels that uniquely identify this timeseries.
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
 
-  // The value of data point.
-  DoubleValue value = 2;
+  // start_time_unixnano is the time when the cumulative value was reset to zero.
+  // This is used for Counter type only. For Gauge the value is not specified and
+  // defaults to 0.
+  //
+  // The cumulative value is over the time interval (start_time_unixnano, timestamp_unixnano].
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  //
+  // Value of 0 indicates that the timestamp is unspecified. In that case the timestamp
+  // may be decided by the backend.
+  fixed64 start_time_unixnano = 2;
+
+  // timestamp_unixnano is the moment when this value was recorded.
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  fixed64 timestamp_unixnano = 3;
+
+  // value itself.
+  double value = 4;
 }
 
 // HistogramDataPoint is a single data point in a timeseries that describes the time-varying
-// values of a Histogram.
+// values of a Histogram. A Histogram contains summary statistics for a population of values,
+// it may optionally contain the distribution of those values across a set of buckets.
 message HistogramDataPoint {
   // The set of labels that uniquely identify this timeseries.
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
 
-  // The value of data point.
-  HistogramValue value = 2;
-
-  // A histogram may optionally contain the distribution of the values in the population.
-  // In that case one of the option fields below and "buckets" field in HistogramValue
-  // both must be defined. Otherwise all option fields and "buckets" field must be omitted
-  // in which case the distribution of values in the histogram is unknown and only the
-  // total count and sum are known.
-  //
-  // Bucket options apply to all points in this HistogramDataPoint. To define
-  // different bucket options for different points create separate instances of
-  // HistogramDataPoint each with its own bucket options.
-
-  // explicit_bounds is the only supported bucket option currently.
-  // TODO: Add more bucket options.
-
-  // explicit_bounds specifies buckets with explicitly defined bounds for values.
-  // The bucket boundaries are described by "bounds" field.
-  //
-  // This defines size(bounds) + 1 (= N) buckets. The boundaries for bucket
-  // at index i are:
-  //
-  // [0, bounds[i]) for i == 0
-  // [bounds[i-1], bounds[i]) for 0 < i < N-1
-  // [bounds[i], +infinity) for i == N-1
-  // The values in bounds array must be strictly increasing and > 0.
-  //
-  // Note: only [a, b) intervals are currently supported for each bucket. If we decides
-  // to also support (a, b] intervals we should add support for these by defining a boolean
-  // value which decides what type of intervals to use.
-  repeated double explicit_bounds = 3;
-}
-
-// SummaryDataPoint is a single data point in a timeseries that describes the time-varying
-// values of a Summary metric.
-message SummaryDataPoint {
-  // The set of labels that uniquely identify this timeseries.
-  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
-
-  // The value of data point.
-  SummaryValue value = 2;
-}
-
-// Int64Value is a timestamped measurement of int64 value.
-message Int64Value {
-  // start_time_unixnano is the time when the cumulative value was reset to zero.
-  // This is used for Counter type only. For Gauge the value is not specified and
-  // defaults to 0.
-  //
-  // The cumulative value is over the time interval (start_time_unixnano, timestamp_unixnano].
-  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-  //
-  // Value of 0 indicates that the timestamp is unspecified. In that case the timestamp
-  // may be decided by the backend.
-  fixed64 start_time_unixnano = 1;
-
-  // timestamp_unixnano is the moment when this value was recorded.
-  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-  fixed64 timestamp_unixnano = 2;
-
-  // value itself.
-  int64 value = 3;
-}
-
-// DoubleValue is a timestamped measurement of double value.
-message DoubleValue {
-  // start_time_unixnano is the time when the cumulative value was reset to zero.
-  // This is used for Counter type only. For Gauge the value is not specified and
-  // defaults to 0.
-  //
-  // The cumulative value is over the time interval (start_time_unixnano, timestamp_unixnano].
-  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-  //
-  // Value of 0 indicates that the timestamp is unspecified. In that case the timestamp
-  // may be decided by the backend.
-  fixed64 start_time_unixnano = 1;
-
-  // timestamp_unixnano is the moment when this value was recorded.
-  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-  fixed64 timestamp_unixnano = 2;
-
-  // value itself.
-  double value = 3;
-}
-
-// HistogramValue contains summary statistics for a population of values. It may
-// optionally contain the distribution of those values across a set of buckets.
-message HistogramValue {
   // start_time_unixnano is the time when the cumulative value was reset to zero.
   //
   // The cumulative value is over the time interval (start_time_unixnano, timestamp_unixnano].
@@ -289,21 +232,20 @@ message HistogramValue {
   // Value of 0 indicates that the timestamp is unspecified. In that case the timestamp
   // may be decided by the backend.
   // Note: this field is always unspecified and ignored if MetricDescriptor.type==GAUGE_HISTOGRAM.
-  fixed64 start_time_unixnano = 1;
+  fixed64 start_time_unixnano = 2;
 
   // timestamp_unixnano is the moment when this value was recorded.
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-  fixed64 timestamp_unixnano = 2;
+  fixed64 timestamp_unixnano = 3;
 
   // count is the number of values in the population. Must be non-negative. This value
-  // must be equal to the sum of the "count" fields in buckets if a histogram is
-  // provided.
-  uint64 count = 3;
+  // must be equal to the sum of the "count" fields in buckets if a histogram is provided.
+  uint64 count = 4;
 
   // sum of the values in the population. If count is zero then this field
   // must be zero. This value must be equal to the sum of the "sum" fields in buckets if
   // a histogram is provided.
-  double sum = 4;
+  double sum = 5;
 
   // Bucket contains values for a bucket.
   message Bucket {
@@ -335,8 +277,7 @@ message HistogramValue {
 
   // buckets is an optional field contains the values of histogram for each bucket.
   //
-  // The sum of the values in the buckets "count" field must equal the value in the
-  // count field of HistogramValue.
+  // The sum of the values in the buckets "count" field must equal the value in the count field.
   //
   // The number of elements in buckets array must be by one greater than the
   // number of elements in bucket_bounds array.
@@ -344,11 +285,39 @@ message HistogramValue {
   // Note: if HistogramDataPoint.bucket_options defines bucket bounds then this field
   // must also be present and number of elements in this field must be equal to the
   // number of buckets defined by bucket_options.
-  repeated Bucket buckets = 5;
+  repeated Bucket buckets = 6;
+
+  // A histogram may optionally contain the distribution of the values in the population.
+  // In that case one of the option fields below and "buckets" field both must be defined.
+  // Otherwise all option fields and "buckets" field must be omitted in which case the
+  // distribution of values in the histogram is unknown and only the total count and sum are known.
+
+  // explicit_bounds is the only supported bucket option currently.
+  // TODO: Add more bucket options.
+
+  // explicit_bounds specifies buckets with explicitly defined bounds for values.
+  // The bucket boundaries are described by "bounds" field.
+  //
+  // This defines size(bounds) + 1 (= N) buckets. The boundaries for bucket
+  // at index i are:
+  //
+  // [0, bounds[i]) for i == 0
+  // [bounds[i-1], bounds[i]) for 0 < i < N-1
+  // [bounds[i], +infinity) for i == N-1
+  // The values in bounds array must be strictly increasing and > 0.
+  //
+  // Note: only [a, b) intervals are currently supported for each bucket. If we decides
+  // to also support (a, b] intervals we should add support for these by defining a boolean
+  // value which decides what type of intervals to use.
+  repeated double explicit_bounds = 7;
 }
 
-// The start_timestamp only applies to the count and sum in the SummaryValue.
-message SummaryValue {
+// SummaryDataPoint is a single data point in a timeseries that describes the time-varying
+// values of a Summary metric.
+message SummaryDataPoint {
+  // The set of labels that uniquely identify this timeseries.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
+
   // start_time_unixnano is the time when the cumulative value was reset to zero.
   //
   // The cumulative value is over the time interval (start_time_unixnano, timestamp_unixnano].
@@ -356,19 +325,19 @@ message SummaryValue {
   //
   // Value of 0 indicates that the timestamp is unspecified. In that case the timestamp
   // may be decided by the backend.
-  fixed64 start_time_unixnano = 1;
+  fixed64 start_time_unixnano = 2;
 
   // timestamp_unixnano is the moment when this value was recorded.
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-  fixed64 timestamp_unixnano = 2;
+  fixed64 timestamp_unixnano = 3;
 
   // The total number of recorded values since start_time. Optional since
   // some systems don't expose this.
-  uint64 count = 3;
+  uint64 count = 4;
 
   // The total sum of recorded values since start_time. Optional since some
   // systems don't expose this. If count is zero then this field must be zero.
-  double sum = 4;
+  double sum = 5;
 
   // Represents the value at a given percentile of a distribution.
   message ValueAtPercentile {
@@ -382,5 +351,5 @@ message SummaryValue {
 
   // A list of values at different percentiles of the distribution calculated
   // from the current snapshot. The percentiles must be strictly increasing.
-  repeated ValueAtPercentile percentile_values = 5;
+  repeated ValueAtPercentile percentile_values = 6;
 }


### PR DESCRIPTION
Historical decisions:
We decided to have values separated from the data points because we may add a repeated values in the future.

Proposal:
Flatten the current protos (avoid unnecessary extra messages/allocations). If in the future we need to optimize (not duplicate the labels) we can have a Timeseries message { labels, repeated DataPoints} where labels in the DataPoints are not present (or redefine the Timeseries completely). Not sure we need that, so better to keep the current definition clean.