### PR TITLE
Rename equals to equals_to

### DIFF
--- a/opentelemetry/proto/metrics/experimental/metrics_config_service.proto
+++ b/opentelemetry/proto/metrics/experimental/metrics_config_service.proto
@@ -70,7 +70,7 @@ message MetricConfigResponse {
     // match against metric names. It should not exceed 100k characters.
     message Pattern {
       oneof match {
-        string equals = 1;       // matches the metric name exactly
+        string equals_to = 1;       // matches the metric name exactly
         string starts_with = 2;  // prefix-matches the metric name
       }
     }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-proto/issues/355

In code generated for C# the property name Equals conflicts with the Equals
method present on the base type that all types in C# derive from. This
results in uncompilable code.