### PR TITLE
Move experimental under the main signal directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Component                | Maturity |
 collector/metrics/*      | Alpha    |
 collector/trace/*        | Stable   |
 common/*                 | Stable   |
-experimental/*           | Pre-Alpha|
 metrics/*                | Alpha    |
 resource/*               | Stable   |
 trace/trace.proto        | Stable   |
@@ -21,3 +20,12 @@ trace/trace_config.proto | Alpha    |
 
 (See [maturity-matrix.yaml](https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f466a58bd2bb94edc72/maturity-matrix.yaml#L57)
 for definition of maturity levels).
+
+## Experiments
+
+In some cases we are trying to experiment with different features. In this case
+we recommend using an "experimental" sub-directory instead of adding them to any
+protocol version. These protocols should not be used, except for
+development/testing purposes.
+
+Another review must be conducted for experimental protocols to join the main project.

--- a/opentelemetry/proto/experimental/README.md
+++ b/opentelemetry/proto/experimental/README.md
@@ -1,5 +1,0 @@
-# Experimental Protocols
-
-This package is for protocols that are still in an experimental phase, preceding alpha. Another review must be conducted for experimental protocols to join the main project. 
-
-These protocols should not be used, except for development/testing purposes.

--- a/opentelemetry/proto/metrics/experimental/configservice.proto
+++ b/opentelemetry/proto/metrics/experimental/configservice.proto
@@ -14,14 +14,14 @@
 
 syntax = "proto3";
 
-package opentelemetry.proto.experimental.metrics.configservice;
+package opentelemetry.proto.metrics.experimental;
 
 import "opentelemetry/proto/resource/v1/resource.proto";
 
 option java_multiple_files = true;
-option java_package = "io.opentelemetry.proto.experimental.metrics.configservice";
+option java_package = "io.opentelemetry.proto.metrics.experimental";
 option java_outer_classname = "MetricConfigServiceProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/experimental/metrics/configservice";
+option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/experimental";
 
 // MetricConfig is a service that enables updating metric schedules, trace
 // parameters, and other configurations on the SDK without having to restart the


### PR DESCRIPTION
This may be personal preference, but I feel this way the repository is more structured.