### PR TITLE
Remove TODOs from metrics.proto. 

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -114,11 +114,6 @@ message Metric {
   // described by http://unitsofmeasure.org/ucum.html.
   string unit = 3;
 
-  // TODO: Decide if support for RawMeasurements (measurements recorded using
-  // the synchronous instruments) is necessary. It can be used to delegate the
-  // aggregation from the application to the agent/collector. See
-  // https://github.com/open-telemetry/opentelemetry-specification/issues/617
-
   // Data determines the aggregation type (if any) of the metric, what is the
   // reported value type for the data points, as well as the relatationship to
   // the time interval over which they are reported.
@@ -447,7 +442,6 @@ message IntHistogramDataPoint {
   // distribution of values in the histogram is unknown and only the total count and sum are known.
 
   // explicit_bounds is the only supported bucket option currently.
-  // TODO: Add more bucket options.
 
   // explicit_bounds specifies buckets with explicitly defined bounds for values.
   //
@@ -523,7 +517,6 @@ message HistogramDataPoint {
   // distribution of values in the histogram is unknown and only the total count and sum are known.
 
   // explicit_bounds is the only supported bucket option currently.
-  // TODO: Add more bucket options.
 
   // explicit_bounds specifies buckets with explicitly defined bounds for values.
   //


### PR DESCRIPTION
Remaining todos are bugs against specification/proto library.

See https://github.com/orgs/open-telemetry/projects/12 for TODOs.