### PR TITLE
Rename logs to log_records in InstrumentationLibraryLogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Full list of differences found in [this compare](https://github.com/open-telemet
 
 ### Changed
 
-* Remove if no changes for this section before release.
+* Rename logs to log_records in InstrumentationLibraryLogs. (#352)
 
 ### Added
 

--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -66,7 +66,7 @@ message InstrumentationLibraryLogs {
   opentelemetry.proto.common.v1.InstrumentationLibrary instrumentation_library = 1;
 
   // A list of log records.
-  repeated LogRecord logs = 2;
+  repeated LogRecord log_records = 2;
 
   // This schema_url applies to all logs in the "logs" field.
   string schema_url = 3;


### PR DESCRIPTION
The renaming is to ensure consistency in how fields are named. We use pluralized
name of the message type elsewhere, so let's use it here as well.

Resolves https://github.com/open-telemetry/opentelemetry-proto/issues/317