### PR TITLE
Unsplit all data points and exemplar by measurement type

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -136,13 +136,16 @@ message Metric {
   //   UpDownSumObserver  Sum(aggregation_temporality=cumulative;is_monotonic=false)
   //   ValueObserver      Gauge()
   oneof data {
-    Gauge gauge = 4;
-    Sum sum = 5;
-    Histogram histogram = 6;  
+    IntGauge int_gauge = 4;
+    DoubleGauge double_gauge = 5;
+    IntSum int_sum = 6;
+    DoubleSum double_sum = 7;
+    IntHistogram int_histogram = 8;
+    DoubleHistogram double_histogram = 9;
   }
 }
 
-// Gauge represents the type of a scalar metric that always exports the
+// Gauge represents the type of a int scalar metric that always exports the
 // "current value" for every data point. It should be used for an "unknown"
 // aggregation.
 // 
@@ -151,64 +154,67 @@ message Metric {
 // aggregation, regardless of aggregation temporalities. Therefore,
 // AggregationTemporality is not included. Consequently, this also means
 // "StartTimeUnixNano" is ignored for all data points.
-message Gauge {
-  repeated Int64DataPoint int64_data_points = 1;
-  repeated DoubleDataPoint double_data_points = 2;
-
-  // It describes the value type of the measurement used to build this
-  // aggregation.
-  //
-  // Determines if the points are Int64DataPoint or DoubleDataPoint, as well
-  // as the value type of the exemplars.
-  MeasurementValueType measurement_value_type = 3;
+message IntGauge {
+  repeated Int64DataPoint data_points = 1;
 }
 
-// Sum represents the type of a numeric scalar metric that is calculated as a
-// sum of all reported measurements over a time interval.
-message Sum {
-  repeated Int64DataPoint int64_data_points = 1;
-  repeated DoubleDataPoint double_data_points = 2;
+// Gauge represents the type of a double scalar metric that always exports the
+// "current value" for every data point. It should be used for an "unknown"
+// aggregation.
+// 
+// A Gauge does not support different aggregation temporalities. Given the
+// aggregation is unknown, points cannot be combined using the same
+// aggregation, regardless of aggregation temporalities. Therefore,
+// AggregationTemporality is not included. Consequently, this also means
+// "StartTimeUnixNano" is ignored for all data points.
+message DoubleGauge {
+  repeated DoubleDataPoint data_points = 1;
+}
 
-  // It describes the value type of the measurement used to build this
-  // aggregation.
-  //
-  // Determines if the points are Int64DataPoint or DoubleDataPoint, as well
-  // as the value type of the exemplars.
-  MeasurementValueType measurement_value_type = 3;
+// Sum represents the type of a numeric int scalar metric that is calculated as
+// a sum of all reported measurements over a time interval.
+message IntSum {
+  repeated Int64DataPoint data_points = 1;
+
+  // aggregation_temporality describes if the aggregator reports delta changes
+  // since last report time, or cumulative changes since a fixed start time.
+  AggregationTemporality aggregation_temporality = 2;
+
+  // If "true" means that the sum is monotonic.
+  bool is_monotonic = 3;
+}
+
+// Sum represents the type of a numeric double scalar metric that is calculated
+// as a sum of all reported measurements over a time interval.
+message DoubleSum {
+  repeated DoubleDataPoint data_points = 1;
   
   // aggregation_temporality describes if the aggregator reports delta changes
   // since last report time, or cumulative changes since a fixed start time.
-  AggregationTemporality aggregation_temporality = 4;
+  AggregationTemporality aggregation_temporality = 2;
 
   // If "true" means that the sum is monotonic.
-  bool is_monotonic = 5;
+  bool is_monotonic = 3;
 }
 
 // Represents the type of a metric that is calculated by aggregating as a
-// Histogram of all reported measurements over a time interval.
-message Histogram {
-  repeated HistogramDataPoint data_points = 1;
-
-  // It describes the value type of the measurement used to build this
-  // aggregation.
-  //
-  // Determines the value type of the exemplars.
-  MeasurementValueType measurement_value_type = 2;
+// Histogram of all reported int measurements over a time interval.
+message IntHistogram {
+  repeated IntHistogramDataPoint data_points = 1;
 
   // aggregation_temporality describes if the aggregator reports delta changes
   // since last report time, or cumulative changes since a fixed start time.
-  AggregationTemporality aggregation_temporality = 3;
+  AggregationTemporality aggregation_temporality = 2;
 }
 
-// MeasurementValueType determines the value type for a measurement.
-enum MeasurementValueType {
-  // UNSPECIFIED is the default MeasurementValueType, it MUST not be used.
-  MEASUREMENT_VALUE_TYPE_UNSPECIFIED = 0;
-  // INT64 is the MeasurementValueType used when the measurements are int64.
-  MEASUREMENT_VALUE_TYPE_INT64 = 1;
-  // DOUBLE is the MeasurementValueType used when the measurements are
-  // floating point numbers.
-  MEASUREMENT_VALUE_TYPE_DOUBLE = 2;
+// Represents the type of a metric that is calculated by aggregating as a
+// Histogram of all reported double measurements over a time interval.
+message DoubleHistogram {
+  repeated DoubleHistogramDataPoint data_points = 1;
+
+  // aggregation_temporality describes if the aggregator reports delta changes
+  // since last report time, or cumulative changes since a fixed start time.
+  AggregationTemporality aggregation_temporality = 2;
 }
 
 // AggregationTemporality defines how a metric aggregator reports aggregated
@@ -282,8 +288,8 @@ enum AggregationTemporality {
   AGGREGATION_TEMPORALITY_CUMULATIVE = 2;
 }
 
-// Int64DataPoint is a single data point in a timeseries that describes the time-varying
-// values of a int64 metric.
+// Int64DataPoint is a single data point in a timeseries that describes the
+// time-varying values of a int64 metric.
 message Int64DataPoint {
   // The set of labels that uniquely identify this timeseries.
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
@@ -313,11 +319,11 @@ message Int64DataPoint {
 
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point
-  repeated Exemplar exemplars = 5;
+  repeated IntExemplar exemplars = 5;
 }
 
-// DoubleDataPoint is a single data point in a timeseries that describes the time-varying
-// value of a double metric.
+// DoubleDataPoint is a single data point in a timeseries that describes the
+// time-varying value of a double metric.
 message DoubleDataPoint {
   // The set of labels that uniquely identify this timeseries.
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
@@ -347,13 +353,14 @@ message DoubleDataPoint {
 
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point
-  repeated Exemplar exemplars = 5;
+  repeated DoubleExemplar exemplars = 5;
 }
 
-// HistogramDataPoint is a single data point in a timeseries that describes the time-varying
-// values of a Histogram. A Histogram contains summary statistics for a population of values,
-// it may optionally contain the distribution of those values across a set of buckets.
-message HistogramDataPoint {
+// IntHistogramDataPoint is a single data point in a timeseries that describes
+// the time-varying values of a Histogram of int values. A Histogram contains
+// summary statistics for a population of values, it may optionally contain
+// the distribution of those values across a set of buckets.
+message IntHistogramDataPoint {
   // The set of labels that uniquely identify this timeseries.
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
 
@@ -377,13 +384,90 @@ message HistogramDataPoint {
   // 1970.
   fixed64 time_unix_nano = 3;
 
-  // count is the number of values in the population. Must be non-negative. This value
-  // must be equal to the sum of the "count" fields in buckets if a histogram is provided.
+  // count is the number of values in the population. Must be non-negative. This
+  // value must be equal to the sum of the "count" fields in buckets if a
+  // histogram is provided.
   uint64 count = 4;
 
   // sum of the values in the population. If count is zero then this field
-  // must be zero. This value must be equal to the sum of the "sum" fields in buckets if
-  // a histogram is provided.
+  // must be zero. This value must be equal to the sum of the "sum" fields in
+  // buckets if a histogram is provided.
+  int64 sum = 5;
+
+  // bucket_counts is an optional field contains the count values of histogram
+  // for each bucket.
+  //
+  // The sum of the bucket_counts must equal the value in the count field.
+  //
+  // The number of elements in bucket_counts array must be by one greater than
+  // the number of elements in explicit_bounds array.
+  repeated uint64 bucket_counts = 6;
+
+  // A histogram may optionally contain the distribution of the values in the population.
+  // In that case one of the option fields below and "buckets" field both must be defined.
+  // Otherwise all option fields and "buckets" field must be omitted in which case the
+  // distribution of values in the histogram is unknown and only the total count and sum are known.
+
+  // explicit_bounds is the only supported bucket option currently.
+  // TODO: Add more bucket options.
+
+  // explicit_bounds specifies buckets with explicitly defined bounds for values.
+  // The bucket boundaries are described by "bounds" field.
+  //
+  // This defines size(bounds) + 1 (= N) buckets. The boundaries for bucket
+  // at index i are:
+  //
+  // (-infinity, bounds[i]) for i == 0
+  // [bounds[i-1], bounds[i]) for 0 < i < N-1
+  // [bounds[i], +infinity) for i == N-1
+  // The values in bounds array must be strictly increasing.
+  //
+  // Note: only [a, b) intervals are currently supported for each bucket except the first one.
+  // If we decide to also support (a, b] intervals we should add support for these by defining
+  // a boolean value which decides what type of intervals to use.
+  repeated double explicit_bounds = 7;
+
+  // (Optional) List of exemplars collected from
+  // measurements that were used to form the data point
+  repeated IntExemplar exemplars = 8;
+}
+
+// HistogramDataPoint is a single data point in a timeseries that describes the
+// time-varying values of a Histogram of double values. A Histogram contains
+// summary statistics for a population of values, it may optionally contain the
+// distribution of those values across a set of buckets.
+message DoubleHistogramDataPoint {
+  // The set of labels that uniquely identify this timeseries.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
+
+  // start_time_unix_nano is the last time when the aggregation value was reset
+  // to "zero". For some metric types this is ignored, see data types for more
+  // details.
+  //
+  // The aggregation value is over the time interval (start_time_unix_nano,
+  // time_unix_nano].
+  // 
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  //
+  // Value of 0 indicates that the timestamp is unspecified. In that case the
+  // timestamp may be decided by the backend.
+  fixed64 start_time_unix_nano = 2;
+
+  // time_unix_nano is the moment when this aggregation value was reported.
+  // 
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 3;
+
+  // count is the number of values in the population. Must be non-negative. This
+  // value must be equal to the sum of the "count" fields in buckets if a
+  // histogram is provided.
+  uint64 count = 4;
+
+  // sum of the values in the population. If count is zero then this field
+  // must be zero. This value must be equal to the sum of the "sum" fields in
+  // buckets if a histogram is provided.
   double sum = 5;
 
   // bucket_counts is an optional field contains the count values of histogram
@@ -421,14 +505,14 @@ message HistogramDataPoint {
 
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point
-  repeated Exemplar exemplars = 8;
+  repeated DoubleExemplar exemplars = 8;
 }
 
-// A representation of an exemplar, which is a sample input measurement.
+// A representation of an exemplar, which is a sample input int measurement.
 // Exemplars also hold information about the environment when the measurement
 // was recorded, for example the span and trace ID of the active span when the
 // exemplar was recorded.
-message Exemplar {
+message IntExemplar {
   // The set of labels that were filtered out by the aggregator, but recorded
   // alongside the original measurement. Only labels that were filtered out
   // by the aggregator should be included
@@ -436,21 +520,50 @@ message Exemplar {
 
   // time_unix_nano is the exact time when this exemplar was recorded
   //
-  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
   fixed64 time_unix_nano = 2;
 
-  // Numerical value of the measurement that was recorded. Only one of these
-  // two fields is used for the data, based on MeasurementValueType.
-  double double_value = 3;
-  int64 int64_value = 4;
+  // Numerical int value of the measurement that was recorded.
+  int64 value = 3;
 
   // (Optional) Span ID of the exemplar trace.
   // span_id may be missing if the measurement is not recorded inside a trace
   // or if the trace is not sampled.
-  bytes span_id = 5;
+  bytes span_id = 4;
 
   // (Optional) Trace ID of the exemplar trace.
   // trace_id may be missing if the measurement is not recorded inside a trace
   // or if the trace is not sampled.
-  bytes trace_id = 6;
+  bytes trace_id = 5;
+}
+
+// A representation of an exemplar, which is a sample input double measurement.
+// Exemplars also hold information about the environment when the measurement
+// was recorded, for example the span and trace ID of the active span when the
+// exemplar was recorded.
+message DoubleExemplar {
+  // The set of labels that were filtered out by the aggregator, but recorded
+  // alongside the original measurement. Only labels that were filtered out
+  // by the aggregator should be included
+  repeated opentelemetry.proto.common.v1.StringKeyValue filtered_labels = 1;
+
+  // time_unix_nano is the exact time when this exemplar was recorded
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 2;
+
+  // Numerical double value of the measurement that was recorded.
+  double value = 3;
+
+  // (Optional) Span ID of the exemplar trace.
+  // span_id may be missing if the measurement is not recorded inside a trace
+  // or if the trace is not sampled.
+  bytes span_id = 4;
+
+  // (Optional) Trace ID of the exemplar trace.
+  // trace_id may be missing if the measurement is not recorded inside a trace
+  // or if the trace is not sampled.
+  bytes trace_id = 5;
 }


### PR DESCRIPTION
Cannot see any significant difference between merged messages vs split messages, code is here https://github.com/bogdandrutu/metrics-proto

```
goos: darwin
goarch: amd64
pkg: github.com/bogdandrutu/metrics-proto/benchmark
BenchmarkEncodeDecode
BenchmarkEncodeDecode/merged
BenchmarkEncodeDecode/merged-16         	   34406	     33744 ns/op	   30288 B/op	     523 allocs/op
BenchmarkEncodeDecode/unmerged
BenchmarkEncodeDecode/unmerged-16       	   36130	     33190 ns/op	   29168 B/op	     523 allocs/op
```

Advantages over #208:
* extensibility - can add new types that work only on some measurement types like strings if we decide to support that)
* no corner cases like measurement type is long and exemplars are using double values.