### PR TITLE
Update table to show that collector status is in step with main proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,12 @@ To generate the raw gRPC client libraries, use `make gen-${LANGUAGE}`. Currently
 Component                            | Maturity |
 -------------------------------------|----------|
 **Binary Protobuf Encoding**         |          |
-collector/metrics/*                  | Stable   |
-collector/trace/*                    | Stable   |
-collector/logs/*                     | Beta     |
 common/*                             | Stable   |
-metrics/*                            | Stable   |
+metrics/\*<br>collector/metrics/*    | Stable   |
 resource/*                           | Stable   |
-trace/trace.proto                    | Stable   |
+trace/trace.proto<br>collector/trace/* | Stable   |
 trace/trace_config.proto             | Alpha    |
-logs/*                               | Beta     |
+logs/*<br>collector/logs/*           | Beta     |
 **JSON encoding**                    |          |
 All messages                         | Alpha    |
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ metrics/\*<br>collector/metrics/*    | Stable   |
 resource/*                           | Stable   |
 trace/trace.proto<br>collector/trace/* | Stable   |
 trace/trace_config.proto             | Alpha    |
-logs/*<br>collector/logs/*           | Beta     |
+logs/\*<br>collector/logs/*          | Beta     |
 **JSON encoding**                    |          |
 All messages                         | Alpha    |
 


### PR DESCRIPTION
This is in response to @tigrannajaryan's comment https://github.com/open-telemetry/opentelemetry-specification/pull/2151#discussion_r755590307:

> We should be able to assume that "Traces" includes `collector/trace` as well ... since they alway are changes in a lockstep.

This supersedes and closes https://github.com/open-telemetry/opentelemetry-specification/pull/2151

Preview: https://github.com/chalin/opentelemetry-proto/tree/chalin-collector-status-in-step-2021-12-01#maturity-level

Screenshot:

> <img src="https://user-images.githubusercontent.com/4140793/144270851-6de8eea3-24c0-4c5b-a382-42ca9ed755f6.png" width=250>

/cc @austinlparker 