### PR TITLE
Clarify attribute key uniqueness requirement

### DIFF
--- a/opentelemetry/proto/common/v1/common.proto
+++ b/opentelemetry/proto/common/v1/common.proto
@@ -53,6 +53,8 @@ message ArrayValue {
 message KeyValueList {
   // A collection of key/value pairs of key-value pairs. The list may be empty (may
   // contain 0 elements).
+  // The keys MUST be unique (it is not allowed to have more than one
+  // value with the same key).
   repeated KeyValue values = 1;
 }
 

--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -135,6 +135,8 @@ message LogRecord {
   opentelemetry.proto.common.v1.AnyValue body = 5;
 
   // Additional attributes that describe the specific event occurrence. [Optional].
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 6;
   uint32 dropped_attributes_count = 7;
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -334,6 +334,8 @@ message NumberDataPoint {
 
   // The set of key/value pairs that uniquely identify the timeseries from
   // where this point belongs. The list may be empty (may contain 0 elements).
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
@@ -380,6 +382,8 @@ message HistogramDataPoint {
 
   // The set of key/value pairs that uniquely identify the timeseries from
   // where this point belongs. The list may be empty (may contain 0 elements).
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
@@ -451,6 +455,8 @@ message HistogramDataPoint {
 message ExponentialHistogramDataPoint {
   // The set of key/value pairs that uniquely identify the timeseries from
   // where this point belongs. The list may be empty (may contain 0 elements).
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
@@ -550,6 +556,8 @@ message SummaryDataPoint {
 
   // The set of key/value pairs that uniquely identify the timeseries from
   // where this point belongs. The list may be empty (may contain 0 elements).
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the

--- a/opentelemetry/proto/resource/v1/resource.proto
+++ b/opentelemetry/proto/resource/v1/resource.proto
@@ -25,7 +25,9 @@ option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/resour
 
 // Resource information.
 message Resource {
-  // Set of labels that describe the resource.
+  // Set of attributes that describe the resource.
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
 
   // dropped_attributes_count is the number of dropped attributes. If the value is 0, then

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -185,6 +185,8 @@ message Span {
   //
   // The OpenTelemetry API specification further restricts the allowed value types:
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
 
   // dropped_attributes_count is the number of attributes that were discarded. Attributes
@@ -203,6 +205,8 @@ message Span {
     string name = 2;
 
     // attributes is a collection of attribute key/value pairs on the event.
+    // Attribute keys MUST be unique (it is not allowed to have more than one
+    // attribute with the same key).
     repeated opentelemetry.proto.common.v1.KeyValue attributes = 3;
 
     // dropped_attributes_count is the number of dropped attributes. If the value is 0,
@@ -233,6 +237,8 @@ message Span {
     string trace_state = 3;
 
     // attributes is a collection of attribute key/value pairs on the link.
+    // Attribute keys MUST be unique (it is not allowed to have more than one
+    // attribute with the same key).
     repeated opentelemetry.proto.common.v1.KeyValue attributes = 4;
 
     // dropped_attributes_count is the number of dropped attributes. If the value is 0,


### PR DESCRIPTION
Attributes keys must be unique. The key/value pair list in the protocol
was always intended to model a map.

Contributes to https://github.com/open-telemetry/opentelemetry-specification/issues/2245