### PR TITLE
Update README.md to mark Logs support as Alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ Component                            | Maturity |
 **Binary Protobuf Encoding**         |          |
 collector/metrics/*                  | Alpha    |
 collector/trace/*                    | Stable   |
+collector/logs/*                     | Alpha    |
 common/*                             | Stable   |
 metrics/*                            | Alpha    |
 resource/*                           | Stable   |
 trace/trace.proto                    | Stable   |
 trace/trace_config.proto             | Alpha    |
+logs/*                               | Alpha    |
 **JSON encoding**                    |          |
 All messages                         | Alpha    |
 


### PR DESCRIPTION
Alpha is the weakest guarantee we have in our maturity matrix.