### PR TITLE
Add more histogram types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,3 @@
 
 # Vim
 .swp
-
-# Generated code
-/gen/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 
 # Vim
 .swp
+
+# Generated code
+/gen/

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -500,14 +500,14 @@ message DoubleHistogramDataPoint {
   // a boolean value which decides what type of intervals to use.
   repeated double explicit_bounds = 7;
 
-  // When bounds have a pattern, a more efficient encoding method may be used.
-  // Only one method should be defined. For performance reason, "oneof" is not used.
-  // When more than one methods are defined, the receiver will use the first one found using this order:
-  //     explicit_bounds, linear_bounds, exponential_bounds, log_linear_bounds
-  LinearBounds linear_bounds = 9;
-  ExponentialBounds exponential_bounds = 10;
-  LogLinearBounds log_linear_bounds = 11;
-
+  // Multiple ways to define the bound sequence is supported. While explicit_bounds is one of the ways,
+  // for backward compatibility reason, it is not included in "oneof bound_type".
+  // Only one of explicit_bounds or bound_type should be present. When both are present, bound_type is ignored.
+  oneof bound_type {
+    LinearBounds linear_bounds = 9;
+    ExponentialBounds exponential_bounds = 10;
+    LogLinearBounds log_linear_bounds = 11;
+  }
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point
   repeated DoubleExemplar exemplars = 8;

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -504,9 +504,9 @@ message DoubleHistogramDataPoint {
   // measurements that were used to form the data point
   repeated DoubleExemplar exemplars = 8;
 
-  // When bounds have a pattern, an alternate encoding method may be used.
+  // When bounds have a pattern, a more efficient encoding method may be used.
   // Only one method should be defined. For performance reason, "oneof" is not used.
-  // When more than one methods are defined, the receiver will use only one in the precedence of:
+  // When more than one methods are defined, the receiver will use the first one found using this order:
   //     explicit_bounds, linear_bounds, exponential_bounds, log_linear_bounds
   LinearBounds linear_bounds = 9;
   ExponentialBounds exponential_bounds = 10;
@@ -524,8 +524,8 @@ message DoubleHistogramDataPoint {
   // ExponentialBounds. Bounds are on log scale.
   // The bound sequence is stitched together using negative bounds, zero bound, and positive bounds.
   // The formula to generate explicit bounds here are for demonstration purpose only.
-  // If the message receiver natively stores exponential histograms, it will not need to generate explicit bound.
-  // It will only need to convert exponential bound parameters to its native parameters.
+  // If the message receiver natively stores exponential histograms, it will not need to generate explicit bounds.
+  // It will only need to record the exponential bound parameters.
   message ExponentialBounds {
     double reference = 1;
     double base = 2;
@@ -585,6 +585,7 @@ message DoubleHistogramDataPoint {
   //        exponent = (i - num_of_linear_subbuckets + 1) / num_of_linear_subbuckets; // Round down toward -infinity
   //        subbucketNumber = i - exponent * num_of_linear_subbuckets;
   //    }
+  //    // Compute the exponential bucket.
   //    double bucketStart = reference * power(base, exponent);
   //    double bucketWidth = bucketStart * (base - 1);
   //    // Add a fraction of bucketWidth to bucketStart to get the bound.

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -188,7 +188,7 @@ message IntSum {
 // as a sum of all reported measurements over a time interval.
 message DoubleSum {
   repeated DoubleDataPoint data_points = 1;
-  
+
   // aggregation_temporality describes if the aggregator reports delta changes
   // since last report time, or cumulative changes since a fixed start time.
   AggregationTemporality aggregation_temporality = 2;
@@ -504,18 +504,17 @@ message DoubleHistogramDataPoint {
   // measurements that were used to form the data point
   repeated DoubleExemplar exemplars = 8;
 
-  // When bounds have a pattern, an alternate method may be used to encode them, reducing message size.
-  // Only one of explicit_bounds, linear_bounds, exponential_bounds should be defined.
-  // For performance reason, "oneof" is not used. When more than one methods are defined,
-  // the consumer will use only one in the precedence of:
-  //     explicit_bounds, linear_bounds, exponential_bounds
-
+  // When bounds have a pattern, an alternate encoding method may be used.
+  // Only one method should be defined. For performance reason, "oneof" is not used.
+  // When more than one methods are defined, the receiver will use only one in the precedence of:
+  //     explicit_bounds, linear_bounds, exponential_bounds, log_linear_bounds
   LinearBounds linear_bounds = 9;
   ExponentialBounds exponential_bounds = 10;
+  LogLinearBounds log_linear_bounds = 11;
 
   // LinearBounds. Bounds can be generated via
   // for (int i = 0; i < num_of_bounds; i++)
-  //     bounds[i] = offset + width * i
+  //     boundList.add(offset + width * i);
   message LinearBounds {
     double offset = 1;
     double width = 2;
@@ -523,75 +522,83 @@ message DoubleHistogramDataPoint {
   }
 
   // ExponentialBounds. Bounds are on log scale.
-  // The bound sequence is stitched together with negative bounds, zero bound, and positive bounds.
-  // Formula to generate explicit bounds from exponential bounds here are for demonstration purpose only.
-  // If the message receiver natively understands exponential histograms, it will not need to generate every bound.
+  // The bound sequence is stitched together using negative bounds, zero bound, and positive bounds.
+  // The formula to generate explicit bounds here are for demonstration purpose only.
+  // If the message receiver natively stores exponential histograms, it will not need to generate explicit bound.
   // It will only need to convert exponential bound parameters to its native parameters.
   message ExponentialBounds {
     double reference = 1;
     double base = 2;
 
     // The bound sequence starts with negative values generated via:
-    // for (int i = index_offset_for_negative_numbers + num_of_bounds_for_negative_numbers - 1;
-    //      i <= index_offset_for_negative_numbers;
-    //      i--)
-    //    bound[i] = -1 * reference * (base ^ i)
+    // for (int i = num_of_bounds_for_negative_numbers - 1; i >= 0; i--)
+    //    int exponent = i + index_offset_for_negative_numbers;
+    //    boundList.add( -1 * reference * power(base, exponent));
     //
     // Example of reference=1, base=2, index_offset_for_negative_numbers=-2, num_of_bounds_for_negative_numbers=6
-    // bounds: -8 -4 -2 -1 -.5 -.25
-    // i:       3  2  1  0 -1  -2
+    // bounds:    -8 -4 -2 -1 -.5 -.25
+    // exponent:   3  2  1  0 -1  -2
     // Note that the loop on i goes down, so that negative numbers with larger absolute values
-    // (but smaller arithmetic values) come first.
-    // num_of_bounds_for_negative_numbers may be zero if there are no negative numbers.
+    // (but smaller arithmetic values) are added first.
 
     sint32 index_offset_for_negative_numbers = 3;
     uint32 num_of_bounds_for_negative_numbers = 4;
 
-    // If has_counter_for_zero is true, a bound of zero follows the negative bounds.
+    // If has_counter_for_zero is true, add a bound of zero using:
+    //    boundList.add(0);
     bool has_counter_for_zero = 5;
 
     // Positive bounds follow the zero bound. Positive bounds are generated via:
-    // for (int i = index_offset_for_positive_numbers;
-    //      i <= index_offset_for_positive_numbers + num_of_bounds_for_positive_numbers - 1;
-    //      i++)
-    //    bound[i] = reference * (base ^ i)
+    // for (int i = 0; i < num_of_bounds_for_positive_numbers; i++)
+    //    int exponent = i + index_offset_for_positive_numbers;
+    //    boundList.add( reference * power(base, exponent));
     //
     // Example of reference=1, base=2, index_offset_for_positive_numbers=-3, num_of_bounds_for_positive_numbers=8
-    // bound: .125 .25 .5 1 2 4 8 16
-    // i:     -3   -2  -1 0 1 2 3 4
-    // num_of_bounds_for_positive_numbers may be zero if there are no positive numbers.
+    // bound:    .125 .25 .5 1 2 4 8 16
+    // exponent: -3   -2  -1 0 1 2 3 4
 
     sint32 index_offset_for_positive_numbers = 6;
     uint32 num_of_bounds_for_positive_numbers = 7;
+  }
 
-    // Certain histograms (such as HdrHistogram) further divide an exponential bucket
-    // into multiple linear subbuckets.
-    // num_of_linear_subbuckets at 1 or 0 (default) means no linear subbuckets.
-    // Example of reference 1, base 2 exponential buckets, with 4 linear subbuckets:
-    // bound: .5 .625 .75 .875 1 1.25 1.5 1.75 2 2.5 3 3.5 4
-    // i:     -4 -3   -2  -1   0 1    2   3    4 5   6 7   8
+  // In LogLinearBounds, each exponential bucket is divided linearly into multiple subbuckets.
+  // LogLinearBounds is an extension of ExponentialBounds. Similar to ExponentialBounds,
+  // the bound sequence is stitched together using negative bounds, zero bound, and positive bounds.
+  //
+  // Example of LogLinearBounds with num_of_linear_subbuckets=4 on ExponentialBounds of
+  //    reference=1, base=2, index_offset_for_positive_numbers=-4, num_of_bounds_for_positive_numbers=15,
+  //
+  // bound:  .5 .625 .75 .875 1 1.25 1.5 1.75 2 2.5 3 3.5 4 5 6
+  // index:  -4 -3   -2  -1   0 1    2   3    4 5   6 7   8 9 10
+  //
+  // Note: Index need not start or end on multiples of num_of_linear_subbuckets.
+  //
+  // Positive bounds are computed as:
+  // for (int count = 0; count < num_of_bounds_for_positive_numbers; count++)
+  //    int i = count + index_offset_for_positive_numbers;
+  //    int exponent;
+  //    int subbucketNumber; // In the range of [0, num_of_linear_subbuckets - 1]
+  //    if (i >= 0) {
+  //        exponent = i / num_of_linear_subbuckets;
+  //        subbucketNumber = i % num_of_linear_subbuckets;
+  //    } else {
+  //        exponent = (i - num_of_linear_subbuckets + 1) / num_of_linear_subbuckets; // Round down toward -infinity
+  //        subbucketNumber = i - exponent * num_of_linear_subbuckets;
+  //    }
+  //    double bucketStart = reference * power(base, exponent);
+  //    double bucketWidth = bucketStart * (base - 1);
+  //    // Add a fraction of bucketWidth to bucketStart to get the bound.
+  //    boundList.add( bucketStart + bucketWidth * ((double)subbucketNumber / num_of_linear_subbuckets));
+  //
+  // For negative bounds, the formula is similar, except that the index loop will go down and the bound will be converted
+  // to a negative number.
+  //
+  // If has_counter_for_zero is true, add a zero bound between negative and positive bounds.
+  // There are no subbuckets between last negative bucket and 0, or between 0 and first positive bucket.
 
-    // When num_of_linear_subbuckets is greater than 1, positive bounds are computed as:
-    // for (int i = index_offset_for_positive_numbers;
-    //      i <= index_offset_for_positive_numbers + num_of_bounds_for_positive_numbers - 1;
-    //      i++)
-    //    int exponent;
-    //    int subbucketNumber; // In the range of [0, num_of_linear_subbuckets - 1]
-    //    if (i >= 0) {
-    //        exponent = i / num_of_linear_subbuckets;
-    //        subbucketNumber = i % num_of_linear_subbuckets;
-    //    } else {
-    //        exponent = (i - num_of_linear_subbuckets + 1) / num_of_linear_subbuckets; // Round down toward -infinity
-    //        subbucketNumber = i - exponent * num_of_linear_subbuckets;
-    //    }
-    //    double bucketStart = reference * (base ^ exponent);
-    //    double bucketWidth = bucketStart * (base - 1);
-    //    bound[i] = bucketStart + bucketWidth * (subbucketNumber / num_of_linear_subbuckets)
-    //
-    // For negative bounds, the formula is similar, except that index loop will go down and bound[i] will be converted
-    // negative number.
-
-    uint32 num_of_linear_subbuckets = 8;
+  message LogLinearBounds {
+    ExponentialBounds exponential_bounds = 1;
+    uint32 num_of_linear_subbuckets = 2;
   }
 }
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -500,10 +500,6 @@ message DoubleHistogramDataPoint {
   // a boolean value which decides what type of intervals to use.
   repeated double explicit_bounds = 7;
 
-  // (Optional) List of exemplars collected from
-  // measurements that were used to form the data point
-  repeated DoubleExemplar exemplars = 8;
-
   // When bounds have a pattern, a more efficient encoding method may be used.
   // Only one method should be defined. For performance reason, "oneof" is not used.
   // When more than one methods are defined, the receiver will use the first one found using this order:
@@ -511,6 +507,10 @@ message DoubleHistogramDataPoint {
   LinearBounds linear_bounds = 9;
   ExponentialBounds exponential_bounds = 10;
   LogLinearBounds log_linear_bounds = 11;
+
+  // (Optional) List of exemplars collected from
+  // measurements that were used to form the data point
+  repeated DoubleExemplar exemplars = 8;
 
   // LinearBounds. Bounds can be generated via
   // for (int i = 0; i < num_of_bounds; i++)

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -523,11 +523,17 @@ message DoubleHistogramDataPoint {
 
   // ExponentialBounds. Bounds are on log scale.
   // The bound sequence is stitched together using negative bounds, zero bound, and positive bounds.
+  // The general rules is: bound = reference * power(base, exponent)
+  // Reference and base are constants. Exponent is integer index of histogram buckets.
+  // Reference defaults to 1. Base should be greater than 1.
+  // Negative index is allowed. It results in a bound between 0 and the reference.
+  // Two sections are specified, one for positive numbers, one for negative numbers.
+  // A special field is used to specify if a bound of zero exists.
   // The formula to generate explicit bounds here are for demonstration purpose only.
   // If the message receiver natively stores exponential histograms, it will not need to generate explicit bounds.
   // It will only need to record the exponential bound parameters.
   message ExponentialBounds {
-    double reference = 1;
+    double reference = 1; // If not present, 1 is assumed.
     double base = 2;
 
     // The bound sequence starts with negative values generated via:
@@ -578,6 +584,23 @@ message DoubleHistogramDataPoint {
   //    int i = count + index_offset_for_positive_numbers;
   //    int exponent;
   //    int subbucketNumber; // In the range of [0, num_of_linear_subbuckets - 1]
+  //
+  //    // i is the bucket index. We need to derive "major" bucket number (ie. exponent) and "minor" bucket number
+  //    // (ie. subbucketNumber) from it. An example of num_of_linear_subbuckets=4:
+  //    // index:           -8  -7  -6  -5  -4  -3  -2  -1   0   1   2   3   4   5   6   7   8
+  //    // exponent:        -2  -2  -2  -2  -1  -1  -1  -1   0   0   0   0   1   1   1   1   2
+  //    // subbucketNumber:  0   1   2   3   0   1   2   3   0   1   2   3   0   1   2   3   0
+  //    // At index 0, exponent=0, subbucketNumber=0.
+  //    // Exponent increases by 1 on every num_of_linear_subbuckets indexes.
+  //    // subbucketNumber cycles from 0 to num_of_linear_subbuckets - 1.
+  //    // For index >= 0, simple division and mod will do the work.
+  //    // For negative indexes, we need some special logic to make division round toward -infinity.
+  //    // In most platforms (such as Java), integer division on negative numbers round toward 0.
+  //    // Toward 0:         -5 / 4 = -1.25 = -1
+  //    // Toward -infinity: -5 / 4 = -1.25 = -2
+  //    // Similarly, some special logic is needed on subbucketNumber to make it cycle in 0, 1, 2 ... order
+  //    // in the negative index range.
+  //
   //    if (i >= 0) {
   //        exponent = i / num_of_linear_subbuckets;
   //        subbucketNumber = i % num_of_linear_subbuckets;

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -484,9 +484,6 @@ message DoubleHistogramDataPoint {
   // Otherwise all option fields and "buckets" field must be omitted in which case the
   // distribution of values in the histogram is unknown and only the total count and sum are known.
 
-  // explicit_bounds is the only supported bucket option currently.
-  // TODO: Add more bucket options.
-
   // explicit_bounds specifies buckets with explicitly defined bounds for values.
   // The bucket boundaries are described by "bounds" field.
   //
@@ -506,6 +503,96 @@ message DoubleHistogramDataPoint {
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point
   repeated DoubleExemplar exemplars = 8;
+
+  // When bounds have a pattern, an alternate method may be used to encode them, reducing message size.
+  // Only one of explicit_bounds, linear_bounds, exponential_bounds should be defined.
+  // For performance reason, "oneof" is not used. When more than one methods are defined,
+  // the consumer will use only one in the precedence of:
+  //     explicit_bounds, linear_bounds, exponential_bounds
+
+  LinearBounds linear_bounds = 9;
+  ExponentialBounds exponential_bounds = 10;
+
+  // LinearBounds. Bounds can be generated via
+  // for (int i = 0; i < num_of_bounds; i++)
+  //     bounds[i] = offset + width * i
+  message LinearBounds {
+    double offset = 1;
+    double width = 2;
+    uint32 num_of_bounds = 3;
+  }
+
+  // ExponentialBounds. Bounds are on log scale.
+  // The bound sequence is stitched together with negative bounds, zero bound, and positive bounds.
+  // Formula to generate explicit bounds from exponential bounds here are for demonstration purpose only.
+  // If the message receiver natively understands exponential histograms, it will not need to generate every bound.
+  // It will only need to convert exponential bound parameters to its native parameters.
+  message ExponentialBounds {
+    double reference = 1;
+    double base = 2;
+
+    // The bound sequence starts with negative values generated via:
+    // for (int i = index_offset_for_negative_numbers + num_of_bounds_for_negative_numbers - 1;
+    //      i <= index_offset_for_negative_numbers;
+    //      i--)
+    //    bound[i] = -1 * reference * (base ^ i)
+    //
+    // Example of reference=1, base=2, index_offset_for_negative_numbers=-2, num_of_bounds_for_negative_numbers=6
+    // bounds: -8 -4 -2 -1 -.5 -.25
+    // i:       3  2  1  0 -1  -2
+    // Note that the loop on i goes down, so that negative numbers with larger absolute values
+    // (but smaller arithmetic values) come first.
+    // num_of_bounds_for_negative_numbers may be zero if there are no negative numbers.
+
+    sint32 index_offset_for_negative_numbers = 3;
+    uint32 num_of_bounds_for_negative_numbers = 4;
+
+    // If has_counter_for_zero is true, a bound of zero follows the negative bounds.
+    bool has_counter_for_zero = 5;
+
+    // Positive bounds follow the zero bound. Positive bounds are generated via:
+    // for (int i = index_offset_for_positive_numbers;
+    //      i <= index_offset_for_positive_numbers + num_of_bounds_for_positive_numbers - 1;
+    //      i++)
+    //    bound[i] = reference * (base ^ i)
+    //
+    // Example of reference=1, base=2, index_offset_for_positive_numbers=-3, num_of_bounds_for_positive_numbers=8
+    // bound: .125 .25 .5 1 2 4 8 16
+    // i:     -3   -2  -1 0 1 2 3 4
+    // num_of_bounds_for_positive_numbers may be zero if there are no positive numbers.
+
+    sint32 index_offset_for_positive_numbers = 6;
+    uint32 num_of_bounds_for_positive_numbers = 7;
+
+    // Certain histograms (such as HdrHistogram) further divide an exponential bucket
+    // into multiple linear subbuckets.
+    // num_of_linear_subbuckets at 1 or 0 (default) means no linear subbuckets.
+    // Example of reference 1, base 2 exponential buckets, with 4 linear subbuckets:
+    // bound: .5 .625 .75 .875 1 1.25 1.5 1.75 2 2.5 3 3.5 4
+    // i:     -4 -3   -2  -1   0 1    2   3    4 5   6 7   8
+
+    // When num_of_linear_subbuckets is greater than 1, positive bounds are computed as:
+    // for (int i = index_offset_for_positive_numbers;
+    //      i <= index_offset_for_positive_numbers + num_of_bounds_for_positive_numbers - 1;
+    //      i++)
+    //    int exponent;
+    //    int subbucketNumber; // In the range of [0, num_of_linear_subbuckets - 1]
+    //    if (i >= 0) {
+    //        exponent = i / num_of_linear_subbuckets;
+    //        subbucketNumber = i % num_of_linear_subbuckets;
+    //    } else {
+    //        exponent = (i - num_of_linear_subbuckets + 1) / num_of_linear_subbuckets; // Round down toward -infinity
+    //        subbucketNumber = i - exponent * num_of_linear_subbuckets;
+    //    }
+    //    double bucketStart = reference * (base ^ exponent);
+    //    double bucketWidth = bucketStart * (base - 1);
+    //    bound[i] = bucketStart + bucketWidth * (subbucketNumber / num_of_linear_subbuckets)
+    //
+    // For negative bounds, the formula is similar, except that index loop will go down and bound[i] will be converted
+    // negative number.
+
+    uint32 num_of_linear_subbuckets = 8;
+  }
 }
 
 // A representation of an exemplar, which is a sample input int measurement.


### PR DESCRIPTION
This is a PR for https://github.com/open-telemetry/opentelemetry-specification/issues/982.  Main changes

* Add linear_bounds, exponential_bounds, and log_linear_bounds types. The new types are treated as compression methods for the existing explicit_bounds. ie. Methods to compress a sequence of doubles. 

Terminology note: For exponential histograms, "base" is used for exponent base, consistent with standard math terminology. "Reference" is used for the multiplier on exponential scale, consistent with common usage in log scale unit such as decibel. 

The proposed protocol is closely related to custom protocol of DDSketch (https://github.com/DataDog/sketches-java/blob/master/src/main/proto/DDSketch.proto). A DDsketch using the logarithm method can be represented as reference=1, base=gamma, index_offset=contiguousBinIndexOffset. A DDSketch using the "fast" option (https://github.com/DataDog/sketches-java/blob/master/src/main/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMapping.java) can be represented as reference=1, base=2, num_linear_subbuckets=2^ numSignificantBinaryDigits. DDSketches using log approximation methods such as quadratic or cubic methods have to use the explicit bound encoding. 

The rationale for supporting logarithm and log linear format is:
* Logarithm format provides memory optimized option, at higher cpu cost. Log/exponential function is well understood and easy to implement. 
* Log linear provides cpu optimized option, at higher memory cost. Linear subbuckets in exponential bucket is easy to describe and implement. Multiple sources produce log linear histogram, example: hdrHistogram, CirllHisto, DDSketch "fast" option. 
* The two options cover the two ends of the cpu-memory trade off. 

The rationale for not supporting quadratic and cubic log approximation is:
* There are many quadratic and cubic approximation methods for log. None could be considered "canonical". Additional research is needed on the optimal parameters on quadratic and cubic approximation that minimizes relative error, and how to represent such parameters in a protocol. 
* There is no formal mathematical description of approximation formula used in histograms like DDSketch and DynaHist (https://github.com/dynatrace-oss/dynahist), making it difficult to understand or evaluate the methods, or to implement a message decoder correctly on another platform or language (today we have to reverse engineer the source code to get the formula). 
* Including these formats in OTel standards would require all message receivers (typically metric storage backends) to be able to decompress the bounds to explicit bounds, or natively store the compressed form. This adds complexity and cost. 
* User demand on fine tuning cpu-memory trade off is yet to be seen.

Open issues:
* Protocol now uses "repeated fixed64 bucket_counts" for counters in buckets. Each counter always costs 8 bytes. Histograms often have counters repeating hundreds or thousands of times. A "varint" counter may be better. In most cases, a counter will need fewer than 4 bytes. A previous PR (https://github.com/open-telemetry/opentelemetry-proto/pull/214) changed counters from uint64 to fixed64. For counters occurring a few times, the space cost may not matter, for histogram counter list, we may need to reconsider.

* There is talk about adding min and max to histogram. One argument for adding them is: Consider the case where we have fooHisto metric tracking histogram of "foo", and a fooSummary metric tracking max of "foo", we could get results like
        percentile(fooHistogram, 100%) = 1000
        max(fooSummary) = 900
In the result above, the returned 100% percentile is higher than the max. In fact, this could occur even before we reach 100%, in percentiles like 99.9%. If we have min/max included in histogram, the percentile function can internally clamp 100% to max, and 0% to min, returning more reasonable results. 