### PR TITLE
Declare common and resource directories stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Component                | Maturity |
 -------------------------|----------|
 collector/metrics/*      | Alpha    |
 collector/trace/*        | Stable   |
-common/*                 | Beta     |
+common/*                 | Stable   |
 metrics/*                | Alpha    |
-resource/*               | Beta     |
+resource/*               | Stable   |
 trace/trace.proto        | Stable   |
 trace/trace_config.proto | Alpha    |
 


### PR DESCRIPTION
We declared traces part of the protocol stable. Traces use common
and resource messages so we have to declare these as stable as well
otherwise the declaration of trace part as stable does not achieve
the goal (the stable interoperability).

Obviously any new messages can be freely added to common and resource,
"stable" label does not prevent that.