### PR TITLE
Fix experimental metrics path in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ GENDIR := gen
 GOPATH_GENDIR := $(GOPATH_DIR)/$(GENDIR)
 
 # Find all .proto files.
-PROTO_FILES := $(wildcard opentelemetry/proto/*/v1/*.proto opentelemetry/proto/collector/*/v1/*.proto opentelemetry/proto/experimental/*/*.proto)
+PROTO_FILES := $(wildcard opentelemetry/proto/*/v1/*.proto opentelemetry/proto/collector/*/v1/*.proto opentelemetry/proto/experimental/metrics/*/*.proto)
 
 # Function to execute a command. Note the empty line before endef to make sure each command
 # gets executed separately instead of concatenated with previous one.


### PR DESCRIPTION
I noticed that the experimental/metrics directory was being missed, and realized I forgot to update the path in the makefile. Sorry!