### PR TITLE
Add optional data point flags to all metrics data points, support staleness markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ Full list of differences found in [this compare.](https://github.com/open-teleme
 * `collector/logs/*` is now considered `Beta`. (#311)
 * `logs/*` is now considered `Beta`. (#311)
 
-### Changed: Metrics
+### Changed
 
 * Remove if no changes for this section before release.
 
 ### Added
 
-* Remove if no changes for this section before release.
+* Metrics data points add a `flags` field with one bit to represent explicitly missing data.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Full list of differences found in [this compare.](https://github.com/open-teleme
 
 ### Added
 
-* Metrics data points add a `flags` field with one bit to represent explicitly missing data.
+* Metrics data points add a `flags` field with one bit to represent explicitly missing data. (#316)
 
 ### Removed
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -298,7 +298,12 @@ enum AggregationTemporality {
 }
 
 // DataPointFlags is defined as a protobuf 'uint32' type and is to be used as a
-// bit-field representing 32 distinct boolean flags.
+// bit-field representing 32 distinct boolean flags.  Each flag defined in this
+// enum is a bit-mask.  To test the presence of a single flag in the flags of
+// a data point, for example, use an expression like:
+//
+//   (point.flags & FLAG_NO_RECORDED_VALUE) == FLAG_NO_RECORDED_VALUE
+//
 enum DataPointFlags {
   FLAG_NONE = 0;
 
@@ -307,7 +312,7 @@ enum DataPointFlags {
   // for an equivalent to the Prometheus "staleness marker".
   FLAG_NO_RECORDED_VALUE = 1;
 
-  // Bits 2-32 are reserved for future use.
+  // Bits 2-31 are reserved for future use.
 }
 
 // NumberDataPoint is a single data point in a timeseries that describes the

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -351,8 +351,9 @@ message NumberDataPoint {
   // measurements that were used to form the data point
   repeated Exemplar exemplars = 5;
 
-  // Flags that apply to this specific data point.
-  DataPointFlags flags = 8;
+  // Flags that apply to this specific data point.  See DataPointFlags
+  // for the available flags and their meaning.
+  uint32 flags = 8;
 }
 
 // HistogramDataPoint is a single data point in a timeseries that describes the
@@ -437,8 +438,9 @@ message HistogramDataPoint {
   // measurements that were used to form the data point
   repeated Exemplar exemplars = 8;
 
-  // Flags that apply to this specific data point.
-  DataPointFlags flags = 10;
+  // Flags that apply to this specific data point.  See DataPointFlags
+  // for the available flags and their meaning.
+  uint32 flags = 10;
 }
 
 // SummaryDataPoint is a single data point in a timeseries that describes the
@@ -507,8 +509,9 @@ message SummaryDataPoint {
   // from the current snapshot. The quantiles must be strictly increasing.
   repeated ValueAtQuantile quantile_values = 6;
 
-  // Flags that apply to this specific data point.
-  DataPointFlags flags = 8;
+  // Flags that apply to this specific data point.  See DataPointFlags
+  // for the available flags and their meaning.
+  uint32 flags = 8;
 }
 
 // A representation of an exemplar, which is a sample input measurement.

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -303,6 +303,19 @@ enum AggregationTemporality {
 }
 
 
+// DataPointFlags is defined as a protobuf 'uint32' type and is to be used as a
+// bit-field representing 32 distinct boolean flags.
+enum DataPointFlags {
+  FLAG_NONE = 0;
+
+  // This DataPoint is valid but has no recorded value.  This value
+  // SHOULD be used to reflect explicitly missing data in a series, as
+  // for an equivalent to the Prometheus "staleness marker".
+  FLAG_NO_RECORDED_VALUE = 1;
+
+  // Bits 2-32 are reserved for future use.
+}
+
 
 // NumberDataPoint is a single data point in a timeseries that describes the
 // time-varying value of a double metric.
@@ -344,6 +357,9 @@ message NumberDataPoint {
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point
   repeated Exemplar exemplars = 5;
+
+  // Flags that apply to this specific data point.
+  DataPointFlags flags = 8;
 }
 
 
@@ -430,6 +446,9 @@ message HistogramDataPoint {
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point
   repeated Exemplar exemplars = 8;
+
+  // Flags that apply to this specific data point.
+  DataPointFlags flags = 10;
 }
 
 // SummaryDataPoint is a single data point in a timeseries that describes the
@@ -497,6 +516,9 @@ message SummaryDataPoint {
   // (Optional) list of values at different quantiles of the distribution calculated
   // from the current snapshot. The quantiles must be strictly increasing.
   repeated ValueAtQuantile quantile_values = 6;
+
+  // Flags that apply to this specific data point.
+  DataPointFlags flags = 8;
 }
 
 


### PR DESCRIPTION
Adds a bit to represent stale points they way Prometheus does when scraping for metrics yields no results. This avoids the use of IEEE 754 NaN values in data points that do not necessarily have a floating point field that can be used.

Resolves #315.

Related: https://github.com/open-telemetry/opentelemetry-specification/issues/1078

Partial copy from #310.
Resolves #309.
