### PR TITLE
Add schema_url fields as described in OTEP 0152

### DIFF
--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -33,9 +33,9 @@ message ResourceLogs {
   // A list of InstrumentationLibraryLogs that originate from a resource.
   repeated InstrumentationLibraryLogs instrumentation_library_logs = 2;
 
-  // This schema_url applies to the "resource" field and to all logs in the
-  // "instrumentation_library_logs" except the logs which have a schema_url
-  // specified in the nested InstrumentationLibraryLogs message.
+  // This schema_url applies to the data in the "resource" field. It does not apply
+  // to the data in the "instrumentation_library_logs" field which have their own
+  // schema_url field.
   string schema_url = 3;
 }
 
@@ -49,8 +49,7 @@ message InstrumentationLibraryLogs {
   // A list of log records.
   repeated LogRecord logs = 2;
 
-  // This schema_url applies to all logs in the "logs" field regardless of the
-  // value of the schema_url field in the outer ResourceLogs message.
+  // This schema_url applies to all logs in the "logs" field.
   string schema_url = 3;
 }
 

--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -32,6 +32,11 @@ message ResourceLogs {
 
   // A list of InstrumentationLibraryLogs that originate from a resource.
   repeated InstrumentationLibraryLogs instrumentation_library_logs = 2;
+
+  // This schema_url applies to the "resource" field and to all logs in the
+  // "instrumentation_library_logs" except the logs which have a schema_url
+  // specified in the nested InstrumentationLibraryLogs message.
+  string schema_url = 3;
 }
 
 // A collection of Logs produced by an InstrumentationLibrary.
@@ -43,6 +48,10 @@ message InstrumentationLibraryLogs {
 
   // A list of log records.
   repeated LogRecord logs = 2;
+
+  // This schema_url applies to all logs in the "logs" field regardless of the
+  // value of the schema_url field in the outer ResourceLogs message.
+  string schema_url = 3;
 }
 
 // Possible values for LogRecord.SeverityNumber.

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -33,9 +33,9 @@ message ResourceMetrics {
   // A list of metrics that originate from a resource.
   repeated InstrumentationLibraryMetrics instrumentation_library_metrics = 2;
 
-  // This schema_url applies to the "resource" field and to all metrics in the
-  // "instrumentation_library_metrics" except the metrics which have a schema_url
-  // specified in the nested InstrumentationLibraryMetrics message.
+  // This schema_url applies to the data in the "resource" field. It does not apply
+  // to the data in the "instrumentation_library_metrics" field which have their own
+  // schema_url field.
   string schema_url = 3;
 }
 
@@ -49,8 +49,7 @@ message InstrumentationLibraryMetrics {
   // A list of metrics that originate from an instrumentation library.
   repeated Metric metrics = 2;
 
-  // This schema_url applies to all metrics in the "metrics" field regardless of the
-  // value of the schema_url field in the outer ResourceMetrics message.
+  // This schema_url applies to all metrics in the "metrics" field.
   string schema_url = 3;
 }
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -32,6 +32,11 @@ message ResourceMetrics {
 
   // A list of metrics that originate from a resource.
   repeated InstrumentationLibraryMetrics instrumentation_library_metrics = 2;
+
+  // This schema_url applies to the "resource" field and to all metrics in the
+  // "instrumentation_library_metrics" except the metrics which have a schema_url
+  // specified in the nested InstrumentationLibraryMetrics message.
+  string schema_url = 3;
 }
 
 // A collection of Metrics produced by an InstrumentationLibrary.
@@ -43,6 +48,10 @@ message InstrumentationLibraryMetrics {
 
   // A list of metrics that originate from an instrumentation library.
   repeated Metric metrics = 2;
+
+  // This schema_url applies to all metrics in the "metrics" field regardless of the
+  // value of the schema_url field in the outer ResourceMetrics message.
+  string schema_url = 3;
 }
 
 // Defines a Metric which has one or more timeseries.  The following is a

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -32,6 +32,11 @@ message ResourceSpans {
 
   // A list of InstrumentationLibrarySpans that originate from a resource.
   repeated InstrumentationLibrarySpans instrumentation_library_spans = 2;
+
+  // This schema_url applies to the "resource" field and to all spans and span events
+  // in the "instrumentation_library_spans" except the spans and span events which
+  // have a schema_url specified in the nested InstrumentationLibrarySpans message.
+  string schema_url = 3;
 }
 
 // A collection of Spans produced by an InstrumentationLibrary.
@@ -43,6 +48,10 @@ message InstrumentationLibrarySpans {
 
   // A list of Spans that originate from an instrumentation library.
   repeated Span spans = 2;
+
+  // This schema_url applies to all spans and span events in the "spans" field regardless
+  // of the value of the schema_url field in the outer ResourceSpans message.
+  string schema_url = 3;
 }
 
 // Span represents a single operation within a trace. Spans can be

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -33,9 +33,9 @@ message ResourceSpans {
   // A list of InstrumentationLibrarySpans that originate from a resource.
   repeated InstrumentationLibrarySpans instrumentation_library_spans = 2;
 
-  // This schema_url applies to the "resource" field and to all spans and span events
-  // in the "instrumentation_library_spans" except the spans and span events which
-  // have a schema_url specified in the nested InstrumentationLibrarySpans message.
+  // This schema_url applies to the data in the "resource" field. It does not apply
+  // to the data in the "instrumentation_library_spans" field which have their own
+  // schema_url field.
   string schema_url = 3;
 }
 
@@ -49,8 +49,7 @@ message InstrumentationLibrarySpans {
   // A list of Spans that originate from an instrumentation library.
   repeated Span spans = 2;
 
-  // This schema_url applies to all spans and span events in the "spans" field regardless
-  // of the value of the schema_url field in the outer ResourceSpans message.
+  // This schema_url applies to all spans and span events in the "spans" field.
   string schema_url = 3;
 }
 


### PR DESCRIPTION
This adds schema_url fields introduced in OTEP 0152 (Telemetry Schemas):
https://github.com/open-telemetry/oteps/blob/main/text/0152-telemetry-schemas.md#otlp-changes
