### PR TITLE
add build badge to top of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Language Independent Interface Types For OpenTelemetry
 
+[![Build Check](https://github.com/open-telemetry/opentelemetry-proto/workflows/Build%20Check/badge.svg?branch=master)](https://github.com/open-telemetry/opentelemetry-proto/actions?query=workflow%3A%22Build+Check%22+branch%3Amaster)
+
 The proto files can be consumed as GIT submodule or copied over and built directly in the consumer project.
 
 The compiled files are published to central repositories (Maven, NPM...) from OpenTelemetry client libraries.


### PR DESCRIPTION
Fixes #241 

Adds a github workflow status badge using a [workflow name](https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/adding-a-workflow-status-badge#using-a-workflow-name).