### PR TITLE
Remove TODO about Histogram sum being double

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -152,8 +152,6 @@ message MetricDescriptor {
   string unit = 3;
 
   // MeasurementValueType determines the value type for a measurement.
-  // TODO: There is an open question about whether this should control int64 vs
-  // double for Histogram. There are good arguments on both sides of this.
   enum MeasurementValueType {
     // UNSPECIFIED is the default MeasurementValueType, it MUST not be
     // used.


### PR DESCRIPTION
From @jmacd:

> I wish to not hold up the specification over either of these questions, so perhaps we could go with a single Double-value Histogram for now, and if ever we decide to add an Integer histogram add it and rename the existing one DoubleHistogram.

