### PR TITLE
Update CHANGELOG to describe breakage at OTLP v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,24 @@ Full list of differences found in [this compare.](https://github.com/open-teleme
 
 Full list of differences found in [this compare.](https://github.com/open-telemetry/opentelemetry-proto/compare/v0.7.0...v0.8.0)
 
+### Historical breaking change notice
+
+Release 0.8 was the last in the line of releases marked as "unstable".
+This release broke compatibility in more ways than were recognized and
+documented at the time of its release.  In particular, #278 created
+the `NumberDataPoint` type and used it in several locations in place
+of the former `DoubleDataPoint`.  The new `oneof` in `NumberDataPoint`
+re-used the former `DoubleDataPoint` tag number, which means that
+pre-0.8 `DoubleSum` and `DoubleGauge` points would parse correctly as
+a 0.8 `Sum` and `Gauge` points containing double-valued numbers.
+
+However, by virtue of a `syntax = "proto3"` declaration, the protocol
+compiler for all versions of OTLP have not included field presence,
+which means 0 values are not serialized.  **The result is that valid
+OTLP 0.7 `DoubleSum` and `DoubleGauge` points would not parse
+correctly as OTLP 0.8 data.**  Instead, they parse as
+`NumberDataPoint` with a missing value in the `oneof` field.
+
 ### Changed: Metrics
 
 * :stop_sign: [DEPRECATION] Deprecate IntSum, IntGauge, and IntDataPoint (#278)


### PR DESCRIPTION
We were unaware of how much the v0.8.0 metrics `NumberDataPoint` broke existing uses of OTLP v0.7. In particular, the `NumberDataPoint` would no longer correctly parse double-valued numbers when they were not encoded by virtue of being the default zero-value.

This adds a note to at least be honest about our mistake.

Context: https://github.com/open-telemetry/opentelemetry-proto/pull/278#discussion_r711815462
cc: @cwildman 