### PR TITLE
Create a oneof for Histogram buckets; add ExplicitBuckets; deprecate DoubleHistogram

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -421,7 +421,6 @@ message IntHistogramDataPoint {
   // distribution of values in the histogram is unknown and only the total count and sum are known.
 
   // explicit_bounds is the only supported bucket option currently.
-  // TODO: Add more bucket options.
 
   // explicit_bounds specifies buckets with explicitly defined bounds for values.
   //
@@ -495,9 +494,6 @@ message DoubleHistogramDataPoint {
   // In that case one of the option fields below and "buckets" field both must be defined.
   // Otherwise all option fields and "buckets" field must be omitted in which case the
   // distribution of values in the histogram is unknown and only the total count and sum are known.
-
-  // explicit_bounds is the only supported bucket option currently.
-  // TODO: Add more bucket options.
 
   // explicit_bounds specifies buckets with explicitly defined bounds for values.
   //
@@ -633,4 +629,89 @@ message DoubleExemplar {
   // trace_id may be missing if the measurement is not recorded inside a trace
   // or if the trace is not sampled.
   bytes trace_id = 5;
+}
+
+// Deprecated DoubleHistogram => DeprecatedHistogram
+
+// Represents the type of a metric that is calculated by aggregating as a
+// Histogram of all reported double measurements over a time interval.
+message DeprecatedHistogram {
+  repeated DeprecatedHistogramDataPoint data_points = 1;
+
+  // aggregation_temporality describes if the aggregator reports delta changes
+  // since last report time, or cumulative changes since a fixed start time.
+  AggregationTemporality aggregation_temporality = 2;
+}
+
+// HistogramDataPoint is a single data point in a timeseries that describes the
+// time-varying values of a Histogram of double values. A Histogram contains
+// summary statistics for a population of values, it may optionally contain the
+// distribution of those values across a set of buckets.
+message DeprecatedHistogramDataPoint {
+  // The set of labels that uniquely identify this timeseries.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
+
+  // start_time_unix_nano is the last time when the aggregation value was reset
+  // to "zero". For some metric types this is ignored, see data types for more
+  // details.
+  //
+  // The aggregation value is over the time interval (start_time_unix_nano,
+  // time_unix_nano].
+  // 
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  //
+  // Value of 0 indicates that the timestamp is unspecified. In that case the
+  // timestamp may be decided by the backend.
+  fixed64 start_time_unix_nano = 2;
+
+  // time_unix_nano is the moment when this aggregation value was reported.
+  // 
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 3;
+
+  // count is the number of values in the population. Must be non-negative. This
+  // value must be equal to the sum of the "count" fields in buckets if a
+  // histogram is provided.
+  fixed64 count = 4;
+
+  // sum of the values in the population. If count is zero then this field
+  // must be zero. This value must be equal to the sum of the "sum" fields in
+  // buckets if a histogram is provided.
+  double sum = 5;
+
+  // bucket_counts is an optional field contains the count values of histogram
+  // for each bucket.
+  //
+  // The sum of the bucket_counts must equal the value in the count field.
+  //
+  // The number of elements in bucket_counts array must be by one greater than
+  // the number of elements in explicit_bounds array.
+  repeated fixed64 bucket_counts = 6;
+
+  // A histogram may optionally contain the distribution of the values in the population.
+  // In that case one of the option fields below and "buckets" field both must be defined.
+  // Otherwise all option fields and "buckets" field must be omitted in which case the
+  // distribution of values in the histogram is unknown and only the total count and sum are known.
+
+  // explicit_bounds specifies buckets with explicitly defined bounds for values.
+  //
+  // This defines size(explicit_bounds) + 1 (= N) buckets. The boundaries for
+  // bucket at index i are:
+  //
+  // (-infinity, explicit_bounds[i]] for i == 0
+  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
+  // (explicit_bounds[i], +infinity) for i == N-1
+  // 
+  // The values in the explicit_bounds array must be strictly increasing.
+  //
+  // Histogram buckets are inclusive of their upper boundary, except the last
+  // bucket where the boundary is at infinity. This format is intentionally
+  // compatible with the OpenMetrics histogram definition.
+  repeated double explicit_bounds = 7;
+
+  // (Optional) List of exemplars collected from
+  // measurements that were used to form the data point
+  repeated DoubleExemplar exemplars = 8;
 }

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -490,20 +490,9 @@ message HistogramDataPoint {
   //
   // If this field is omitted, there is an implied single bucket
   // spanning (-Inf,+Inf) containing the whole population.
-  //
-  // Each of the supported buckets in the oneof below are expected
-  // to state under which circumstances buckets of that type are
-  // considered Mergeable in a non-lossy way with buckets of the same
-  // type.
-  //
-  // OTLP does not allow two `Metric` instances having `Histogram`s
-  // with unmergable bucket types to be merged.  These will remain
-  // disjoint `Metric` instances through any processors within
-  // OpenTelemetry.
   oneof buckets {
     // ExplicitBuckets support encoding arbitrary boundaries and
-    // counts.  Histograms with these buckets are mergeable when
-    // they have identical boundaries, otherwise are not mergeable.
+    // counts.
     ExplicitBuckets explicit = 9;
   }
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -141,8 +141,14 @@ message Metric {
     DoubleGauge double_gauge = 5;
     IntSum int_sum = 6;
     DoubleSum double_sum = 7;
+    // IntHistogram and DoubleHistogram are DEPRECATED and will be removed soon.
+    // 1. Old senders and receivers that are not aware of this change will
+    // continue using the `int_histogram` and `double_histogram` field.
+    // 2. New senders, which are aware of this change MUST send only `histogram`.
+    // 3. New receivers, which are aware of this change MUST convert this into
+    // `histogram` by converting point values.
     IntHistogram int_histogram = 8;
-    DeprecatedHistogram deprecated_histogram = 9;
+    DoubleHistogram double_histogram = 9;
     Histogram histogram = 12;
     DoubleSummary double_summary = 11;
   }
@@ -490,9 +496,10 @@ message HistogramDataPoint {
   // considered Mergeable in a non-lossy way with buckets of the same
   // type.
   //
-  // When a single Metric uses Histograms with buckets of that are not
-  // mergeable, they will pass through OpenTelemetry collectors as
-  // distinct Metric series, as they cannot be merged.
+  // OTLP does not allow two `Metric` instances having `Histogram`s
+  // with unmergable bucket types to be merged.  These will remain
+  // disjoint `Metric` instances through any processors within
+  // OpenTelemetry.
   oneof buckets {
     // ExplicitBuckets support encoding arbitrary boundaries and
     // counts.  Histograms with these buckets are mergeable when
@@ -650,23 +657,23 @@ message DoubleExemplar {
   bytes trace_id = 5;
 }
 
-// Deprecated DoubleHistogram => DeprecatedHistogram
-
+// DoubleHistogram is DEPRECATED.
 // Represents the type of a metric that is calculated by aggregating as a
 // Histogram of all reported double measurements over a time interval.
-message DeprecatedHistogram {
-  repeated DeprecatedHistogramDataPoint data_points = 1;
+message DoubleHistogram {
+  repeated DoubleHistogramDataPoint data_points = 1;
 
   // aggregation_temporality describes if the aggregator reports delta changes
   // since last report time, or cumulative changes since a fixed start time.
   AggregationTemporality aggregation_temporality = 2;
 }
 
-// HistogramDataPoint is a single data point in a timeseries that describes the
+// DoubleHistogramDataPoint is DEPRECATED.
+// Represents a single data point in a timeseries that describes the
 // time-varying values of a Histogram of double values. A Histogram contains
 // summary statistics for a population of values, it may optionally contain the
 // distribution of those values across a set of buckets.
-message DeprecatedHistogramDataPoint {
+message DoubleHistogramDataPoint {
   // The set of labels that uniquely identify this timeseries.
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -494,7 +494,7 @@ message HistogramDataPoint {
   // mergeable, they will pass through OpenTelemetry collectors as
   // distinct Metric series, as they cannot be merged.
   oneof buckets {
-    // ExplicitBounds support encoding arbitrary boundaries and
+    // ExplicitBuckets support encoding arbitrary boundaries and
     // counts.  Histograms with these buckets are mergeable when
     // they have identical boundaries, otherwise are not mergeable.
     ExplicitBuckets explicit = 9;
@@ -506,9 +506,9 @@ message HistogramDataPoint {
 }
 
 // ExplicitBuckets is a standard way of represeting arbitrary
-// histogram data using explicit boundaries.  It simply combines an
-// array of N-1 boundaries and an arry of N counts.
-message ExplicitBounds {
+// histogram data using explicit boundaries.  It combines an
+// array of N-1 boundaries and an array of N counts.
+message ExplicitBuckets {
   // counts is an optional field contains the count values of histogram
   // for each bucket.
   //

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -421,8 +421,6 @@ message IntHistogramDataPoint {
   // Otherwise all option fields and "buckets" field must be omitted in which case the
   // distribution of values in the histogram is unknown and only the total count and sum are known.
 
-  // explicit_bounds is the only supported bucket option currently.
-
   // explicit_bounds specifies buckets with explicitly defined bounds for values.
   //
   // This defines size(explicit_bounds) + 1 (= N) buckets. The boundaries for
@@ -482,39 +480,59 @@ message HistogramDataPoint {
   // buckets if a histogram is provided.
   double sum = 5;
 
-  // bucket_counts is an optional field contains the count values of histogram
-  // for each bucket.
+  // buckets are one of several defined bucketing strategies
   //
-  // The sum of the bucket_counts must equal the value in the count field.
+  // If this field is omitted, there is an implied single bucket
+  // spanning (-Inf,+Inf) containing the whole population.
   //
-  // The number of elements in bucket_counts array must be by one greater than
-  // the number of elements in explicit_bounds array.
-  repeated fixed64 bucket_counts = 6;
-
-  // A histogram may optionally contain the distribution of the values in the population.
-  // In that case one of the option fields below and "buckets" field both must be defined.
-  // Otherwise all option fields and "buckets" field must be omitted in which case the
-  // distribution of values in the histogram is unknown and only the total count and sum are known.
-
-  // explicit_bounds specifies buckets with explicitly defined bounds for values.
+  // Each of the supported buckets in the oneof below are expected
+  // to state under which circumstances buckets of that type are
+  // considered Mergeable in a non-lossy way with buckets of the same
+  // type.
   //
-  // This defines size(explicit_bounds) + 1 (= N) buckets. The boundaries for
-  // bucket at index i are:
-  //
-  // (-infinity, explicit_bounds[i]] for i == 0
-  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
-  // (explicit_bounds[i], +infinity) for i == N-1
-  // 
-  // The values in the explicit_bounds array must be strictly increasing.
-  //
-  // Histogram buckets are inclusive of their upper boundary, except the last
-  // bucket where the boundary is at infinity. This format is intentionally
-  // compatible with the OpenMetrics histogram definition.
-  repeated double explicit_bounds = 7;
+  // When a single Metric uses Histograms with buckets of that are not
+  // mergeable, they will pass through OpenTelemetry collectors as
+  // distinct Metric series, as they cannot be merged.
+  oneof buckets {
+    // ExplicitBounds support encoding arbitrary boundaries and
+    // counts.  Histograms with these buckets are mergeable when
+    // they have identical boundaries, otherwise are not mergeable.
+    ExplicitBuckets explicit = 9;
+  }
 
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point
   repeated DoubleExemplar exemplars = 8;
+}
+
+// ExplicitBuckets is a standard way of represeting arbitrary
+// histogram data using explicit boundaries.  It simply combines an
+// array of N-1 boundaries and an arry of N counts.
+message ExplicitBounds {
+  // counts is an optional field contains the count values of histogram
+  // for each bucket.
+  //
+  // The sum of the counts must equal the value in the count field.
+  //
+  // The number of elements in counts array must be by one greater than
+  // the number of elements in boundaries array.
+  repeated fixed64 counts = 6;
+
+  // boundaries specifies buckets with explicitly defined boundaries.
+  //
+  // This defines N = size(boundaries) + 1 buckets. The boundaries for
+  // bucket at index i are:
+  //
+  // (-infinity, boundaries[i]] for i == 0
+  // (boundaries[i-1], boundaries[i]] for 0 < i < N-1
+  // (boundaries[i], +infinity) for i == N-1
+  // 
+  // The values in the boundaries array must be strictly increasing.
+  //
+  // Histogram buckets are inclusive of their upper boundary, except the last
+  // bucket where the boundary is at infinity. This format is intentionally
+  // compatible with the OpenMetrics histogram definition.
+  repeated double boundaries = 7;
 }
 
 // DoubleSummaryDataPoint is a single data point in a timeseries that describes the
@@ -716,3 +734,4 @@ message DeprecatedHistogramDataPoint {
   // measurements that were used to form the data point
   repeated DoubleExemplar exemplars = 8;
 }
+

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -424,19 +424,19 @@ message IntHistogramDataPoint {
   // TODO: Add more bucket options.
 
   // explicit_bounds specifies buckets with explicitly defined bounds for values.
-  // The bucket boundaries are described by "bounds" field.
   //
-  // This defines size(bounds) + 1 (= N) buckets. The boundaries for bucket
-  // at index i are:
+  // This defines size(explicit_bounds) + 1 (= N) buckets. The boundaries for
+  // bucket at index i are:
   //
-  // (-infinity, bounds[i]) for i == 0
-  // [bounds[i-1], bounds[i]) for 0 < i < N-1
-  // [bounds[i], +infinity) for i == N-1
-  // The values in bounds array must be strictly increasing.
+  // (-infinity, explicit_bounds[i]] for i == 0
+  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
+  // (explicit_bounds[i], +infinity) for i == N-1
+  // 
+  // The values in the explicit_bounds array must be strictly increasing.
   //
-  // Note: only [a, b) intervals are currently supported for each bucket except the first one.
-  // If we decide to also support (a, b] intervals we should add support for these by defining
-  // a boolean value which decides what type of intervals to use.
+  // Histogram buckets are inclusive of their upper boundary, except the last
+  // bucket where the boundary is at infinity. This format is intentionally
+  // compatible with the OpenMetrics histogram definition.
   repeated double explicit_bounds = 7;
 
   // (Optional) List of exemplars collected from
@@ -500,19 +500,19 @@ message DoubleHistogramDataPoint {
   // TODO: Add more bucket options.
 
   // explicit_bounds specifies buckets with explicitly defined bounds for values.
-  // The bucket boundaries are described by "bounds" field.
   //
-  // This defines size(bounds) + 1 (= N) buckets. The boundaries for bucket
-  // at index i are:
+  // This defines size(explicit_bounds) + 1 (= N) buckets. The boundaries for
+  // bucket at index i are:
   //
-  // (-infinity, bounds[i]) for i == 0
-  // [bounds[i-1], bounds[i]) for 0 < i < N-1
-  // [bounds[i], +infinity) for i == N-1
-  // The values in bounds array must be strictly increasing.
+  // (-infinity, explicit_bounds[i]] for i == 0
+  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
+  // (explicit_bounds[i], +infinity) for i == N-1
+  // 
+  // The values in the explicit_bounds array must be strictly increasing.
   //
-  // Note: only [a, b) intervals are currently supported for each bucket except the first one.
-  // If we decide to also support (a, b] intervals we should add support for these by defining
-  // a boolean value which decides what type of intervals to use.
+  // Histogram buckets are inclusive of their upper boundary, except the last
+  // bucket where the boundary is at infinity. This format is intentionally
+  // compatible with the OpenMetrics histogram definition.
   repeated double explicit_bounds = 7;
 
   // (Optional) List of exemplars collected from

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -142,7 +142,8 @@ message Metric {
     IntSum int_sum = 6;
     DoubleSum double_sum = 7;
     IntHistogram int_histogram = 8;
-    DoubleHistogram double_histogram = 9;
+    DeprecatedHistogram deprecated_histogram = 9;
+    Histogram histogram = 12;
     DoubleSummary double_summary = 11;
   }
 }
@@ -211,8 +212,8 @@ message IntHistogram {
 
 // Represents the type of a metric that is calculated by aggregating as a
 // Histogram of all reported double measurements over a time interval.
-message DoubleHistogram {
-  repeated DoubleHistogramDataPoint data_points = 1;
+message Histogram {
+  repeated HistogramDataPoint data_points = 1;
 
   // aggregation_temporality describes if the aggregator reports delta changes
   // since last report time, or cumulative changes since a fixed start time.
@@ -447,7 +448,7 @@ message IntHistogramDataPoint {
 // time-varying values of a Histogram of double values. A Histogram contains
 // summary statistics for a population of values, it may optionally contain the
 // distribution of those values across a set of buckets.
-message DoubleHistogramDataPoint {
+message HistogramDataPoint {
   // The set of labels that uniquely identify this timeseries.
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -662,6 +662,8 @@ message DoubleExemplar {
 // Represents the type of a metric that is calculated by aggregating as a
 // Histogram of all reported double measurements over a time interval.
 message DoubleHistogram {
+  option deprecated = true;
+
   repeated DoubleHistogramDataPoint data_points = 1;
 
   // aggregation_temporality describes if the aggregator reports delta changes
@@ -675,6 +677,8 @@ message DoubleHistogram {
 // summary statistics for a population of values, it may optionally contain the
 // distribution of those values across a set of buckets.
 message DoubleHistogramDataPoint {
+  option deprecated = true;
+
   // The set of labels that uniquely identify this timeseries.
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -509,7 +509,7 @@ message ExplicitBuckets {
   // for each bucket.
   //
   // The sum of the counts must equal the value in the HistogramDataPoint's
- count field.
+  // count field.
   //
   // The number of elements in counts array must be one greater than
   // the number of elements in boundaries array.

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -486,7 +486,7 @@ message HistogramDataPoint {
   // buckets if a histogram is provided.
   double sum = 5;
 
-  // buckets are one of several defined bucketing strategies
+  // buckets is one of several defined bucketing strategies
   //
   // If this field is omitted, there is an implied single bucket
   // spanning (-Inf,+Inf) containing the whole population.
@@ -501,16 +501,17 @@ message HistogramDataPoint {
   repeated DoubleExemplar exemplars = 8;
 }
 
-// ExplicitBuckets is a standard way of represeting arbitrary
+// ExplicitBuckets is a standard way of representing arbitrary
 // histogram data using explicit boundaries.  It combines an
 // array of N-1 boundaries and an array of N counts.
 message ExplicitBuckets {
   // counts is an optional field contains the count values of histogram
   // for each bucket.
   //
-  // The sum of the counts must equal the value in the count field.
+  // The sum of the counts must equal the value in the HistogramDataPoint's
+ count field.
   //
-  // The number of elements in counts array must be by one greater than
+  // The number of elements in counts array must be one greater than
   // the number of elements in boundaries array.
   repeated fixed64 counts = 6;
 
@@ -730,4 +731,3 @@ message DoubleHistogramDataPoint {
   // measurements that were used to form the data point
   repeated DoubleExemplar exemplars = 8;
 }
-


### PR DESCRIPTION
This deprecates the existing DoubleHistogram and creates a new one with room for more histogram types to be added in the future.

The oneof proposed here was first described in the issue https://github.com/open-telemetry/opentelemetry-proto/issues/259#issuecomment-784850753 and has support from contributors working on #226, e.g., https://github.com/open-telemetry/opentelemetry-proto/pull/226#issuecomment-776526864.

Fixes #259.
Alternate to #255.