### PR TITLE
Adding make target for python code generation

### DIFF
--- a/makefile
+++ b/makefile
@@ -38,6 +38,13 @@ gen-java:
 	mkdir -p ./$(GENDIR)/java
 	$(foreach file,$(PROTO_FILES),$(call exec-command, protoc --java_out=./$(GENDIR)/java $(file)))
 
+# Generate ProtoBuf implementation for Python.
+.PHONY: gen-python
+gen-python:
+	rm -rf ./$(GENDIR)/python
+	mkdir -p ./$(GENDIR)/python
+	$(foreach file,$(PROTO_FILES),$(call exec-command,protoc --python_out=./$(GENDIR)/python $(file)))
+
 # Generate Swagger
 .PHONY: gen-swagger
 gen-swagger:

--- a/makefile
+++ b/makefile
@@ -43,7 +43,9 @@ gen-java:
 gen-python:
 	rm -rf ./$(GENDIR)/python
 	mkdir -p ./$(GENDIR)/python
-	$(foreach file,$(PROTO_FILES),$(call exec-command,protoc --python_out=./$(GENDIR)/python $(file)))
+	$(foreach file,$(PROTO_FILES),$(call exec-command, protoc --python_out=./$(GENDIR)/python $(file)))
+	python -m grpc_tools.protoc -I ./ --python_out=./$(GENDIR)/python --grpc_python_out=./$(GENDIR)/python opentelemetry/proto/collector/trace/v1/trace_service.proto
+	python -m grpc_tools.protoc -I ./ --python_out=./$(GENDIR)/python --grpc_python_out=./$(GENDIR)/python opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 
 # Generate Swagger
 .PHONY: gen-swagger


### PR DESCRIPTION
Left the generated code out as it will live in the opentelemetry-python repository as a separate installable package.

Partially fixes https://github.com/open-telemetry/opentelemetry-proto/issues/91