### PR TITLE
Modify Span status according to specification

### DIFF
--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -220,7 +220,7 @@ message Span {
   // enforced. If this value is 0, then no links were dropped.
   uint32 dropped_links_count = 14;
 
-  // An optional final status for this span. Semantically when Status isn't set it means
+  // An optional final status for this span. Semantically when Status isn't set, it means
   // span's status code is unset, i.e. assume STATUS_CANONICAL_CODE_UNSET (code = 0).
   Status status = 15;
 }
@@ -251,7 +251,7 @@ message Status {
 
   // The deprecated status code. This is an optional field.
   //
-  // This field is deprecated and is replaced by `code` field below. See backward
+  // This field is deprecated and is replaced by the `code` field below. See backward
   // compatibility notes below. According to our stability guarantees this field
   // will be removed in 12 months, on Sep 26, 2021. All usage of old senders and
   // receivers that do not understand the `code` field MUST be phased out by then.
@@ -277,27 +277,27 @@ message Status {
 
   // IMPORTANT: Backward compatibility notes:
   //
-  // To ensure any two pair of senders and receivers continues to correctly signal and
-  // interpret erroneous situation the senders and receivers SHOULD follow these rules:
+  // To ensure any pair of senders and receivers continues to correctly signal and
+  // interpret erroneous situations, the senders and receivers SHOULD follow these rules:
   //
-  // 1. Old senders and receives that are not aware of `code` field will continue using
-  // `deprecated_code` field to signal and interpret erroneous situation.
+  // 1. Old senders and receivers that are not aware of `code` field will continue using
+  // the `deprecated_code` field to signal and interpret erroneous situation.
   //
-  // 2. New senders, which are aware of `code` field should set both `deprecated_code`
-  // and `code` fields according to the following rules:
+  // 2. New senders, which are aware of the `code` field SHOULD set both the
+  // `deprecated_code` and `code` fields according to the following rules:
   //
-  //   if code==STATUS_CANONICAL_CODE_UNSET then `deprecated_code` must be
+  //   if code==STATUS_CANONICAL_CODE_UNSET then `deprecated_code` MUST be
   //   set to DEPRECATED_STATUS_CODE_OK.
   //
-  //   if code==STATUS_CANONICAL_CODE_ERROR then `deprecated_code` must be
+  //   if code==STATUS_CANONICAL_CODE_OK then `deprecated_code` MUST be
+  //   set to DEPRECATED_STATUS_CODE_OK.
+  //
+  //   if code==STATUS_CANONICAL_CODE_ERROR then `deprecated_code` MUST be
   //   set to DEPRECATED_STATUS_CODE_UNKNOWN_ERROR.
-  //
-  //   if code==STATUS_CANONICAL_CODE_OK then `deprecated_code` must be
-  //   set to DEPRECATED_STATUS_CODE_OK.
   //
   // These rules allow old receivers to correctly interpret data received from new senders.
   //
-  // 3. New receivers should look both at `code` and `deprecated_code` fields in order
+  // 3. New receivers should look at both the `code` and `deprecated_code` fields in order
   // to interpret the overall status:
   //
   //   If code==STATUS_CANONICAL_CODE_UNSET then the value of `deprecated_code` is the
@@ -310,7 +310,7 @@ message Status {
   //     the overall status to be STATUS_CANONICAL_CODE_ERROR.
   //
   //   If code!=STATUS_CANONICAL_CODE_UNSET then the value of `deprecated_code` should be
-  //   ignored, the `code` field is the sole carrier of status.
+  //   ignored, the `code` field is the sole carrier of the status.
   //
   // These rules allow new receivers to correctly interpret data received from old senders.
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -221,7 +221,7 @@ message Span {
   uint32 dropped_links_count = 14;
 
   // An optional final status for this span. Semantically when Status isn't set, it means
-  // span's status code is unset, i.e. assume STATUS_CANONICAL_CODE_UNSET (code = 0).
+  // span's status code is unset, i.e. assume STATUS_CANONICAL_CODE_UNSET (canonical_code = 0).
   Status status = 15;
 }
 
@@ -229,33 +229,34 @@ message Span {
 // programming environments, including REST APIs and RPC APIs.
 message Status {
 
-  enum DeprecatedStatusCode {
-    DEPRECATED_STATUS_CODE_OK                  = 0;
-    DEPRECATED_STATUS_CODE_CANCELLED           = 1;
-    DEPRECATED_STATUS_CODE_UNKNOWN_ERROR       = 2;
-    DEPRECATED_STATUS_CODE_INVALID_ARGUMENT    = 3;
-    DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED   = 4;
-    DEPRECATED_STATUS_CODE_NOT_FOUND           = 5;
-    DEPRECATED_STATUS_CODE_ALREADY_EXISTS      = 6;
-    DEPRECATED_STATUS_CODE_PERMISSION_DENIED   = 7;
-    DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED  = 8;
-    DEPRECATED_STATUS_CODE_FAILED_PRECONDITION = 9;
-    DEPRECATED_STATUS_CODE_ABORTED             = 10;
-    DEPRECATED_STATUS_CODE_OUT_OF_RANGE        = 11;
-    DEPRECATED_STATUS_CODE_UNIMPLEMENTED       = 12;
-    DEPRECATED_STATUS_CODE_INTERNAL_ERROR      = 13;
-    DEPRECATED_STATUS_CODE_UNAVAILABLE         = 14;
-    DEPRECATED_STATUS_CODE_DATA_LOSS           = 15;
-    DEPRECATED_STATUS_CODE_UNAUTHENTICATED     = 16;
+  enum StatusCode {
+    STATUS_CODE_OK                  = 0;
+    STATUS_CODE_CANCELLED           = 1;
+    STATUS_CODE_UNKNOWN_ERROR       = 2;
+    STATUS_CODE_INVALID_ARGUMENT    = 3;
+    STATUS_CODE_DEADLINE_EXCEEDED   = 4;
+    STATUS_CODE_NOT_FOUND           = 5;
+    STATUS_CODE_ALREADY_EXISTS      = 6;
+    STATUS_CODE_PERMISSION_DENIED   = 7;
+    STATUS_CODE_RESOURCE_EXHAUSTED  = 8;
+    STATUS_CODE_FAILED_PRECONDITION = 9;
+    STATUS_CODE_ABORTED             = 10;
+    STATUS_CODE_OUT_OF_RANGE        = 11;
+    STATUS_CODE_UNIMPLEMENTED       = 12;
+    STATUS_CODE_INTERNAL_ERROR      = 13;
+    STATUS_CODE_UNAVAILABLE         = 14;
+    STATUS_CODE_DATA_LOSS           = 15;
+    STATUS_CODE_UNAUTHENTICATED     = 16;
   };
 
   // The deprecated status code. This is an optional field.
   //
-  // This field is deprecated and is replaced by the `code` field below. See backward
-  // compatibility notes below. According to our stability guarantees this field
+  // This field is deprecated and is replaced by the `canonical_code` field below. See
+  // backward compatibility notes below. According to our stability guarantees this field
   // will be removed in 12 months, on Sep 26, 2021. All usage of old senders and
-  // receivers that do not understand the `code` field MUST be phased out by then.
-  DeprecatedStatusCode deprecated_code = 1 [deprecated=true];
+  // receivers that do not understand the `canonical_code` field MUST be phased out
+  // by then.
+  StatusCode code = 1 [deprecated=true];
 
   // A developer-facing human readable error message.
   string message = 2;
@@ -272,45 +273,45 @@ message Status {
     STATUS_CANONICAL_CODE_ERROR               = 2;
   };
 
-  // The status code.
-  StatusCanonicalCode code = 3;
+  // The new status canonical_code.
+  StatusCanonicalCode canonical_code = 3;
 
   // IMPORTANT: Backward compatibility notes:
   //
   // To ensure any pair of senders and receivers continues to correctly signal and
   // interpret erroneous situations, the senders and receivers SHOULD follow these rules:
   //
-  // 1. Old senders and receivers that are not aware of `code` field will continue using
-  // the `deprecated_code` field to signal and interpret erroneous situation.
+  // 1. Old senders and receivers that are not aware of `canonical_code` field will
+  // continue using the `code` field to signal and interpret erroneous situation.
   //
-  // 2. New senders, which are aware of the `code` field SHOULD set both the
-  // `deprecated_code` and `code` fields according to the following rules:
+  // 2. New senders, which are aware of the `canonical_code` field SHOULD set both the
+  // `code` and `canonical_code` fields according to the following rules:
   //
-  //   if code==STATUS_CANONICAL_CODE_UNSET then `deprecated_code` MUST be
-  //   set to DEPRECATED_STATUS_CODE_OK.
+  //   if canonical_code==STATUS_CANONICAL_CODE_UNSET then `code` MUST be
+  //   set to STATUS_CODE_OK.
   //
-  //   if code==STATUS_CANONICAL_CODE_OK then `deprecated_code` MUST be
-  //   set to DEPRECATED_STATUS_CODE_OK.
+  //   if canonical_code==STATUS_CANONICAL_CODE_OK then `code` MUST be
+  //   set to STATUS_CODE_OK.
   //
-  //   if code==STATUS_CANONICAL_CODE_ERROR then `deprecated_code` MUST be
-  //   set to DEPRECATED_STATUS_CODE_UNKNOWN_ERROR.
+  //   if canonical_code==STATUS_CANONICAL_CODE_ERROR then `code` MUST be
+  //   set to STATUS_CODE_UNKNOWN_ERROR.
   //
   // These rules allow old receivers to correctly interpret data received from new senders.
   //
-  // 3. New receivers should look at both the `code` and `deprecated_code` fields in order
+  // 3. New receivers should look at both the `canonical_code` and `code` fields in order
   // to interpret the overall status:
   //
-  //   If code==STATUS_CANONICAL_CODE_UNSET then the value of `deprecated_code` is the
+  //   If canonical_code==STATUS_CANONICAL_CODE_UNSET then the value of `code` is the
   //   carrier of the overall status according to these rules:
   //
-  //     if deprecated_code==DEPRECATED_STATUS_CODE_OK then the receiver should interpret
+  //     if code==STATUS_CODE_OK then the receiver should interpret
   //     the overall status to be STATUS_CANONICAL_CODE_UNSET.
   //
-  //     if deprecated_code!=DEPRECATED_STATUS_CODE_OK then the receiver should interpret
+  //     if code!=STATUS_CODE_OK then the receiver should interpret
   //     the overall status to be STATUS_CANONICAL_CODE_ERROR.
   //
-  //   If code!=STATUS_CANONICAL_CODE_UNSET then the value of `deprecated_code` should be
-  //   ignored, the `code` field is the sole carrier of the status.
+  //   If canonical_code!=STATUS_CANONICAL_CODE_UNSET then the value of `code` should be
+  //   ignored, the `canonical_code` field is the sole carrier of the status.
   //
   // These rules allow new receivers to correctly interpret data received from old senders.
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -221,7 +221,7 @@ message Span {
   uint32 dropped_links_count = 14;
 
   // An optional final status for this span. Semantically when Status isn't set, it means
-  // span's status code is unset, i.e. assume STATUS_CANONICAL_CODE_UNSET (code = 0).
+  // span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0).
   Status status = 15;
 }
 
@@ -261,19 +261,19 @@ message Status {
   string message = 2;
 
   // For the semantics of status codes see
-  // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#statuscanonicalcode
-  enum StatusCanonicalCode {
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-status
+  enum StatusCode {
     // The default status.
-    STATUS_CANONICAL_CODE_UNSET               = 0;
+    STATUS_CODE_UNSET               = 0;
     // The Span has been validated by an Application developers or Operator to have
     // completed successfully.
-    STATUS_CANONICAL_CODE_OK                  = 1;
+    STATUS_CODE_OK                  = 1;
     // The Span contains an error.
-    STATUS_CANONICAL_CODE_ERROR               = 2;
+    STATUS_CODE_ERROR               = 2;
   };
 
   // The status code.
-  StatusCanonicalCode code = 3;
+  StatusCode code = 3;
 
   // IMPORTANT: Backward compatibility notes:
   //
@@ -286,13 +286,13 @@ message Status {
   // 2. New senders, which are aware of the `code` field SHOULD set both the
   // `deprecated_code` and `code` fields according to the following rules:
   //
-  //   if code==STATUS_CANONICAL_CODE_UNSET then `deprecated_code` MUST be
+  //   if code==STATUS_CODE_UNSET then `deprecated_code` MUST be
   //   set to DEPRECATED_STATUS_CODE_OK.
   //
-  //   if code==STATUS_CANONICAL_CODE_OK then `deprecated_code` MUST be
+  //   if code==STATUS_CODE_OK then `deprecated_code` MUST be
   //   set to DEPRECATED_STATUS_CODE_OK.
   //
-  //   if code==STATUS_CANONICAL_CODE_ERROR then `deprecated_code` MUST be
+  //   if code==STATUS_CODE_ERROR then `deprecated_code` MUST be
   //   set to DEPRECATED_STATUS_CODE_UNKNOWN_ERROR.
   //
   // These rules allow old receivers to correctly interpret data received from new senders.
@@ -300,16 +300,16 @@ message Status {
   // 3. New receivers should look at both the `code` and `deprecated_code` fields in order
   // to interpret the overall status:
   //
-  //   If code==STATUS_CANONICAL_CODE_UNSET then the value of `deprecated_code` is the
+  //   If code==STATUS_CODE_UNSET then the value of `deprecated_code` is the
   //   carrier of the overall status according to these rules:
   //
   //     if deprecated_code==DEPRECATED_STATUS_CODE_OK then the receiver should interpret
-  //     the overall status to be STATUS_CANONICAL_CODE_UNSET.
+  //     the overall status to be STATUS_CODE_UNSET.
   //
   //     if deprecated_code!=DEPRECATED_STATUS_CODE_OK then the receiver should interpret
-  //     the overall status to be STATUS_CANONICAL_CODE_ERROR.
+  //     the overall status to be STATUS_CODE_ERROR.
   //
-  //   If code!=STATUS_CANONICAL_CODE_UNSET then the value of `deprecated_code` should be
+  //   If code!=STATUS_CODE_UNSET then the value of `deprecated_code` should be
   //   ignored, the `code` field is the sole carrier of the status.
   //
   // These rules allow new receivers to correctly interpret data received from old senders.

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -228,6 +228,44 @@ message Span {
 // The Status type defines a logical error model that is suitable for different
 // programming environments, including REST APIs and RPC APIs.
 message Status {
+  // IMPORTANT: Backward compatibility notes:
+  //
+  // To ensure any pair of senders and receivers continues to correctly signal and
+  // interpret erroneous situations, the senders and receivers MUST follow these rules:
+  //
+  // 1. Old senders and receivers that are not aware of `code` field will continue using
+  // the `deprecated_code` field to signal and interpret erroneous situation.
+  //
+  // 2. New senders, which are aware of the `code` field MUST set both the
+  // `deprecated_code` and `code` fields according to the following rules:
+  //
+  //   if code==STATUS_CODE_UNSET then `deprecated_code` MUST be
+  //   set to DEPRECATED_STATUS_CODE_OK.
+  //
+  //   if code==STATUS_CODE_OK then `deprecated_code` MUST be
+  //   set to DEPRECATED_STATUS_CODE_OK.
+  //
+  //   if code==STATUS_CODE_ERROR then `deprecated_code` MUST be
+  //   set to DEPRECATED_STATUS_CODE_UNKNOWN_ERROR.
+  //
+  // These rules allow old receivers to correctly interpret data received from new senders.
+  //
+  // 3. New receivers MUST look at both the `code` and `deprecated_code` fields in order
+  // to interpret the overall status:
+  //
+  //   If code==STATUS_CODE_UNSET then the value of `deprecated_code` is the
+  //   carrier of the overall status according to these rules:
+  //
+  //     if deprecated_code==DEPRECATED_STATUS_CODE_OK then the receiver MUST interpret
+  //     the overall status to be STATUS_CODE_UNSET.
+  //
+  //     if deprecated_code!=DEPRECATED_STATUS_CODE_OK then the receiver MUST interpret
+  //     the overall status to be STATUS_CODE_ERROR.
+  //
+  //   If code!=STATUS_CODE_UNSET then the value of `deprecated_code` MUST be
+  //   ignored, the `code` field is the sole carrier of the status.
+  //
+  // These rules allow new receivers to correctly interpret data received from old senders.
 
   enum DeprecatedStatusCode {
     DEPRECATED_STATUS_CODE_OK                  = 0;
@@ -274,43 +312,4 @@ message Status {
 
   // The status code.
   StatusCode code = 3;
-
-  // IMPORTANT: Backward compatibility notes:
-  //
-  // To ensure any pair of senders and receivers continues to correctly signal and
-  // interpret erroneous situations, the senders and receivers SHOULD follow these rules:
-  //
-  // 1. Old senders and receivers that are not aware of `code` field will continue using
-  // the `deprecated_code` field to signal and interpret erroneous situation.
-  //
-  // 2. New senders, which are aware of the `code` field SHOULD set both the
-  // `deprecated_code` and `code` fields according to the following rules:
-  //
-  //   if code==STATUS_CODE_UNSET then `deprecated_code` MUST be
-  //   set to DEPRECATED_STATUS_CODE_OK.
-  //
-  //   if code==STATUS_CODE_OK then `deprecated_code` MUST be
-  //   set to DEPRECATED_STATUS_CODE_OK.
-  //
-  //   if code==STATUS_CODE_ERROR then `deprecated_code` MUST be
-  //   set to DEPRECATED_STATUS_CODE_UNKNOWN_ERROR.
-  //
-  // These rules allow old receivers to correctly interpret data received from new senders.
-  //
-  // 3. New receivers should look at both the `code` and `deprecated_code` fields in order
-  // to interpret the overall status:
-  //
-  //   If code==STATUS_CODE_UNSET then the value of `deprecated_code` is the
-  //   carrier of the overall status according to these rules:
-  //
-  //     if deprecated_code==DEPRECATED_STATUS_CODE_OK then the receiver should interpret
-  //     the overall status to be STATUS_CODE_UNSET.
-  //
-  //     if deprecated_code!=DEPRECATED_STATUS_CODE_OK then the receiver should interpret
-  //     the overall status to be STATUS_CODE_ERROR.
-  //
-  //   If code!=STATUS_CODE_UNSET then the value of `deprecated_code` should be
-  //   ignored, the `code` field is the sole carrier of the status.
-  //
-  // These rules allow new receivers to correctly interpret data received from old senders.
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -220,9 +220,8 @@ message Span {
   // enforced. If this value is 0, then no links were dropped.
   uint32 dropped_links_count = 14;
 
-  // An optional final status for this span. Semantically when Status
-  // wasn't set it is means span ended without errors and assume
-  // Status.Ok (code = 0).
+  // An optional final status for this span. Semantically when Status isn't set it means
+  // span's status code is unset, i.e. assume STATUS_CANONICAL_CODE_UNSET (code = 0).
   Status status = 15;
 }
 
@@ -230,32 +229,88 @@ message Span {
 // programming environments, including REST APIs and RPC APIs.
 message Status {
 
-  // StatusCode mirrors the codes defined at
-  // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-tracing.md#statuscanonicalcode
-  enum StatusCode {
-    STATUS_CODE_OK                  = 0;
-    STATUS_CODE_CANCELLED           = 1;
-    STATUS_CODE_UNKNOWN_ERROR       = 2;
-    STATUS_CODE_INVALID_ARGUMENT    = 3;
-    STATUS_CODE_DEADLINE_EXCEEDED   = 4;
-    STATUS_CODE_NOT_FOUND           = 5;
-    STATUS_CODE_ALREADY_EXISTS      = 6;
-    STATUS_CODE_PERMISSION_DENIED   = 7;
-    STATUS_CODE_RESOURCE_EXHAUSTED  = 8;
-    STATUS_CODE_FAILED_PRECONDITION = 9;
-    STATUS_CODE_ABORTED             = 10;
-    STATUS_CODE_OUT_OF_RANGE        = 11;
-    STATUS_CODE_UNIMPLEMENTED       = 12;
-    STATUS_CODE_INTERNAL_ERROR      = 13;
-    STATUS_CODE_UNAVAILABLE         = 14;
-    STATUS_CODE_DATA_LOSS           = 15;
-    STATUS_CODE_UNAUTHENTICATED     = 16;
+  enum DeprecatedStatusCode {
+    DEPRECATED_STATUS_CODE_OK                  = 0;
+    DEPRECATED_STATUS_CODE_CANCELLED           = 1;
+    DEPRECATED_STATUS_CODE_UNKNOWN_ERROR       = 2;
+    DEPRECATED_STATUS_CODE_INVALID_ARGUMENT    = 3;
+    DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED   = 4;
+    DEPRECATED_STATUS_CODE_NOT_FOUND           = 5;
+    DEPRECATED_STATUS_CODE_ALREADY_EXISTS      = 6;
+    DEPRECATED_STATUS_CODE_PERMISSION_DENIED   = 7;
+    DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED  = 8;
+    DEPRECATED_STATUS_CODE_FAILED_PRECONDITION = 9;
+    DEPRECATED_STATUS_CODE_ABORTED             = 10;
+    DEPRECATED_STATUS_CODE_OUT_OF_RANGE        = 11;
+    DEPRECATED_STATUS_CODE_UNIMPLEMENTED       = 12;
+    DEPRECATED_STATUS_CODE_INTERNAL_ERROR      = 13;
+    DEPRECATED_STATUS_CODE_UNAVAILABLE         = 14;
+    DEPRECATED_STATUS_CODE_DATA_LOSS           = 15;
+    DEPRECATED_STATUS_CODE_UNAUTHENTICATED     = 16;
   };
 
-  // The status code. This is optional field. It is safe to assume 0 (OK)
-  // when not set.
-  StatusCode code = 1;
+  // The deprecated status code. This is an optional field.
+  //
+  // This field is deprecated and is replaced by `code` field below. See backward
+  // compatibility notes below. According to our stability guarantees this field
+  // will be removed in 12 months, on Sep 26, 2021. All usage of old senders and
+  // receivers that do not understand the `code` field MUST be phased out by then.
+  DeprecatedStatusCode deprecated_code = 1 [deprecated=true];
 
   // A developer-facing human readable error message.
   string message = 2;
+
+  // For the semantics of status codes see
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#statuscanonicalcode
+  enum StatusCanonicalCode {
+    // The default status.
+    STATUS_CANONICAL_CODE_UNSET               = 0;
+    // The Span has been validated by an Application developers or Operator to have
+    // completed successfully.
+    STATUS_CANONICAL_CODE_OK                  = 1;
+    // The Span contains an error.
+    STATUS_CANONICAL_CODE_ERROR               = 2;
+  };
+
+  // The status code.
+  StatusCanonicalCode code = 3;
+
+  // IMPORTANT: Backward compatibility notes:
+  //
+  // To ensure any two pair of senders and receivers continues to correctly signal and
+  // interpret erroneous situation the senders and receivers SHOULD follow these rules:
+  //
+  // 1. Old senders and receives that are not aware of `code` field will continue using
+  // `deprecated_code` field to signal and interpret erroneous situation.
+  //
+  // 2. New senders, which are aware of `code` field should set both `deprecated_code`
+  // and `code` fields according to the following rules:
+  //
+  //   if code==STATUS_CANONICAL_CODE_UNSET then `deprecated_code` must be
+  //   set to DEPRECATED_STATUS_CODE_OK.
+  //
+  //   if code==STATUS_CANONICAL_CODE_ERROR then `deprecated_code` must be
+  //   set to DEPRECATED_STATUS_CODE_UNKNOWN_ERROR.
+  //
+  //   if code==STATUS_CANONICAL_CODE_OK then `deprecated_code` must be
+  //   set to DEPRECATED_STATUS_CODE_OK.
+  //
+  // These rules allow old receivers to correctly interpret data received from new senders.
+  //
+  // 3. New receivers should look both at `code` and `deprecated_code` fields in order
+  // to interpret the overall status:
+  //
+  //   If code==STATUS_CANONICAL_CODE_UNSET then the value of `deprecated_code` is the
+  //   carrier of the overall status according to these rules:
+  //
+  //     if deprecated_code==DEPRECATED_STATUS_CODE_OK then the receiver should interpret
+  //     the overall status to be STATUS_CANONICAL_CODE_UNSET.
+  //
+  //     if deprecated_code!=DEPRECATED_STATUS_CODE_OK then the receiver should interpret
+  //     the overall status to be STATUS_CANONICAL_CODE_ERROR.
+  //
+  //   If code!=STATUS_CANONICAL_CODE_UNSET then the value of `deprecated_code` should be
+  //   ignored, the `code` field is the sole carrier of status.
+  //
+  // These rules allow new receivers to correctly interpret data received from old senders.
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -221,7 +221,7 @@ message Span {
   uint32 dropped_links_count = 14;
 
   // An optional final status for this span. Semantically when Status isn't set, it means
-  // span's status code is unset, i.e. assume CODE_VALUE_UNSET (code_value = 0).
+  // span's status code is unset, i.e. assume STATUS_CANONICAL_CODE_UNSET (canonical_code = 0).
   Status status = 15;
 }
 
@@ -251,10 +251,10 @@ message Status {
 
   // The deprecated status code. This is an optional field.
   //
-  // This field is deprecated and is replaced by the `code_value` field below. See
+  // This field is deprecated and is replaced by the `canonical_code` field below. See
   // backward compatibility notes below. According to our stability guarantees this field
   // will be removed in 12 months, on Sep 26, 2021. All usage of old senders and
-  // receivers that do not understand the `code_value` field MUST be phased out
+  // receivers that do not understand the `canonical_code` field MUST be phased out
   // by then.
   StatusCode code = 1 [deprecated=true];
 
@@ -263,52 +263,55 @@ message Status {
 
   // For the semantics of status codes see
   // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#statuscanonicalcode
-  enum CodeValue {
+  enum StatusCanonicalCode {
     // The default status.
-    CODE_VALUE_UNSET = 0;
+    STATUS_CANONICAL_CODE_UNSET               = 0;
     // The Span has been validated by an Application developers or Operator to have
     // completed successfully.
-    CODE_VALUE_OK    = 1;
+    STATUS_CANONICAL_CODE_OK                  = 1;
     // The Span contains an error.
-    CODE_VALUE_ERROR = 2;
+    STATUS_CANONICAL_CODE_ERROR               = 2;
   };
 
-  // The new status code value.
-  CodeValue code_value = 3;
+  // The new status canonical_code.
+  StatusCanonicalCode canonical_code = 3;
 
   // IMPORTANT: Backward compatibility notes:
   //
   // To ensure any pair of senders and receivers continues to correctly signal and
   // interpret erroneous situations, the senders and receivers SHOULD follow these rules:
   //
-  // 1. Old senders and receivers that are not aware of `code_value` field will
+  // 1. Old senders and receivers that are not aware of `canonical_code` field will
   // continue using the `code` field to signal and interpret erroneous situation.
   //
-  // 2. New senders, which are aware of the `code_value` field SHOULD set both the
-  // `code` and `code_value` fields according to the following rules:
+  // 2. New senders, which are aware of the `canonical_code` field SHOULD set both the
+  // `code` and `canonical_code` fields according to the following rules:
   //
-  //   if code_value==CODE_VALUE_UNSET then `code` MUST be set to STATUS_CODE_OK.
+  //   if canonical_code==STATUS_CANONICAL_CODE_UNSET then `code` MUST be
+  //   set to STATUS_CODE_OK.
   //
-  //   if code_value==CODE_VALUE_OK then `code` MUST be set to STATUS_CODE_OK.
+  //   if canonical_code==STATUS_CANONICAL_CODE_OK then `code` MUST be
+  //   set to STATUS_CODE_OK.
   //
-  //   if code_value==CODE_VALUE_ERROR then `code` MUST be set to STATUS_CODE_UNKNOWN_ERROR.
+  //   if canonical_code==STATUS_CANONICAL_CODE_ERROR then `code` MUST be
+  //   set to STATUS_CODE_UNKNOWN_ERROR.
   //
   // These rules allow old receivers to correctly interpret data received from new senders.
   //
-  // 3. New receivers should look at both the `code_value` and `code` fields in order
+  // 3. New receivers should look at both the `canonical_code` and `code` fields in order
   // to interpret the overall status:
   //
-  //   If code_value==CODE_VALUE_UNSET then the value of `code` is the
+  //   If canonical_code==STATUS_CANONICAL_CODE_UNSET then the value of `code` is the
   //   carrier of the overall status according to these rules:
   //
   //     if code==STATUS_CODE_OK then the receiver should interpret
-  //     the overall status to be CODE_UNSET.
+  //     the overall status to be STATUS_CANONICAL_CODE_UNSET.
   //
   //     if code!=STATUS_CODE_OK then the receiver should interpret
-  //     the overall status to be CODE_ERROR.
+  //     the overall status to be STATUS_CANONICAL_CODE_ERROR.
   //
-  //   If code_value!=CODE_VALUE_UNSET then the value of `code` should be
-  //   ignored, the `code_value` field is the sole carrier of the status.
+  //   If canonical_code!=STATUS_CANONICAL_CODE_UNSET then the value of `code` should be
+  //   ignored, the `canonical_code` field is the sole carrier of the status.
   //
   // These rules allow new receivers to correctly interpret data received from old senders.
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -253,7 +253,7 @@ message Status {
   //
   // This field is deprecated and is replaced by the `code` field below. See backward
   // compatibility notes below. According to our stability guarantees this field
-  // will be removed in 12 months, on Sep 26, 2021. All usage of old senders and
+  // will be removed in 12 months, on Oct 22, 2021. All usage of old senders and
   // receivers that do not understand the `code` field MUST be phased out by then.
   DeprecatedStatusCode deprecated_code = 1 [deprecated=true];
 

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -221,7 +221,7 @@ message Span {
   uint32 dropped_links_count = 14;
 
   // An optional final status for this span. Semantically when Status isn't set, it means
-  // span's status code is unset, i.e. assume STATUS_CANONICAL_CODE_UNSET (canonical_code = 0).
+  // span's status code is unset, i.e. assume CODE_VALUE_UNSET (code_value = 0).
   Status status = 15;
 }
 
@@ -251,10 +251,10 @@ message Status {
 
   // The deprecated status code. This is an optional field.
   //
-  // This field is deprecated and is replaced by the `canonical_code` field below. See
+  // This field is deprecated and is replaced by the `code_value` field below. See
   // backward compatibility notes below. According to our stability guarantees this field
   // will be removed in 12 months, on Sep 26, 2021. All usage of old senders and
-  // receivers that do not understand the `canonical_code` field MUST be phased out
+  // receivers that do not understand the `code_value` field MUST be phased out
   // by then.
   StatusCode code = 1 [deprecated=true];
 
@@ -263,55 +263,52 @@ message Status {
 
   // For the semantics of status codes see
   // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#statuscanonicalcode
-  enum StatusCanonicalCode {
+  enum CodeValue {
     // The default status.
-    STATUS_CANONICAL_CODE_UNSET               = 0;
+    CODE_VALUE_UNSET = 0;
     // The Span has been validated by an Application developers or Operator to have
     // completed successfully.
-    STATUS_CANONICAL_CODE_OK                  = 1;
+    CODE_VALUE_OK    = 1;
     // The Span contains an error.
-    STATUS_CANONICAL_CODE_ERROR               = 2;
+    CODE_VALUE_ERROR = 2;
   };
 
-  // The new status canonical_code.
-  StatusCanonicalCode canonical_code = 3;
+  // The new status code value.
+  CodeValue code_value = 3;
 
   // IMPORTANT: Backward compatibility notes:
   //
   // To ensure any pair of senders and receivers continues to correctly signal and
   // interpret erroneous situations, the senders and receivers SHOULD follow these rules:
   //
-  // 1. Old senders and receivers that are not aware of `canonical_code` field will
+  // 1. Old senders and receivers that are not aware of `code_value` field will
   // continue using the `code` field to signal and interpret erroneous situation.
   //
-  // 2. New senders, which are aware of the `canonical_code` field SHOULD set both the
-  // `code` and `canonical_code` fields according to the following rules:
+  // 2. New senders, which are aware of the `code_value` field SHOULD set both the
+  // `code` and `code_value` fields according to the following rules:
   //
-  //   if canonical_code==STATUS_CANONICAL_CODE_UNSET then `code` MUST be
-  //   set to STATUS_CODE_OK.
+  //   if code_value==CODE_VALUE_UNSET then `code` MUST be set to STATUS_CODE_OK.
   //
-  //   if canonical_code==STATUS_CANONICAL_CODE_OK then `code` MUST be
-  //   set to STATUS_CODE_OK.
+  //   if code_value==CODE_VALUE_OK then `code` MUST be set to STATUS_CODE_OK.
   //
-  //   if canonical_code==STATUS_CANONICAL_CODE_ERROR then `code` MUST be
-  //   set to STATUS_CODE_UNKNOWN_ERROR.
+  //   if code_value==CODE_VALUE_ERROR then `code` MUST be set to STATUS_CODE_UNKNOWN_ERROR.
   //
   // These rules allow old receivers to correctly interpret data received from new senders.
   //
-  // 3. New receivers should look at both the `canonical_code` and `code` fields in order
+  // 3. New receivers should look at both the `code_value` and `code` fields in order
   // to interpret the overall status:
   //
-  //   If canonical_code==STATUS_CANONICAL_CODE_UNSET then the value of `code` is the
+  //   If code_value==CODE_VALUE_UNSET then the value of `code` is the
   //   carrier of the overall status according to these rules:
   //
   //     if code==STATUS_CODE_OK then the receiver should interpret
-  //     the overall status to be STATUS_CANONICAL_CODE_UNSET.
+  //     the overall status to be CODE_UNSET.
   //
   //     if code!=STATUS_CODE_OK then the receiver should interpret
-  //     the overall status to be STATUS_CANONICAL_CODE_ERROR.
+  //     the overall status to be CODE_ERROR.
   //
-  //   If canonical_code!=STATUS_CANONICAL_CODE_UNSET then the value of `code` should be
-  //   ignored, the `canonical_code` field is the sole carrier of the status.
+  //   If code_value!=CODE_VALUE_UNSET then the value of `code` should be
+  //   ignored, the `code_value` field is the sole carrier of the status.
   //
   // These rules allow new receivers to correctly interpret data received from old senders.
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -221,7 +221,7 @@ message Span {
   uint32 dropped_links_count = 14;
 
   // An optional final status for this span. Semantically when Status isn't set, it means
-  // span's status code is unset, i.e. assume STATUS_CANONICAL_CODE_UNSET (canonical_code = 0).
+  // span's status code is unset, i.e. assume STATUS_CANONICAL_CODE_UNSET (code = 0).
   Status status = 15;
 }
 
@@ -229,34 +229,33 @@ message Span {
 // programming environments, including REST APIs and RPC APIs.
 message Status {
 
-  enum StatusCode {
-    STATUS_CODE_OK                  = 0;
-    STATUS_CODE_CANCELLED           = 1;
-    STATUS_CODE_UNKNOWN_ERROR       = 2;
-    STATUS_CODE_INVALID_ARGUMENT    = 3;
-    STATUS_CODE_DEADLINE_EXCEEDED   = 4;
-    STATUS_CODE_NOT_FOUND           = 5;
-    STATUS_CODE_ALREADY_EXISTS      = 6;
-    STATUS_CODE_PERMISSION_DENIED   = 7;
-    STATUS_CODE_RESOURCE_EXHAUSTED  = 8;
-    STATUS_CODE_FAILED_PRECONDITION = 9;
-    STATUS_CODE_ABORTED             = 10;
-    STATUS_CODE_OUT_OF_RANGE        = 11;
-    STATUS_CODE_UNIMPLEMENTED       = 12;
-    STATUS_CODE_INTERNAL_ERROR      = 13;
-    STATUS_CODE_UNAVAILABLE         = 14;
-    STATUS_CODE_DATA_LOSS           = 15;
-    STATUS_CODE_UNAUTHENTICATED     = 16;
+  enum DeprecatedStatusCode {
+    DEPRECATED_STATUS_CODE_OK                  = 0;
+    DEPRECATED_STATUS_CODE_CANCELLED           = 1;
+    DEPRECATED_STATUS_CODE_UNKNOWN_ERROR       = 2;
+    DEPRECATED_STATUS_CODE_INVALID_ARGUMENT    = 3;
+    DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED   = 4;
+    DEPRECATED_STATUS_CODE_NOT_FOUND           = 5;
+    DEPRECATED_STATUS_CODE_ALREADY_EXISTS      = 6;
+    DEPRECATED_STATUS_CODE_PERMISSION_DENIED   = 7;
+    DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED  = 8;
+    DEPRECATED_STATUS_CODE_FAILED_PRECONDITION = 9;
+    DEPRECATED_STATUS_CODE_ABORTED             = 10;
+    DEPRECATED_STATUS_CODE_OUT_OF_RANGE        = 11;
+    DEPRECATED_STATUS_CODE_UNIMPLEMENTED       = 12;
+    DEPRECATED_STATUS_CODE_INTERNAL_ERROR      = 13;
+    DEPRECATED_STATUS_CODE_UNAVAILABLE         = 14;
+    DEPRECATED_STATUS_CODE_DATA_LOSS           = 15;
+    DEPRECATED_STATUS_CODE_UNAUTHENTICATED     = 16;
   };
 
   // The deprecated status code. This is an optional field.
   //
-  // This field is deprecated and is replaced by the `canonical_code` field below. See
-  // backward compatibility notes below. According to our stability guarantees this field
+  // This field is deprecated and is replaced by the `code` field below. See backward
+  // compatibility notes below. According to our stability guarantees this field
   // will be removed in 12 months, on Sep 26, 2021. All usage of old senders and
-  // receivers that do not understand the `canonical_code` field MUST be phased out
-  // by then.
-  StatusCode code = 1 [deprecated=true];
+  // receivers that do not understand the `code` field MUST be phased out by then.
+  DeprecatedStatusCode deprecated_code = 1 [deprecated=true];
 
   // A developer-facing human readable error message.
   string message = 2;
@@ -273,45 +272,45 @@ message Status {
     STATUS_CANONICAL_CODE_ERROR               = 2;
   };
 
-  // The new status canonical_code.
-  StatusCanonicalCode canonical_code = 3;
+  // The status code.
+  StatusCanonicalCode code = 3;
 
   // IMPORTANT: Backward compatibility notes:
   //
   // To ensure any pair of senders and receivers continues to correctly signal and
   // interpret erroneous situations, the senders and receivers SHOULD follow these rules:
   //
-  // 1. Old senders and receivers that are not aware of `canonical_code` field will
-  // continue using the `code` field to signal and interpret erroneous situation.
+  // 1. Old senders and receivers that are not aware of `code` field will continue using
+  // the `deprecated_code` field to signal and interpret erroneous situation.
   //
-  // 2. New senders, which are aware of the `canonical_code` field SHOULD set both the
-  // `code` and `canonical_code` fields according to the following rules:
+  // 2. New senders, which are aware of the `code` field SHOULD set both the
+  // `deprecated_code` and `code` fields according to the following rules:
   //
-  //   if canonical_code==STATUS_CANONICAL_CODE_UNSET then `code` MUST be
-  //   set to STATUS_CODE_OK.
+  //   if code==STATUS_CANONICAL_CODE_UNSET then `deprecated_code` MUST be
+  //   set to DEPRECATED_STATUS_CODE_OK.
   //
-  //   if canonical_code==STATUS_CANONICAL_CODE_OK then `code` MUST be
-  //   set to STATUS_CODE_OK.
+  //   if code==STATUS_CANONICAL_CODE_OK then `deprecated_code` MUST be
+  //   set to DEPRECATED_STATUS_CODE_OK.
   //
-  //   if canonical_code==STATUS_CANONICAL_CODE_ERROR then `code` MUST be
-  //   set to STATUS_CODE_UNKNOWN_ERROR.
+  //   if code==STATUS_CANONICAL_CODE_ERROR then `deprecated_code` MUST be
+  //   set to DEPRECATED_STATUS_CODE_UNKNOWN_ERROR.
   //
   // These rules allow old receivers to correctly interpret data received from new senders.
   //
-  // 3. New receivers should look at both the `canonical_code` and `code` fields in order
+  // 3. New receivers should look at both the `code` and `deprecated_code` fields in order
   // to interpret the overall status:
   //
-  //   If canonical_code==STATUS_CANONICAL_CODE_UNSET then the value of `code` is the
+  //   If code==STATUS_CANONICAL_CODE_UNSET then the value of `deprecated_code` is the
   //   carrier of the overall status according to these rules:
   //
-  //     if code==STATUS_CODE_OK then the receiver should interpret
+  //     if deprecated_code==DEPRECATED_STATUS_CODE_OK then the receiver should interpret
   //     the overall status to be STATUS_CANONICAL_CODE_UNSET.
   //
-  //     if code!=STATUS_CODE_OK then the receiver should interpret
+  //     if deprecated_code!=DEPRECATED_STATUS_CODE_OK then the receiver should interpret
   //     the overall status to be STATUS_CANONICAL_CODE_ERROR.
   //
-  //   If canonical_code!=STATUS_CANONICAL_CODE_UNSET then the value of `code` should be
-  //   ignored, the `canonical_code` field is the sole carrier of the status.
+  //   If code!=STATUS_CANONICAL_CODE_UNSET then the value of `deprecated_code` should be
+  //   ignored, the `code` field is the sole carrier of the status.
   //
   // These rules allow new receivers to correctly interpret data received from old senders.
 }


### PR DESCRIPTION
1. Renamed Status.code field to Status.deprecated_code.
2. Renamed StatusCode enum to Status.DeprecatedStatusCode.
3. Introduce new Status.code with corresponding StatusCode enum.
4. Added guidelines about how to use the fields to ensure backward compatibility.
