### PR TITLE
Declare Logs Beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Full list of differences found in [this compare.](https://github.com/open-teleme
 
 ### Maturity
 
-* Remove if no changes for this section before release.
+* `collector/logs/*` is now considered `Beta`. (#311)
+* `logs/*` is now considered `Beta`. (#311)
 
 ### Changed: Metrics
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Component                            | Maturity |
 **Binary Protobuf Encoding**         |          |
 collector/metrics/*                  | Stable   |
 collector/trace/*                    | Stable   |
-collector/logs/*                     | Alpha    |
+collector/logs/*                     | Beta     |
 common/*                             | Stable   |
 metrics/*                            | Stable   |
 resource/*                           | Stable   |
 trace/trace.proto                    | Stable   |
 trace/trace_config.proto             | Alpha    |
-logs/*                               | Alpha    |
+logs/*                               | Beta     |
 **JSON encoding**                    |          |
 All messages                         | Alpha    |
 


### PR DESCRIPTION
The Log SIG discussed and made a decision to declare Log data model and Log part of OTLP Beta.

(See SIG meeting notes here https://docs.google.com/document/d/1cX5fWXyWqVVzYHSFUymYUfWxUK5hT97gc23w595LmdM/edit#heading=h.28y76as82bvu)