### PR TITLE
metrics proto: rename dropped labels to filtered labels

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -429,10 +429,10 @@ message HistogramDataPoint {
 // was recorded, for example the span and trace ID of the active span when the
 // exemplar was recorded.
 message Exemplar {
-  // The set of labels that were dropped by the aggregator, but recorded
-  // alongside the original measurement. Only labels that were dropped by the
-  // aggregator should be included
-  repeated opentelemetry.proto.common.v1.StringKeyValue dropped_labels = 1;
+  // The set of labels that were filtered out by the aggregator, but recorded
+  // alongside the original measurement. Only labels that were filtered out
+  // by the aggregator should be included
+  repeated opentelemetry.proto.common.v1.StringKeyValue filtered_labels = 1;
 
   // time_unix_nano is the exact time when this exemplar was recorded
   //


### PR DESCRIPTION
In other protos "dropped" is used to refer to counts of
how many of an item were discarded because did not meet
the spec (such as an attribute key being too long) or
because there is a limit on the total number.

This field is not labels dropped for not conforming to
a spec but labels filtered out because they were not
included in the aggregations definition of labels to
include. So this commit renames to `filtered` instead
of `dropped` to avoid confusion.