### PR TITLE
Fix value int index in Exemplar, skipped 6 by mistake

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -651,7 +651,7 @@ message Exemplar {
   // inside this oneof.
   oneof value {
     double as_double = 3;
-    sfixed64 as_int = 7;
+    sfixed64 as_int = 6;
   }
 
   // (Optional) Span ID of the exemplar trace.


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>