### PR TITLE
Fix comment on explicit_bounds

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -417,7 +417,7 @@ message HistogramDataPoint {
   //
   // (-infinity, explicit_bounds[i]] for i == 0
   // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < size(explicit_bounds)
-  // (explicit_bounds[i], +infinity) for i == size(explicit_bounds)
+  // (explicit_bounds[i-1], +infinity) for i == size(explicit_bounds)
   //
   // The values in the explicit_bounds array must be strictly increasing.
   //
@@ -644,7 +644,7 @@ message IntHistogramDataPoint {
   //
   // (-infinity, explicit_bounds[i]] for i == 0
   // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < size(explicit_bounds)
-  // (explicit_bounds[i], +infinity) for i == size(explicit_bounds)
+  // (explicit_bounds[i-1], +infinity) for i == size(explicit_bounds)
   //
   // The values in the explicit_bounds array must be strictly increasing.
   //

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -413,12 +413,11 @@ message HistogramDataPoint {
 
   // explicit_bounds specifies buckets with explicitly defined bounds for values.
   //
-  // This defines size(explicit_bounds) + 1 (= N) buckets. The boundaries for
-  // bucket at index i are:
+  // The boundaries for bucket at index i are:
   //
   // (-infinity, explicit_bounds[i]] for i == 0
-  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
-  // (explicit_bounds[i-1], +infinity) for i == N-1
+  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < size(explicit_bounds)
+  // (explicit_bounds[i], +infinity) for i == size(explicit_bounds)
   //
   // The values in the explicit_bounds array must be strictly increasing.
   //
@@ -641,12 +640,11 @@ message IntHistogramDataPoint {
 
   // explicit_bounds specifies buckets with explicitly defined bounds for values.
   //
-  // This defines size(explicit_bounds) + 1 (= N) buckets. The boundaries for
-  // bucket at index i are:
+  // The boundaries for bucket at index i are:
   //
   // (-infinity, explicit_bounds[i]] for i == 0
-  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
-  // (explicit_bounds[i-1], +infinity) for i == N-1
+  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < size(explicit_bounds)
+  // (explicit_bounds[i], +infinity) for i == size(explicit_bounds)
   //
   // The values in the explicit_bounds array must be strictly increasing.
   //

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -474,7 +474,7 @@ message IntHistogramDataPoint {
   //
   // (-infinity, explicit_bounds[i]] for i == 0
   // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
-  // (explicit_bounds[i], +infinity) for i == N-1
+  // (explicit_bounds[i-1], +infinity) for i == N-1
   //
   // The values in the explicit_bounds array must be strictly increasing.
   //
@@ -558,7 +558,7 @@ message HistogramDataPoint {
   //
   // (-infinity, explicit_bounds[i]] for i == 0
   // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
-  // (explicit_bounds[i], +infinity) for i == N-1
+  // (explicit_bounds[i-1], +infinity) for i == N-1
   //
   // The values in the explicit_bounds array must be strictly increasing.
   //

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -346,6 +346,8 @@ message NumberDataPoint {
   repeated Exemplar exemplars = 5;
 }
 
+
+
 // HistogramDataPoint is a single data point in a timeseries that describes the
 // time-varying values of a Histogram of double values. A Histogram contains
 // summary statistics for a population of values, it may optionally contain the
@@ -644,7 +646,7 @@ message IntHistogramDataPoint {
   //
   // (-infinity, explicit_bounds[i]] for i == 0
   // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
-  // (explicit_bounds[i-], +infinity) for i == N-1
+  // (explicit_bounds[i-1], +infinity) for i == N-1
   //
   // The values in the explicit_bounds array must be strictly increasing.
   //


### PR DESCRIPTION
Fix bug in comment for explicit_bounds.

If I gave explicit_bounds of...

explicit_bounds  = [ 10, 20, 30 ]

`N` = 4 (sizeof(explicit_bounds) + 1)
valid `i` will include 0, 1, 2.

Given previous statement of...
(explicit_bounds[i], +infinity) for `i` == `N`-1
would cause a out-of-bound error. `N`-1= 3.  explicit_bounds[3] is out-of-bound.
