### PR TITLE
Explicitly declare OTLP/JSON as Alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,18 @@ See [contribution guidelines](CONTRIBUTING.md) if you would like to make any cha
 
 ## Maturity Level
 
-Component                | Maturity |
--------------------------|----------|
-collector/metrics/*      | Alpha    |
-collector/trace/*        | Stable   |
-common/*                 | Stable   |
-metrics/*                | Alpha    |
-resource/*               | Stable   |
-trace/trace.proto        | Stable   |
-trace/trace_config.proto | Alpha    |
+Component                            | Maturity |
+-------------------------------------|----------|
+**Binary Protobuf Encoding**         |          |
+collector/metrics/*                  | Alpha    |
+collector/trace/*                    | Stable   |
+common/*                             | Stable   |
+metrics/*                            | Alpha    |
+resource/*                           | Stable   |
+trace/trace.proto                    | Stable   |
+trace/trace_config.proto             | Alpha    |
+**JSON encoding**                    |          |
+All messages                         | Alpha    |
 
 (See [maturity-matrix.yaml](https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f466a58bd2bb94edc72/maturity-matrix.yaml#L57)
 for definition of maturity levels).


### PR DESCRIPTION
OTLP/JSON was proposed as an OTEP122 and merged very recently (July 7, 2020).
OTEP122 which standardizes OTLP/JSON was merged after we updated protocol
maturity matrix the last time in this repo.

This commit explicitly declares that OTLP/JSON is not yet stable (it was never the
intent to declare it stable immediately after OTEP122 was merged). OTLP/JSON
needs more time to mature.