### PR TITLE
Add "gen" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 
 # Vim
 .swp
+
+# Generated code
+/gen/


### PR DESCRIPTION
The make process creates "gen" directory for generated code from protobuf. "gen" should be ignored by git.