### PR TITLE
Add proto messages for signals data independent of OTLP protocol

### DIFF
--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -24,6 +24,25 @@ option java_package = "io.opentelemetry.proto.logs.v1";
 option java_outer_classname = "LogsProto";
 option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/logs/v1";
 
+// LogsData represents the logs data that can be stored in a persistent storage,
+// OR can be embedded by other protocols that transfer OTLP logs data but do not
+// implement the OTLP protocol.
+//
+// The main difference between this message and collector protocol is that
+// in this message there will not be any "control" or "metadata" specific to
+// OTLP protocol.
+//
+// When new fields are added into this message, the OTLP request MUST be updated
+// as well.
+message LogsData {
+  // An array of ResourceLogs.
+  // For data coming from a single resource this array will typically contain
+  // one element. Intermediary nodes that receive data from multiple origins
+  // typically batch the data before forwarding further and in that case this
+  // array will contain multiple elements.
+  repeated ResourceLogs resource_logs = 1;
+}
+
 // A collection of InstrumentationLibraryLogs from a Resource.
 message ResourceLogs {
   // The resource for the logs in this message.

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -24,6 +24,25 @@ option java_package = "io.opentelemetry.proto.metrics.v1";
 option java_outer_classname = "MetricsProto";
 option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/v1";
 
+// MetricsData represents the metrics data that can be stored in a persistent
+// storage, OR can be embedded by other protocols that transfer OTLP metrics
+// data but do not implement the OTLP protocol.
+//
+// The main difference between this message and collector protocol is that
+// in this message there will not be any "control" or "metadata" specific to
+// OTLP protocol.
+//
+// When new fields are added into this message, the OTLP request MUST be updated
+// as well.
+message MetricsData {
+  // An array of ResourceMetrics.
+  // For data coming from a single resource this array will typically contain
+  // one element. Intermediary nodes that receive data from multiple origins
+  // typically batch the data before forwarding further and in that case this
+  // array will contain multiple elements.
+  repeated ResourceMetrics resource_metrics = 1;
+}
+
 // A collection of InstrumentationLibraryMetrics from a Resource.
 message ResourceMetrics {
   // The resource for the metrics in this message.

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -24,6 +24,25 @@ option java_package = "io.opentelemetry.proto.trace.v1";
 option java_outer_classname = "TraceProto";
 option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/trace/v1";
 
+// TracesData represents the traces data that can be stored in a persistent storage,
+// OR can be embedded by other protocols that transfer OTLP traces data but do
+// not implement the OTLP protocol.
+//
+// The main difference between this message and collector protocol is that
+// in this message there will not be any "control" or "metadata" specific to
+// OTLP protocol.
+//
+// When new fields are added into this message, the OTLP request MUST be updated
+// as well.
+message TracesData {
+  // An array of ResourceSpans.
+  // For data coming from a single resource this array will typically contain
+  // one element. Intermediary nodes that receive data from multiple origins
+  // typically batch the data before forwarding further and in that case this
+  // array will contain multiple elements.
+  repeated ResourceSpans resource_spans = 1;
+}
+
 // A collection of InstrumentationLibrarySpans from a Resource.
 message ResourceSpans {
   // The resource for the spans in this message.


### PR DESCRIPTION
The main motivation for this is to ensure that other protocols can use it to
send/receive OTLP data, as well as for persistent storages such as kafka, disk, etc.

Unfortunately we cannot use the same message in the OTLP request messages since it will be a breaking change,
but we can ensure that all fields present in the data message will be added to the request message as well.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>