### PR TITLE
Rename Span Event name to short_name

### DIFF
--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -170,9 +170,11 @@ message Span {
     // time_unix_nano is the time the event occurred.
     fixed64 time_unix_nano = 1;
 
-    // name of the event.
-    // This field is semantically required to be set to non-empty string.
-    string name = 2;
+    // Short event identifier that does not contain varying parts. short_name describes
+    // what happened (e.g. "ProcessStarted"). Recommended to be no longer than 50
+    // characters. Not guaranteed to be unique in any way. Typically used for filtering
+    // and grouping purposes in backends. This field is optional.
+    string short_name = 2;
 
     // attributes is a collection of attribute key/value pairs on the event.
     repeated opentelemetry.proto.common.v1.AttributeKeyValue attributes = 3;


### PR DESCRIPTION
This is part of the alignment effort defined here https://github.com/open-telemetry/opentelemetry-specification/issues/622

The comment added clarifies the semantics, but I believe this is compatible
with our previous understanding and doe not change that understanding.

This does not break the protocol since renaming the fields does not change
the wire format.