### PR TITLE
Change trace -> traces for non collector

### DIFF
--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package opentelemetry.proto.collector.trace.v1;
 
-import "opentelemetry/proto/trace/v1/trace.proto";
+import "opentelemetry/proto/traces/v1/traces.proto";
 
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.collector.trace.v1";
@@ -38,7 +38,7 @@ message ExportTraceServiceRequest {
   // element. Intermediary nodes (such as OpenTelemetry Collector) that receive
   // data from multiple origins typically batch the data before forwarding further and
   // in that case this array will contain multiple elements.
-  repeated opentelemetry.proto.trace.v1.ResourceSpans resource_spans = 1;
+  repeated opentelemetry.proto.traces.v1.ResourceSpans resource_spans = 1;
 }
 
 message ExportTraceServiceResponse {

--- a/opentelemetry/proto/traces/v1/traces.proto
+++ b/opentelemetry/proto/traces/v1/traces.proto
@@ -14,15 +14,15 @@
 
 syntax = "proto3";
 
-package opentelemetry.proto.trace.v1;
+package opentelemetry.proto.traces.v1;
 
 import "opentelemetry/proto/common/v1/common.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
 option java_multiple_files = true;
-option java_package = "io.opentelemetry.proto.trace.v1";
-option java_outer_classname = "TraceProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/trace/v1";
+option java_package = "io.opentelemetry.proto.traces.v1";
+option java_outer_classname = "TracesProto";
+option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/traces/v1";
 
 // A collection of InstrumentationLibrarySpans from a Resource.
 message ResourceSpans {

--- a/opentelemetry/proto/traces/v1/traces_config.proto
+++ b/opentelemetry/proto/traces/v1/traces_config.proto
@@ -14,12 +14,12 @@
 
 syntax = "proto3";
 
-package opentelemetry.proto.trace.v1;
+package opentelemetry.proto.traces.v1;
 
 option java_multiple_files = true;
-option java_package = "io.opentelemetry.proto.trace.v1";
+option java_package = "io.opentelemetry.proto.traces.v1";
 option java_outer_classname = "TraceConfigProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/trace/v1";
+option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/traces/v1";
 
 // Global configuration of the trace service. All fields must be specified, or
 // the default (zero) values will be used for each type.


### PR DESCRIPTION
This is a backwards compatible change from the wire format perspective. Changing the collector gRPC service name and package + the grpc gateway path will be breaking changes for the protocol.

Would like to make a decision on this.