### PR TITLE
Remove outdated comment on attributes in trace.proto

### DIFF
--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -158,8 +158,7 @@ message Span {
   // This field is semantically required and it is expected that end_time >= start_time.
   fixed64 end_time_unix_nano = 8;
 
-  // attributes is a collection of key/value pairs. The value can be a string,
-  // an integer, a double or the Boolean values `true` or `false`. Note, global attributes
+  // attributes is a collection of key/value pairs. Note, global attributes
   // like server name can be set using the resource API. Examples of attributes:
   //
   //     "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -165,6 +165,9 @@ message Span {
   //     "/http/server_latency": 300
   //     "abc.com/myattribute": true
   //     "abc.com/score": 10.239
+  //
+  // The OpenTelemetry API specification further restricts the allowed value types:
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
 
   // dropped_attributes_count is the number of attributes that were discarded. Attributes


### PR DESCRIPTION
One can just look up the definition of `KeyValue` and `AnyValue` in `common.proto` which will stay up to date.

`AnyValue` is defined as:
https://github.com/open-telemetry/opentelemetry-proto/blob/e57e8494433f26e9050835c76e74282b0cd718a8/opentelemetry/proto/common/v1/common.proto#L30-L38

The Tracing API spec further restricts it to this subset:
https://github.com/open-telemetry/opentelemetry-specification/blob/eb44020eaf959464f2395023ab7c93a709de1725/specification/common/common.md#L21-L25
This could be stated in the comment instead if preferred.