### PR TITLE
Mark metrics protocol as stable for the 0.9 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
+
 ## Unreleased
+
+Full list of differences found in [this compare.](https://github.com/open-telemetry/opentelemetry-proto/compare/v0.9.0...v0.10.0)
+
+### Maturity
+
+* Remove if no changes for this section before release.
+
+### Changed: Metrics
+
+* Remove if no changes for this section before release.
+
+### Added
+
+* Remove if no changes for this section before release.
+
+### Removed
+
+* Remove if no changes for this section before release.
+
+## 0.9.0 - 2021-04-12
 
 Full list of differences found in [this compare.](https://github.com/open-telemetry/opentelemetry-proto/compare/v0.8.0...v0.9.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ Full list of differences found in [this compare.](https://github.com/open-teleme
 
 * Remove if no changes for this section before release.
 
-### Changed
+### Changed: Metrics
 
-* Remove if no changes for this section before release.
+* :stop_sign: [DATA MODEL CHANGE] Histogram/Summary sums must be monotonic counters of events (#302)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Full list of differences found in [this compare.](https://github.com/open-teleme
 ### Added
 
 - Common - Add bytes (binary) as data type to AnyValue (#297)
+- Common - Add schema_url fields as described in OTEP 0152 (#298)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,16 @@ Full list of differences found in [this compare.](https://github.com/open-teleme
 
 ### Maturity
 
-* Remove if no changes for this section before release.
+* `collector/metrics/*` is now considered `stable`. (#305)
 
 ### Changed: Metrics
 
 * :stop_sign: [DATA MODEL CHANGE] Histogram/Summary sums must be monotonic counters of events (#302)
+* :stop_sign: [DATA MODEL CHANGE] Clarify requirements and semantics for start time (#295)
 
 ### Added
 
-* Remove if no changes for this section before release.
+- Common - Add bytes (binary) as data type to AnyValue (#297)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ To generate the raw gRPC client libraries use `make gen-${LANGUAGE}`. Current su
 Component                            | Maturity |
 -------------------------------------|----------|
 **Binary Protobuf Encoding**         |          |
-collector/metrics/*                  | Beta     |
+collector/metrics/*                  | Stable   |
 collector/trace/*                    | Stable   |
 collector/logs/*                     | Alpha    |
 common/*                             | Stable   |
-metrics/*                            | Beta     |
+metrics/*                            | Stable   |
 resource/*                           | Stable   |
 trace/trace.proto                    | Stable   |
 trace/trace_config.proto             | Alpha    |

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -247,8 +247,8 @@ message IntHistogram {
   AggregationTemporality aggregation_temporality = 2;
 }
 
-// Histogram represents the type of a metric that is calculated by aggregating as a
-// Histogram of all reported double measurements over a time interval.
+// Histogram represents the type of a metric that is calculated by aggregating
+// as a Histogram of all reported double measurements over a time interval.
 message Histogram {
   repeated HistogramDataPoint data_points = 1;
 
@@ -526,6 +526,12 @@ message HistogramDataPoint {
   // sum of the values in the population. If count is zero then this field
   // must be zero. This value must be equal to the sum of the "sum" fields in
   // buckets if a histogram is provided.
+  //
+  // Note: Sum should only be filled out when measuring non-negative discrete
+  // events, and is assumed to be monotonic over the values of these events.
+  // Negative events *can* be recorded, but sum should not be filled out when
+  // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
+  // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
   double sum = 5;
 
   // bucket_counts is an optional field contains the count values of histogram
@@ -593,6 +599,12 @@ message SummaryDataPoint {
 
   // sum of the values in the population. If count is zero then this field
   // must be zero.
+  //
+  // Note: Sum should only be filled out when measuring non-negative discrete
+  // events, and is assumed to be monotonic over the values of these events.
+  // Negative events *can* be recorded, but sum should not be filled out when
+  // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
+  // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
   double sum = 5;
 
   // Represents the value at a given quantile of a distribution.
@@ -609,6 +621,8 @@ message SummaryDataPoint {
     double quantile = 1;
 
     // The value at the given quantile of a distribution.
+    //
+    // Quantile values must NOT be negative.
     double value = 2;
   }
 


### PR DESCRIPTION
- Metrics datamodel SiG confirms no breaking changes will be made going forward.
- All release-blocking issues for the protocol definitions are resolved.