### PR TITLE
Change Metric type to be a more detailed structure with details about the aggregation and temporality.

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -52,7 +52,7 @@ message InstrumentationLibraryMetrics {
 // to refer to any one of the lists of points contained in the Metric.
 //
 // - Metric is composed of a MetricDescriptor and a list of data points.
-// - MetricDescriptor contains a name, description, unit, type, and temporarility.
+// - MetricDescriptor contains a name, description, unit, and type.
 // - Points is a list of DataPoints (shown vertically).
 // - DataPoint contains timestamps, labels, and one of the possible value type fields.
 //
@@ -63,8 +63,8 @@ message InstrumentationLibraryMetrics {
 //  |          |         | description            |
 //  |          |         | unit                   |
 //  |    points|--+      | type                   |
-//  +----------+  |      | temporarility          |
-//                |      +------------------------+
+//  +----------+  |      +------------------------+
+//                |
 //                |
 //                |      +---------------------------+
 //                |      |DataPoint 1                |
@@ -98,7 +98,7 @@ message InstrumentationLibraryMetrics {
 //   set for individual points.
 // - TimeUnixNano MUST be set to:
 //   - the end of the interval (CUMULATIVE or DELTA)
-//   - the instantaneous time of the event (INSTANTANEOUS).
+//   - the instantaneous time of the event.
 message Metric {
   // metric_descriptor describes the Metric.
   MetricDescriptor metric_descriptor = 1;
@@ -124,48 +124,140 @@ message MetricDescriptor {
   // described by http://unitsofmeasure.org/ucum.html.
   string unit = 3;
 
-  // Type is the type of values a metric has.
-  enum Type {
-    // INVALID_TYPE is the default Type, it MUST not be used.
-    INVALID_TYPE = 0;
-
-    // INT64 values are signed 64-bit integers.
-    //
-    // A Metric of this Type MUST store its values as Int64DataPoint.
+  // MeasurementValueType determines the value type for a measurement.
+  enum MeasurementValueType {
+    // INVALID_SCALAR_VALUE_TYPE is the default ScalarValueType, it MUST not be
+    // used.
+    INVALID_MEASUREMENT_VALUE_TYPE = 0;
+    // The scalar value type is an int64.
     INT64 = 1;
-
-    // MONOTONIC_INT64 values are monotonically increasing signed 64-bit
-    // integers.
-    //
-    // A Metric of this Type MUST store its values as Int64DataPoint.
-    MONOTONIC_INT64 = 2;
-
-    // DOUBLE values are double-precision floating-point numbers.
-    //
-    // A Metric of this Type MUST store its values as DoubleDataPoint.
-    DOUBLE = 3;
-
-    // MONOTONIC_DOUBLE values are monotonically increasing double-precision
-    // floating-point numbers.
-    //
-    // A Metric of this Type MUST store its values as DoubleDataPoint.
-    MONOTONIC_DOUBLE = 4;
-
-    // Histogram measurement.
-    // Corresponding values are stored in HistogramDataPoint.
-    HISTOGRAM = 5;
-
-    // Summary value. Some frameworks implemented Histograms as a summary of observations
-    // (usually things like request durations and response sizes). While it
-    // also provides a total count of observations and a sum of all observed
-    // values, it calculates configurable quantiles over a sliding time
-    // window.
-    // Corresponding values are stored in SummaryDataPoint.
-    SUMMARY = 6;
+    // The scalar value type is a floating point number.
+    DOUBLE = 2;
   }
 
-  // type is the type of values this metric has.
-  Type type = 4;
+  // Represents the type for a scalar metric that exports raw measurements.
+  // Generally this is the value of an OpenTelemetry Counter/UpDownCounter or
+  // ValueRecorder instrument without aggregation.
+  //
+  // It does not contain a temporality field because every raw measurement is
+  // associated with only one moment in time "the recorded time".
+  //
+  // A Metric of this Type MUST store its values as RawIntValue or
+  // RawDobleValue.
+  // TODO: add the RawIntValue and RawDobleValue.
+  message RawMeasurement {
+    // Determines if the points are RawIntValue or RawDobleValue.
+    MeasurementValueType measurement_value_type = 1;
+
+    // Structure is the structural quality of a measurement, indicating
+    // whether measurements data describes a sum (ADDING), whether it is a
+    // monotonic sum (ADDING_MONOTONIC), or a collection (GROUPING). 
+    enum Structure {
+      // Default structure for a measurement.
+      GROUPING = 0;
+      ADDING = 1;
+      ADDING_MONOTONIC = 2;
+    }
+    Structure structure = 2;
+  }
+
+  // Represents the type of a scalar metric that always exports the "current
+  // value" for every timeseries. It can be used when an "unknown" aggregation,
+  // or a known aggregation where the only important value is the current value,
+  // is used.
+  // 
+  // It does not contain a temporality field (even if it may be known) because
+  // the aggregation is unknown so points cannot be combined using the same
+  // aggregation to aggregate over time. Because of this "StartTimeUnixNano" is
+  // ignored for all data points.
+  //
+  // A Metric of this Type MUST store its values as Int64DataPoint or
+  // DoubleDataPoint.
+  message Gauge {
+    // It describes the value type of the measurement used to build this
+    // aggregation.
+    //
+    // Determines if the points are Int64DataPoint or DoubleDataPoint, as well
+    // as the value type of the exemplars.
+    MeasurementValueType measurement_value_type = 1;
+  }
+
+  // Represents the type of a numeric scalar metric that is calculated as a sum
+  // of all positive only reported measurements over a time interval.
+  //
+  // See https://github.com/open-telemetry/opentelemetry-specification/issues/725
+  // for more details of why only monotonic Sum can have temporality, and
+  // non-monotonic sums MUST be sent as Gauge (current value).
+  //
+  // A Metric of this Type MUST store its values as Int64DataPoint or
+  // DoubleDataPoint.
+  message MonotonicSum {
+    // It describes the value type of the measurement used to build this
+    // aggregation.
+    //
+    // Determines if the points are Int64DataPoint or DoubleDataPoint, as well
+    // as the value type of the exemplars.
+    MeasurementValueType measurement_value_type = 1;
+
+    // Temporality is the temporal quality values of a metric have.
+    Temporality temporality = 2;
+
+    // TODO: Decide if knowing that the aggregated measurements are raw
+    // measurements is important or not. Equivalent of "Snapshot" in #162.
+  }
+
+  // Represents the type of a metric that is calculated by aggregating as a
+  // Histogram of all reported measurements over a time interval.
+  //
+  // A Metric of this Type MUST store its values as HistogramDataPoint.
+  message Histogram {
+    // It describes the value type of the measurement used to build this
+    // aggregation.
+    //
+    // Determines the value type of the exemplars.
+    MeasurementValueType measurement_value_type = 1;
+
+    // Temporality is the temporal quality values of a metric have.
+    Temporality temporality = 2;
+
+    // TODO: Decide if knowing that the aggregated measurements are raw
+    // measurements is important or not. Equivalent of "Snapshot" in #162.
+
+    // TODO: Decide if knowing that the Sum is monotonic is important or not,
+    // may be derived from the buckets definition.
+  }
+
+  // Represents the type of a metric that is calculated by computing a summary
+  // of all reported measurements over a time interval.
+  //
+  // A Metric of this Type MUST store its values as SummaryDataPoint.
+  message Summary {
+    // It describes the value type of the measurement used to build this
+    // aggregation.
+    //
+    // Determines the value type of the exemplars.
+    MeasurementValueType measurement_value_type = 1;
+
+    // Temporality is the temporal quality values of a metric have.
+    Temporality temporality = 2;
+
+    // TODO: Decide if knowing that the aggregated measurements are raw
+    // measurements is important or not. Equivalent of "Snapshot" in #162.
+
+    // TODO: Decide if knowing that the Sum is monotonic is important or not,
+    // may be derived from the buckets definition.
+  }
+
+  // Type is the type of the metric and determines what are the type of the
+  // reported value, as well as the relatationship to the time interval over
+  // which they are reported.
+  oneof type {
+    RawMeasurement raw_measurement = 4;
+    Gauge gauge = 5;
+    MonotonicSum monotonic_sum = 6;
+    Histogram histogram = 7;
+    Summary summary = 8;
+  }
 
   // Temporality is the temporal quality values of a metric have. It
   // describes how those values relate to the time interval over which they
@@ -174,12 +266,6 @@ message MetricDescriptor {
     // INVALID_TEMPORALITY is the default Temporality, it MUST not be
     // used.
     INVALID_TEMPORALITY = 0;
-
-    // INSTANTANEOUS is a metric whose values are measured at a particular
-    // instant. The values are not aggregated over any time interval and are
-    // unique per timestamp. As such, these metrics are not expected to have
-    // an associated start time.
-    INSTANTANEOUS = 1;
 
     // DELTA is a metric whose values are the aggregation of measurements
     // made over a time interval. Successive metrics contain aggregation of
@@ -205,7 +291,7 @@ message MetricDescriptor {
     //   8. The 1 second collection cycle ends. A metric is exported for the
     //      number of requests received over the interval of time t_0+1 to
     //      t_0+2 with a value of 2.
-    DELTA = 2;
+    DELTA = 1;
 
     // CUMULATIVE is a metric whose values are the aggregation of
     // successively made measurements from a fixed start time until the last
@@ -238,11 +324,8 @@ message MetricDescriptor {
     //   12. The 1 second collection cycle ends. A metric is exported for the
     //      number of requests received over the interval of time t_1 to
     //      t_0+1 with a value of 1.
-    CUMULATIVE = 3;
+    CUMULATIVE = 2;
   }
-
-  // temporality is the Temporality of values this metric has.
-  Temporality temporality = 5;
 }
 
 // Int64DataPoint is a single data point in a timeseries that describes the time-varying


### PR DESCRIPTION
This is an alternative to PR #168. It takes a more descriptive approach where the Aggregation (the last applied aggregation if any) is clearly defined and Temporality is available only where it makes sense. This can help clearly identify what are the possible values and properties for different types of Aggregations.

There are some things that can be considered (TODOs left in the code):
* Histogram/Summary sum - monotonicity?
* Previous aggregation measurements: raw measurements or "derived" measurements (results of another aggregation).

IMPORTANT: This PR and #168 are not equivalent, this is inspired by that PR but makes some changes that are not compatible with that PR.