### PR TITLE
Remove "experimental" notice from trace_service.proto

### DIFF
--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -14,9 +14,6 @@
 
 syntax = "proto3";
 
-// NOTE: This proto is experimental and is subject to change at this point.
-// Please do not use it at the moment.
-
 package opentelemetry.proto.collector.trace.v1;
 
 import "opentelemetry/proto/trace/v1/trace.proto";


### PR DESCRIPTION
Trace proto is already declared Stable so this notice is no longer necessary.