### PR TITLE
Refine descriptions of Histogram+Summary for explicit OpenMetrics compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Full list of differences found in [this compare.](https://github.com/open-teleme
 
 * Remove if no changes for this section before release.
 
-### Changed: MEtrics
+### Changed: Metrics
 
 * :stop_sign: [DATA MODEL CHANGE] Histogram/Summary sums must be monotonic counters of events (#302)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ Full list of differences found in [this compare.](https://github.com/open-teleme
 
 * Remove if no changes for this section before release.
 
-### Changed
+### Changed: MEtrics
 
-* Remove if no changes for this section before release.
+* :stop_sign: [DATA MODEL CHANGE] Histogram/Summary sums must be monotonic counters of events (#302)
 
 ### Added
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -220,8 +220,8 @@ message IntHistogram {
   AggregationTemporality aggregation_temporality = 2;
 }
 
-// Histogram represents the type of a metric that is calculated by aggregating as a
-// Histogram of all reported double measurements over a time interval.
+// Histogram represents the type of a metric that is calculated by aggregating
+// as a Histogram of all reported double measurements over a time interval.
 message Histogram {
   repeated HistogramDataPoint data_points = 1;
 
@@ -527,6 +527,11 @@ message HistogramDataPoint {
   // sum of the values in the population. If count is zero then this field
   // must be zero. This value must be equal to the sum of the "sum" fields in
   // buckets if a histogram is provided.
+  //
+  // Note: Sum should only be filled out when measuring non-negative discrete
+  // events, and is assumed to be monotonic over the values of these events.
+  // Negative events *can* be recorded, but sum should not be filled out when
+  // doing so.
   double sum = 5;
 
   // bucket_counts is an optional field contains the count values of histogram
@@ -617,6 +622,8 @@ message SummaryDataPoint {
     double quantile = 1;
 
     // The value at the given quantile of a distribution.
+    //
+    // Quantile values must NOT be negative.
     double value = 2;
   }
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -599,6 +599,12 @@ message SummaryDataPoint {
 
   // sum of the values in the population. If count is zero then this field
   // must be zero.
+  //
+  // Note: Sum should only be filled out when measuring non-negative discrete
+  // events, and is assumed to be monotonic over the values of these events.
+  // Negative events *can* be recorded, but sum should not be filled out when
+  // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
+  // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
   double sum = 5;
 
   // Represents the value at a given quantile of a distribution.

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -531,7 +531,8 @@ message HistogramDataPoint {
   // Note: Sum should only be filled out when measuring non-negative discrete
   // events, and is assumed to be monotonic over the values of these events.
   // Negative events *can* be recorded, but sum should not be filled out when
-  // doing so.
+  // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
+  // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
   double sum = 5;
 
   // bucket_counts is an optional field contains the count values of histogram


### PR DESCRIPTION
Fixes #187
Fixes https://github.com/open-telemetry/wg-prometheus/issues/21

- Summary data points must record non-negative values
- Histogram sum can only be present if underlying measurements are non-negative. (Opening a bug to expand our API to allow this to present in more scenarios later)