### PR TITLE
Base-2 exponential histogram protocol support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Full list of differences found in [this compare.](https://github.com/open-teleme
 
 ### Added
 
-* Remove if no changes for this section before release.
+* ExponentialHistogram is a base-2 exponential histogram described in [OTEP 149](https://github.com/open-telemetry/oteps/pull/149).
 
 ### Removed
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -447,39 +447,11 @@ message HistogramDataPoint {
 // distribution of those values across a set of buckets.
 //
 message ExponentialHistogramDataPoint {
-  // The set of key/value pairs that uniquely identify the timeseries from
-  // where this point belongs. The list may be empty (may contain 0 elements).
-  repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
-
-  // StartTimeUnixNano is optional but strongly encouraged, see the
-  // the detiled comments above Metric.
-  //
-  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
-  // 1970.
-  fixed64 start_time_unix_nano = 2;
-
-  // TimeUnixNano is required, see the detailed comments above Metric.
-  //
-  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
-  // 1970.
-  fixed64 time_unix_nano = 3;
-
-  // count is the number of values in the population. Must be non-negative. This
-  // value must be equal to the sum of the "count" fields in buckets if a
-  // histogram is provided.
-  fixed64 count = 4;
-
-  // sum of the values in the population. If count is zero then this field
-  // must be zero. This value must be equal to the sum of the "sum" fields in
-  // buckets if a histogram is provided.
-  //
-  // Note: Sum should only be filled out when measuring non-negative discrete
-  // events, and is assumed to be monotonic over the values of these events.
-  // Negative events *can* be recorded, but sum should not be filled out when
-  // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-  // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
-  double sum = 5;
-
+  // T.B.D. The Attributes, Timestamps, Flags, Count, and Sum fields will
+  // be copied from HistohgramDataPoint before merging.  These fields arte
+  // identical between these two types, and both have pending changes in the
+  // opentelemetry-proto repository.
+  
   // scale describes the resolution of the histogram.  Boundaries are
   // located at powers of the base, where:
   //
@@ -509,66 +481,35 @@ message ExponentialHistogramDataPoint {
   // mass equal to (zero_count / count).
   fixed64 zero_count = 7;
 
-  // zero_tolerance may be optionally set to convey the width of the
-  // zero region.  When this is not set, implementations may assume
-  // the zero tolerance equals the smallest representable positive
-  // IEEE 754 double-precision floating point number, which is (2^−1074).
-  //
-  // Producers can be configured to round measurements to zero that fall
-  // below the zero tolerance.  Users should avoid producing measurements
-  // that have meaningless precision near zero, as exponential buckets
-  // become increasingly dense in this region.
-  //
-  // Implementations MAY consider the zero bucket to have probability
-  // density equal to (zero_count / 2*zero_tolerance), if set.
-  double zero_tolerance = 8;
-
   // positive carries the positive range of exponential bucket counts.
-  SparseBuckets positive = 9;
+  Span positive = 8;
 
   // negative carries the negative range of exponential bucket counts.
-  SparseBuckets negative = 10;
+  Span negative = 9;
 
-  // SparseBuckets are a sparse set of bucket counts, compactly encoded.
-  message SparseBuckets {
-    // Span encodes a run of contiguous histogram buckets.
-    message Span {
-      sint32 offset = 1; // Gap to previous span, or starting point for 1st span (which can be negative).
-      uint32 length = 2; // Length of consecutive buckets.
-    }
+  // Buckets are a set of bucket counts, encoded in a contiguous array
+  // of counts.
+  message Span {
+    // Offset is the index of the first count expressed in this span.
+    // 
+    // Note: This uses a varint encoding as a simple form of compression.
+    sint64 offset = 1;
 
-    // span is a repeated list of Spans that encodes a range of
-    // exponential buckets, positive or negative.  The offset of the
-    // first Span indicates the smallest index in the Histogram with
-    // non-zero count.  Subsequent contiguous buckets will be included
-    // in the same Span, and subsequent Spans encode additional
-    // buckets separated by gaps where the histogram has zero count.
+    // Count is an array of counts, where count[i] carries the count
+    // of the bucket at index (offset+i), i.e., count[i] is the count
+    // of values less than or equal to base^(offset+i) and greater
+    // than base^(offset+i-1).
     //
-    // The starting index of a Span equals its own offset plus the
-    // starting index of the previous Span plus the previous Span's
-    // length.  As a recursive formula:
-    //
-    //    starting_index(span[x+1]) =
-    //       starting_index(span[x]) +
-    //       span[x+1].offset +
-    //       span[x].length
-    //
-    // For example, the two Spans [ {offset: 10, length: 3}, {offset:
-    // 5, length: 8} ] indicate a total of 11 buckets with indices at
-    // [10, 11, 12] and [18, 19, 20, 21, 22, 23, 24, 25].
-    repeated Span span = 1;
-
-    // delta is an array of counts corresponding to the buckets
-    // described by `span`, encoded as deltas.  The indicated count 
-    // for bucket[x] is defined as a recursive formula:
-    //
-    //    bucket_count(x+1) = bucket_count(x) + delta[x+1]
-    repeated sint64 delta = 2;
+    // Note: By contrast, the explicit HistogramDataPoint uses
+    // fixedt64.  This field is expected to have many buckets,
+    // especially zeros, so has been selected to ensure varint
+    // encoding.
+    repeated uint64 bucket_counts = 6;
   } 
 
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point
-  repeated Exemplar exemplars = 11;
+  repeated Exemplar exemplars = 10;
 }
 
 // SummaryDataPoint is a single data point in a timeseries that describes the

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -176,7 +176,7 @@ message Metric {
     // This field will be removed in ~3 months, on July 1, 2021.
     IntHistogram int_histogram = 8 [deprecated = true];
     Histogram histogram = 9;
-    ExponentialHistogram exponential_histogram = 12;
+    ExponentialHistogram exponential_histogram = 10;
     Summary summary = 11;
   }
 }

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -534,7 +534,7 @@ message ExponentialHistogramDataPoint {
   // Buckets are a set of bucket counts, encoded in a contiguous array
   // of counts.
   message Buckets {
-    // Offset is the index of the first count expressed in this span.
+    // Offset is the bucket index of the first entry in the bucket_counts array.
     // 
     // Note: This uses a varint encoding as a simple form of compression.
     sint32 offset = 1;
@@ -545,9 +545,9 @@ message ExponentialHistogramDataPoint {
     // base^(offset+i+1).
     //
     // Note: By contrast, the explicit HistogramDataPoint uses
-    // fixedt64.  This field is expected to have many buckets,
-    // especially zeros, so has been selected to ensure varint
-    // encoding.
+    // fixed64.  This field is expected to have many buckets,
+    // especially zeros, so uint64 has been selected to ensure
+    // varint encoding.
     repeated uint64 bucket_counts = 2;
   } 
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -416,8 +416,7 @@ message HistogramDataPoint {
   fixed64 count = 4;
 
   // sum of the values in the population. If count is zero then this field
-  // must be zero. This value must be equal to the sum of the "sum" fields in
-  // buckets if a histogram is provided.
+  // must be zero.
   //
   // Note: Sum should only be filled out when measuring non-negative discrete
   // events, and is assumed to be monotonic over the values of these events.
@@ -482,14 +481,13 @@ message ExponentialHistogramDataPoint {
   // 1970.
   fixed64 time_unix_nano = 3;
 
-  // count is the number of values in the population. Must be non-negative. This
-  // value must be equal to the sum of the "count" fields in buckets if a
-  // histogram is provided.
+  // count is the number of values in the population. Must be
+  // non-negative. This value must be equal to the sum of the "bucket_counts"
+  // values in the positive and negative Buckets plus the "zero_count" field.
   fixed64 count = 4;
 
   // sum of the values in the population. If count is zero then this field
-  // must be zero. This value must be equal to the sum of the "sum" fields in
-  // buckets if a histogram is provided.
+  // must be zero.
   //
   // Note: Sum should only be filled out when measuring non-negative discrete
   // events, and is assumed to be monotonic over the values of these events.

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -527,6 +527,10 @@ message ExponentialHistogramDataPoint {
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point
   repeated Exemplar exemplars = 10;
+
+  // Flags that apply to this specific data point.  See DataPointFlags
+  // for the available flags and their meaning.
+  uint32 flags = 11;
 }
 
 // SummaryDataPoint is a single data point in a timeseries that describes the

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -566,7 +566,7 @@ message ExponentialHistogramDataPoint {
 
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point
-  repeated Exemplar exemplars = 8;
+  repeated Exemplar exemplars = 11;
 }
 
 // SummaryDataPoint is a single data point in a timeseries that describes the

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -490,9 +490,11 @@ message ExponentialHistogramDataPoint {
   // greater than (base^(index-1)).
   //
   // The positive and negative ranges of the histogram are expressed
-  // separately but both use the same scale to locate their boundaries.
+  // separately.  Negative values are mapped by their absolute value
+  // into the negative range using the same scale as the positive range.
   //
-  // scale is valid in the range -4 through +8 inclusive.
+  // scale is not restricted by the protocol, as the permissible
+  // values depend on the range of the data.
   sint32 scale = 6;
 
   // zero_count is the count of values that are either exactly zero or
@@ -504,7 +506,7 @@ message ExponentialHistogramDataPoint {
   // the width of the zero region.
   //
   // Implementations MAY consider the zero bucket to have probability
-  // mass equal to (zero_count / sum).
+  // mass equal to (zero_count / count).
   fixed64 zero_count = 7;
 
   // zero_tolerance may be optionally set to convey the width of the

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -464,10 +464,10 @@ message HistogramDataPoint {
 // distribution of those values across a set of buckets.
 //
 message ExponentialHistogramDataPoint {
-  // T.B.D. The Attributes, Timestamps, Flags, Count, and Sum fields will
-  // be copied from HistohgramDataPoint before merging.  These fields arte
-  // identical between these two types, and both have pending changes in the
-  // opentelemetry-proto repository.
+  // T.B.D. The Attributes, Timestamps, Count, and Sum fields will be
+  // copied with their comments from HistohgramDataPoint before
+  // merging.  These fields arte identical between these two types,
+  // and have a pending change in the opentelemetry-proto repository.
   
   // scale describes the resolution of the histogram.  Boundaries are
   // located at powers of the base, where:

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -344,7 +344,7 @@ message NumberDataPoint {
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1 [deprecated = true];
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
-  // the detiled comments above Metric.
+  // the detailed comments above Metric.
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.
@@ -398,7 +398,7 @@ message HistogramDataPoint {
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1 [deprecated = true];
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
-  // the detiled comments above Metric.
+  // the detailed comments above Metric.
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.
@@ -469,7 +469,7 @@ message ExponentialHistogramDataPoint {
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
-  // the detiled comments above Metric.
+  // the detailed comments above Metric.
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.
@@ -576,7 +576,7 @@ message SummaryDataPoint {
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1 [deprecated = true];
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
-  // the detiled comments above Metric.
+  // the detailed comments above Metric.
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.
@@ -687,7 +687,7 @@ message IntDataPoint {
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
-  // the detiled comments above Metric.
+  // the detailed comments above Metric.
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.
@@ -736,7 +736,7 @@ message IntHistogramDataPoint {
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
-  // the detiled comments above Metric.
+  // the detailed comments above Metric.
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -413,12 +413,11 @@ message HistogramDataPoint {
 
   // explicit_bounds specifies buckets with explicitly defined bounds for values.
   //
-  // This defines size(explicit_bounds) + 1 (= N) buckets. The boundaries for
-  // bucket at index i are:
+  // The boundaries for bucket at index i are:
   //
   // (-infinity, explicit_bounds[i]] for i == 0
-  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
-  // (explicit_bounds[i], +infinity) for i == N-1
+  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < size(explicit_bounds)
+  // (explicit_bounds[i-1], +infinity) for i == size(explicit_bounds)
   //
   // The values in the explicit_bounds array must be strictly increasing.
   //
@@ -641,12 +640,11 @@ message IntHistogramDataPoint {
 
   // explicit_bounds specifies buckets with explicitly defined bounds for values.
   //
-  // This defines size(explicit_bounds) + 1 (= N) buckets. The boundaries for
-  // bucket at index i are:
+  // The boundaries for bucket at index i are:
   //
   // (-infinity, explicit_bounds[i]] for i == 0
-  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
-  // (explicit_bounds[i], +infinity) for i == N-1
+  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < size(explicit_bounds)
+  // (explicit_bounds[i-1], +infinity) for i == size(explicit_bounds)
   //
   // The values in the explicit_bounds array must be strictly increasing.
   //

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -180,22 +180,7 @@ message Metric {
   }
 }
 
-// IntGauge is deprecated.  Use Gauge with an integer value in NumberDataPoint.
-//
-// IntGauge represents the type of a int scalar metric that always exports the
-// "current value" for every data point. It should be used for an "unknown"
-// aggregation.
-//
-// A Gauge does not support different aggregation temporalities. Given the
-// aggregation is unknown, points cannot be combined using the same
-// aggregation, regardless of aggregation temporalities. Therefore,
-// AggregationTemporality is not included. Consequently, this also means
-// "StartTimeUnixNano" is ignored for all data points.
-message IntGauge {
-  option deprecated = true;
 
-  repeated IntDataPoint data_points = 1;
-}
 
 // Gauge represents the type of a double scalar metric that always exports the
 // "current value" for every data point. It should be used for an "unknown"
@@ -210,22 +195,6 @@ message Gauge {
   repeated NumberDataPoint data_points = 1;
 }
 
-// IntSum is deprecated.  Use Sum with an integer value in NumberDataPoint.
-//
-// IntSum represents the type of a numeric int scalar metric that is calculated as
-// a sum of all reported measurements over a time interval.
-message IntSum {
-  option deprecated = true;
-
-  repeated IntDataPoint data_points = 1;
-
-  // aggregation_temporality describes if the aggregator reports delta changes
-  // since last report time, or cumulative changes since a fixed start time.
-  AggregationTemporality aggregation_temporality = 2;
-
-  // If "true" means that the sum is monotonic.
-  bool is_monotonic = 3;
-}
 
 // Sum represents the type of a numeric double scalar metric that is calculated
 // as a sum of all reported measurements over a time interval.
@@ -240,20 +209,7 @@ message Sum {
   bool is_monotonic = 3;
 }
 
-// IntHistogram is deprecated, replaced by Histogram points using double-
-// valued exemplars.
-//
-// This represents the type of a metric that is calculated by aggregating as a
-// Histogram of all reported int measurements over a time interval.
-message IntHistogram {
-  option deprecated = true;
 
-  repeated IntHistogramDataPoint data_points = 1;
-
-  // aggregation_temporality describes if the aggregator reports delta changes
-  // since last report time, or cumulative changes since a fixed start time.
-  AggregationTemporality aggregation_temporality = 2;
-}
 
 // Histogram represents the type of a metric that is calculated by aggregating
 // as a Histogram of all reported double measurements over a time interval.
@@ -346,34 +302,7 @@ enum AggregationTemporality {
   AGGREGATION_TEMPORALITY_CUMULATIVE = 2;
 }
 
-// IntDataPoint is a single data point in a timeseries that describes the
-// time-varying values of a int64 metric.
-message IntDataPoint {
-  option deprecated = true;
 
-  // The set of labels that uniquely identify this timeseries.
-  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
-
-  // StartTimeUnixNano is optional but strongly encouraged, see the
-  // the detiled comments above Metric.
-  //
-  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
-  // 1970.
-  fixed64 start_time_unix_nano = 2;
-
-  // TimeUnixNano is required, see the detailed comments above Metric.
-  //
-  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
-  // 1970.
-  fixed64 time_unix_nano = 3;
-
-  // value itself.
-  sfixed64 value = 4;
-
-  // (Optional) List of exemplars collected from
-  // measurements that were used to form the data point
-  repeated IntExemplar exemplars = 5;
-}
 
 // NumberDataPoint is a single data point in a timeseries that describes the
 // time-varying value of a double metric.
@@ -417,76 +346,7 @@ message NumberDataPoint {
   repeated Exemplar exemplars = 5;
 }
 
-// IntHistogramDataPoint is deprecated; use HistogramDataPoint.
-//
-// This is a single data point in a timeseries that describes
-// the time-varying values of a Histogram of int values. A Histogram contains
-// summary statistics for a population of values, it may optionally contain
-// the distribution of those values across a set of buckets.
-//
-// If the histogram contains the distribution of values, then both
-// "explicit_bounds" and "bucket counts" fields must be defined.
-// If the histogram does not contain the distribution of values, then both
-// "explicit_bounds" and "bucket_counts" must be omitted and only "count" and
-// "sum" are known.
-message IntHistogramDataPoint {
-  option deprecated = true;
 
-  // The set of labels that uniquely identify this timeseries.
-  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
-
-  // StartTimeUnixNano is optional but strongly encouraged, see the
-  // the detiled comments above Metric.
-  //
-  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
-  // 1970.
-  fixed64 start_time_unix_nano = 2;
-
-  // TimeUnixNano is required, see the detailed comments above Metric.
-  //
-  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
-  // 1970.
-  fixed64 time_unix_nano = 3;
-
-  // count is the number of values in the population. Must be non-negative. This
-  // value must be equal to the sum of the "count" fields in buckets if a
-  // histogram is provided.
-  fixed64 count = 4;
-
-  // sum of the values in the population. If count is zero then this field
-  // must be zero. This value must be equal to the sum of the "sum" fields in
-  // buckets if a histogram is provided.
-  sfixed64 sum = 5;
-
-  // bucket_counts is an optional field contains the count values of histogram
-  // for each bucket.
-  //
-  // The sum of the bucket_counts must equal the value in the count field.
-  //
-  // The number of elements in bucket_counts array must be by one greater than
-  // the number of elements in explicit_bounds array.
-  repeated fixed64 bucket_counts = 6;
-
-  // explicit_bounds specifies buckets with explicitly defined bounds for values.
-  //
-  // This defines size(explicit_bounds) + 1 (= N) buckets. The boundaries for
-  // bucket at index i are:
-  //
-  // (-infinity, explicit_bounds[i]] for i == 0
-  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
-  // (explicit_bounds[i], +infinity) for i == N-1
-  //
-  // The values in the explicit_bounds array must be strictly increasing.
-  //
-  // Histogram buckets are inclusive of their upper boundary, except the last
-  // bucket where the boundary is at infinity. This format is intentionally
-  // compatible with the OpenMetrics histogram definition.
-  repeated double explicit_bounds = 7;
-
-  // (Optional) List of exemplars collected from
-  // measurements that were used to form the data point
-  repeated IntExemplar exemplars = 8;
-}
 
 // HistogramDataPoint is a single data point in a timeseries that describes the
 // time-varying values of a Histogram of double values. A Histogram contains
@@ -639,37 +499,7 @@ message SummaryDataPoint {
   repeated ValueAtQuantile quantile_values = 6;
 }
 
-// A representation of an exemplar, which is a sample input int measurement.
-// Exemplars also hold information about the environment when the measurement
-// was recorded, for example the span and trace ID of the active span when the
-// exemplar was recorded.
-message IntExemplar {
-  option deprecated = true;
 
-  // The set of labels that were filtered out by the aggregator, but recorded
-  // alongside the original measurement. Only labels that were filtered out
-  // by the aggregator should be included
-  repeated opentelemetry.proto.common.v1.StringKeyValue filtered_labels = 1;
-
-  // time_unix_nano is the exact time when this exemplar was recorded
-  //
-  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
-  // 1970.
-  fixed64 time_unix_nano = 2;
-
-  // Numerical int value of the measurement that was recorded.
-  sfixed64 value = 3;
-
-  // (Optional) Span ID of the exemplar trace.
-  // span_id may be missing if the measurement is not recorded inside a trace
-  // or if the trace is not sampled.
-  bytes span_id = 4;
-
-  // (Optional) Trace ID of the exemplar trace.
-  // trace_id may be missing if the measurement is not recorded inside a trace
-  // or if the trace is not sampled.
-  bytes trace_id = 5;
-}
 
 // A representation of an exemplar, which is a sample input measurement.
 // Exemplars also hold information about the environment when the measurement
@@ -705,6 +535,160 @@ message Exemplar {
     double as_double = 3;
     sfixed64 as_int = 6;
   }
+
+  // (Optional) Span ID of the exemplar trace.
+  // span_id may be missing if the measurement is not recorded inside a trace
+  // or if the trace is not sampled.
+  bytes span_id = 4;
+
+  // (Optional) Trace ID of the exemplar trace.
+  // trace_id may be missing if the measurement is not recorded inside a trace
+  // or if the trace is not sampled.
+  bytes trace_id = 5;
+}
+
+//
+// Move deprecated messages below this line
+//
+
+// IntDataPoint is deprecated. Use integer value in NumberDataPoint.
+message IntDataPoint {
+  option deprecated = true;
+
+  // The set of labels that uniquely identify this timeseries.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
+
+  // StartTimeUnixNano is optional but strongly encouraged, see the
+  // the detiled comments above Metric.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 start_time_unix_nano = 2;
+
+  // TimeUnixNano is required, see the detailed comments above Metric.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 3;
+
+  // value itself.
+  sfixed64 value = 4;
+
+  // (Optional) List of exemplars collected from
+  // measurements that were used to form the data point
+  repeated IntExemplar exemplars = 5;
+}
+
+// IntGauge is deprecated.  Use Gauge with an integer value in NumberDataPoint.
+message IntGauge {
+  option deprecated = true;
+
+  repeated IntDataPoint data_points = 1;
+}
+
+// IntSum is deprecated.  Use Sum with an integer value in NumberDataPoint.
+message IntSum {
+  option deprecated = true;
+
+  repeated IntDataPoint data_points = 1;
+
+  // aggregation_temporality describes if the aggregator reports delta changes
+  // since last report time, or cumulative changes since a fixed start time.
+  AggregationTemporality aggregation_temporality = 2;
+
+  // If "true" means that the sum is monotonic.
+  bool is_monotonic = 3;
+}
+
+// IntHistogramDataPoint is deprecated; use HistogramDataPoint.
+message IntHistogramDataPoint {
+  option deprecated = true;
+
+  // The set of labels that uniquely identify this timeseries.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
+
+  // StartTimeUnixNano is optional but strongly encouraged, see the
+  // the detiled comments above Metric.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 start_time_unix_nano = 2;
+
+  // TimeUnixNano is required, see the detailed comments above Metric.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 3;
+
+  // count is the number of values in the population. Must be non-negative. This
+  // value must be equal to the sum of the "count" fields in buckets if a
+  // histogram is provided.
+  fixed64 count = 4;
+
+  // sum of the values in the population. If count is zero then this field
+  // must be zero. This value must be equal to the sum of the "sum" fields in
+  // buckets if a histogram is provided.
+  sfixed64 sum = 5;
+
+  // bucket_counts is an optional field contains the count values of histogram
+  // for each bucket.
+  //
+  // The sum of the bucket_counts must equal the value in the count field.
+  //
+  // The number of elements in bucket_counts array must be by one greater than
+  // the number of elements in explicit_bounds array.
+  repeated fixed64 bucket_counts = 6;
+
+  // explicit_bounds specifies buckets with explicitly defined bounds for values.
+  //
+  // This defines size(explicit_bounds) + 1 (= N) buckets. The boundaries for
+  // bucket at index i are:
+  //
+  // (-infinity, explicit_bounds[i]] for i == 0
+  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
+  // (explicit_bounds[i], +infinity) for i == N-1
+  //
+  // The values in the explicit_bounds array must be strictly increasing.
+  //
+  // Histogram buckets are inclusive of their upper boundary, except the last
+  // bucket where the boundary is at infinity. This format is intentionally
+  // compatible with the OpenMetrics histogram definition.
+  repeated double explicit_bounds = 7;
+
+  // (Optional) List of exemplars collected from
+  // measurements that were used to form the data point
+  repeated IntExemplar exemplars = 8;
+}
+
+// IntHistogram is deprecated, replaced by Histogram points using double-
+// valued exemplars.
+message IntHistogram {
+  option deprecated = true;
+
+  repeated IntHistogramDataPoint data_points = 1;
+
+  // aggregation_temporality describes if the aggregator reports delta changes
+  // since last report time, or cumulative changes since a fixed start time.
+  AggregationTemporality aggregation_temporality = 2;
+}
+
+// IntExemplar is deprecated. Use Exemplar with as_int for value
+message IntExemplar {
+  option deprecated = true;
+
+  // The set of labels that were filtered out by the aggregator, but recorded
+  // alongside the original measurement. Only labels that were filtered out
+  // by the aggregator should be included
+  repeated opentelemetry.proto.common.v1.StringKeyValue filtered_labels = 1;
+
+  // time_unix_nano is the exact time when this exemplar was recorded
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 2;
+
+  // Numerical int value of the measurement that was recorded.
+  sfixed64 value = 3;
 
   // (Optional) Span ID of the exemplar trace.
   // span_id may be missing if the measurement is not recorded inside a trace

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -221,6 +221,16 @@ message Histogram {
   AggregationTemporality aggregation_temporality = 2;
 }
 
+// ExponentialHistogram represents the type of a metric that is calculated by aggregating
+// as a ExponentialHistogram of all reported double measurements over a time interval.
+message ExponentialHistogram {
+  repeated ExponentialHistogramDataPoint data_points = 1;
+
+  // aggregation_temporality describes if the aggregator reports delta changes
+  // since last report time, or cumulative changes since a fixed start time.
+  AggregationTemporality aggregation_temporality = 2;
+}
+
 // Summary metric data are used to convey quantile summaries,
 // a Prometheus (see: https://prometheus.io/docs/concepts/metric_types/#summary)
 // and OpenMetrics (see: https://github.com/OpenObservability/OpenMetrics/blob/4dbf6075567ab43296eed941037c12951faafb92/protos/prometheus.proto#L45)
@@ -425,6 +435,134 @@ message HistogramDataPoint {
   // bucket where the boundary is at infinity. This format is intentionally
   // compatible with the OpenMetrics histogram definition.
   repeated double explicit_bounds = 7;
+
+  // (Optional) List of exemplars collected from
+  // measurements that were used to form the data point
+  repeated Exemplar exemplars = 8;
+}
+
+// ExponentialHistogramDataPoint is a single data point in a timeseries that describes the
+// time-varying values of a ExponentialHistogram of double values. A ExponentialHistogram contains
+// summary statistics for a population of values, it may optionally contain the
+// distribution of those values across a set of buckets.
+//
+message ExponentialHistogramDataPoint {
+  // The set of key/value pairs that uniquely identify the timeseries from
+  // where this point belongs. The list may be empty (may contain 0 elements).
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
+
+  // StartTimeUnixNano is optional but strongly encouraged, see the
+  // the detiled comments above Metric.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 start_time_unix_nano = 2;
+
+  // TimeUnixNano is required, see the detailed comments above Metric.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 3;
+
+  // count is the number of values in the population. Must be non-negative. This
+  // value must be equal to the sum of the "count" fields in buckets if a
+  // histogram is provided.
+  fixed64 count = 4;
+
+  // sum of the values in the population. If count is zero then this field
+  // must be zero. This value must be equal to the sum of the "sum" fields in
+  // buckets if a histogram is provided.
+  //
+  // Note: Sum should only be filled out when measuring non-negative discrete
+  // events, and is assumed to be monotonic over the values of these events.
+  // Negative events *can* be recorded, but sum should not be filled out when
+  // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
+  // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+  double sum = 5;
+
+  // scale describes the resolution of the histogram.  Boundaries are
+  // located at powers of the base, where:
+  //
+  //   base = (2^(2^-scale))
+  //
+  // The histogram bucket identified by `index`, a signed integer,
+  // contains values that are less than or equal to (base^index) and
+  // greater than (base^(index-1)).
+  //
+  // The positive and negative ranges of the histogram are expressed
+  // separately but both use the same scale to locate their boundaries.
+  //
+  // scale is valid in the range -4 through +8 inclusive.
+  sint32 scale = 6;
+
+  // zero_count is the count of values that are either exactly zero or
+  // within the region considered zero by the instrumentation at the
+  // tolerated degree of precision.  This bucket stores values that
+  // cannot be expressed using the standard exponential formula as
+  // well as values that have been rounded to zero.  Users have the
+  // option to set zero_tolerance to convey additional information about
+  // the width of the zero region.
+  //
+  // Implementations MAY consider the zero bucket to have probability
+  // mass equal to (zero_count / sum).
+  fixed64 zero_count = 7;
+
+  // zero_tolerance may be optionally set to convey the width of the
+  // zero region.  When this is not set, implementations may assume
+  // the zero tolerance equals the smallest representable positive
+  // IEEE 754 double-precision floating point number, which is (2^−1074).
+  //
+  // Producers can be configured to round measurements to zero that fall
+  // below the zero tolerance.  Users should avoid producing measurements
+  // that have meaningless precision near zero, as exponential buckets
+  // become increasingly dense in this region.
+  //
+  // Implementations MAY consider the zero bucket to have probability
+  // density equal to (zero_count / 2*zero_tolerance), if set.
+  double zero_tolerance = 8;
+
+  // positive carries the positive range of exponential bucket counts.
+  SparseBuckets positive = 9;
+
+  // negative carries the negative range of exponential bucket counts.
+  SparseBuckets negative = 10;
+
+  // SparseBuckets are a sparse set of bucket counts, compactly encoded.
+  message SparseBuckets {
+    // Span encodes a run of contiguous histogram buckets.
+    message Span {
+      sint32 offset = 1; // Gap to previous span, or starting point for 1st span (which can be negative).
+      uint32 length = 2; // Length of consecutive buckets.
+    }
+
+    // span is a repeated list of Spans that encodes a range of
+    // exponential buckets, positive or negative.  The offset of the
+    // first Span indicates the smallest index in the Histogram with
+    // non-zero count.  Subsequent contiguous buckets will be included
+    // in the same Span, and subsequent Spans encode additional
+    // buckets separated by gaps where the histogram has zero count.
+    //
+    // The starting index of a Span equals its own offset plus the
+    // starting index of the previous Span plus the previous Span's
+    // length.  As a recursive formula:
+    //
+    //    starting_index(span[x+1]) =
+    //       starting_index(span[x]) +
+    //       span[x+1].offset +
+    //       span[x].length
+    //
+    // For example, the two Spans [ {offset: 10, length: 3}, {offset:
+    // 5, length: 8} ] indicate a total of 11 buckets with indices at
+    // [10, 11, 12] and [18, 19, 20, 21, 22, 23, 24, 25].
+    repeated Span span = 1;
+
+    // delta is an array of counts corresponding to the buckets
+    // described by `span`, encoded as deltas.  The indicated count 
+    // for bucket[x] is defined as a recursive formula:
+    //
+    //    bucket_count(x+1) = bucket_count(x) + delta[x+1]
+    repeated sint64 delta = 2;
+  } 
 
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -521,7 +521,7 @@ message ExponentialHistogramDataPoint {
     // fixedt64.  This field is expected to have many buckets,
     // especially zeros, so has been selected to ensure varint
     // encoding.
-    repeated uint64 bucket_counts = 6;
+    repeated uint64 bucket_counts = 2;
   } 
 
   // (Optional) List of exemplars collected from


### PR DESCRIPTION
Adds a base-2 exponential histogram to OTLP metrics.

This protocol is copied from the OpenMetrics/Prometheus draft created by @beorn7, with comments written by me to summarize discussion in https://github.com/open-telemetry/opentelemetry-specification/issues/1776 (particularly around the meaning of the zero bucket), following the design effort in [OTEP 149](https://github.com/open-telemetry/oteps/pull/149) led by @yzhuge. 

Note: Past debate and discussion in the OTel Metrics SIG has led us to use different types for different kinds of histogram, as opposed to burying a new `oneof` in the existing types. This proposal follows that decision, and I would prefer not to revisit that topic. The new ExponentialHistogram and ExponentialHistogramDataPoint types mimic the existing explicit histogram types for most of their fields, including attributes, timestamps, sum, count, and exemplars fields. As such, the real review here is on lines 483 onward, starting from the `scale` field.