### PR TITLE
Add an idempotency key to trace/metrics/logs Export*ServiceRequest

### DIFF
--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -48,8 +48,8 @@ message ExportLogsServiceRequest {
   // events.
   //
   // OTLP clients SHOULD include an idempotency key.  Empty
-  // idempotency keys are invalid and MUST be ignored.  A 128-bit [V4
-  // UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
+  // idempotency keys are invalid and MUST be ignored.  A 128-bit V4
+  // UUID (https://tools.ietf.org/html/rfc4122) is the
   // recommended idempotency key format.
   bytes idempotency_key = 2;
 }

--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -48,7 +48,7 @@ message ExportLogsServiceRequest {
   // events.
   //
   // OTLP clients SHOULD include a randomly generated idempotency key.
-  // Values of size less than 8 bytes are invalid and must be ignored.
+  // Values of size less than 8 bytes are invalid and MUST be ignored.
   //
   // [V4 UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
   // recommended idempotency key format.

--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -42,6 +42,17 @@ message ExportLogsServiceRequest {
   // data from multiple origins typically batch the data before forwarding further and
   // in that case this array will contain multiple elements.
   repeated opentelemetry.proto.logs.v1.ResourceLogs resource_logs = 1;
+
+  // An idempotency key is optional information used in a server to
+  // detect retried requests and avoid double-counting of logging
+  // events.
+  //
+  // OTLP clients SHOULD include a randomly generated idempotency key.
+  // Values of size less than 8 bytes are invalid and must be ignored.
+  //
+  // [V4 UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
+  // recommended idempotency key format.
+  string idempotency_key = 2;
 }
 
 message ExportLogsServiceResponse {

--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -47,12 +47,11 @@ message ExportLogsServiceRequest {
   // detect retried requests and avoid double-counting of logging
   // events.
   //
-  // OTLP clients SHOULD include a randomly generated idempotency key.
-  // Values of size less than 8 bytes are invalid and MUST be ignored.
-  //
-  // [V4 UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
+  // OTLP clients SHOULD include an idempotency key.  Empty
+  // idempotency keys are invalid and MUST be ignored.  A 128-bit [V4
+  // UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
   // recommended idempotency key format.
-  string idempotency_key = 2;
+  bytes idempotency_key = 2;
 }
 
 message ExportLogsServiceResponse {

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -40,13 +40,16 @@ message ExportMetricsServiceRequest {
   // in that case this array will contain multiple elements.
   repeated opentelemetry.proto.metrics.v1.ResourceMetrics resource_metrics = 1;
 
-  // An idempotency key is optional information used in a server bytes used to
-  // detect retried requests and avoid duplicate counting.  This is especially
-  // important for metrics exported with AggregationTemporality=DELTA.
+  // An idempotency key is optional information used in a server to
+  // detect retried requests and avoid double-counting of metric
+  // events.
   //
-  // OTLP clients SHOULD include a randomly generated idempotency key.  The recommended
-  // size for an idempotency key is 8 bytes.
-  optional bytes idempotency_key = 2;
+  // OTLP clients SHOULD include a randomly generated idempotency key.
+  // Values of size less than 8 bytes are invalid and must be ignored.
+  //
+  // [V4 UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
+  // recommended idempotency key format.
+  string idempotency_key = 2;
 }
 
 message ExportMetricsServiceResponse {

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -44,12 +44,11 @@ message ExportMetricsServiceRequest {
   // detect retried requests and avoid double-counting of metric
   // events.
   //
-  // OTLP clients SHOULD include a randomly generated idempotency key.
-  // Values of size less than 8 bytes are invalid and MUST be ignored.
-  //
-  // [V4 UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
+  // OTLP clients SHOULD include an idempotency key.  Empty
+  // idempotency keys are invalid and MUST be ignored.  A 128-bit [V4
+  // UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
   // recommended idempotency key format.
-  string idempotency_key = 2;
+  bytes idempotency_key = 2;
 }
 
 message ExportMetricsServiceResponse {

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -45,8 +45,8 @@ message ExportMetricsServiceRequest {
   // events.
   //
   // OTLP clients SHOULD include an idempotency key.  Empty
-  // idempotency keys are invalid and MUST be ignored.  A 128-bit [V4
-  // UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
+  // idempotency keys are invalid and MUST be ignored.  A 128-bit V4
+  // UUID (https://tools.ietf.org/html/rfc4122) is the
   // recommended idempotency key format.
   bytes idempotency_key = 2;
 }

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -45,7 +45,7 @@ message ExportMetricsServiceRequest {
   // events.
   //
   // OTLP clients SHOULD include a randomly generated idempotency key.
-  // Values of size less than 8 bytes are invalid and must be ignored.
+  // Values of size less than 8 bytes are invalid and MUST be ignored.
   //
   // [V4 UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
   // recommended idempotency key format.

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -39,6 +39,14 @@ message ExportMetricsServiceRequest {
   // data from multiple origins typically batch the data before forwarding further and
   // in that case this array will contain multiple elements.
   repeated opentelemetry.proto.metrics.v1.ResourceMetrics resource_metrics = 1;
+
+  // An idempotency key is optional information used in a server bytes used to
+  // detect retried requests and avoid duplicate counting.  This is especially
+  // important for metrics exported with AggregationTemporality=DELTA.
+  //
+  // OTLP clients SHOULD include a randomly generated idempotency key.  The recommended
+  // size for an idempotency key is 8 bytes.
+  optional bytes idempotency_key = 2;
 }
 
 message ExportMetricsServiceResponse {

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -45,8 +45,8 @@ message ExportTraceServiceRequest {
   // events.
   //
   // OTLP clients SHOULD include an idempotency key.  Empty
-  // idempotency keys are invalid and MUST be ignored.  A 128-bit [V4
-  // UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
+  // idempotency keys are invalid and MUST be ignored.  A 128-bit V4
+  // UUID (https://tools.ietf.org/html/rfc4122) is the
   // recommended idempotency key format.
   bytes idempotency_key = 2;
 }

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -44,12 +44,11 @@ message ExportTraceServiceRequest {
   // detect retried requests and avoid double-counting of tracinfg
   // events.
   //
-  // OTLP clients SHOULD include a randomly generated idempotency key.
-  // Values of size less than 8 bytes are invalid and MUST be ignored.
-  //
-  // [V4 UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
+  // OTLP clients SHOULD include an idempotency key.  Empty
+  // idempotency keys are invalid and MUST be ignored.  A 128-bit [V4
+  // UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
   // recommended idempotency key format.
-  string idempotency_key = 2;
+  bytes idempotency_key = 2;
 }
 
 message ExportTraceServiceResponse {

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -45,7 +45,7 @@ message ExportTraceServiceRequest {
   // events.
   //
   // OTLP clients SHOULD include a randomly generated idempotency key.
-  // Values of size less than 8 bytes are invalid and must be ignored.
+  // Values of size less than 8 bytes are invalid and MUST be ignored.
   //
   // [V4 UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
   // recommended idempotency key format.

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -39,6 +39,17 @@ message ExportTraceServiceRequest {
   // data from multiple origins typically batch the data before forwarding further and
   // in that case this array will contain multiple elements.
   repeated opentelemetry.proto.trace.v1.ResourceSpans resource_spans = 1;
+
+  // An idempotency key is optional information used in a server to
+  // detect retried requests and avoid double-counting of tracinfg
+  // events.
+  //
+  // OTLP clients SHOULD include a randomly generated idempotency key.
+  // Values of size less than 8 bytes are invalid and must be ignored.
+  //
+  // [V4 UUID]([RFC 4122](https://tools.ietf.org/html/rfc4122)) is the
+  // recommended idempotency key format.
+  string idempotency_key = 2;
 }
 
 message ExportTraceServiceResponse {


### PR DESCRIPTION
Adds an idempotency key as described in #218. This is to support AggregationTemporality=DELTA correctly in systems that ingest and store DELTA data points.

Fixes #218.