### PR TITLE
Deprecate LogRecord.Name field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Full list of differences found in [this compare](https://github.com/open-telemet
 
 ### Removed
 
-* Remove if no changes for this section before release.
+* Deprecate LogRecord.Name field. (#357)
 
 ## 0.12.0 - 2022-01-19
 

--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -127,7 +127,8 @@ message LogRecord {
   // Short event identifier that does not contain varying parts. Name describes
   // what happened (e.g. "ProcessStarted"). Recommended to be no longer than 50
   // characters. Not guaranteed to be unique in any way. [Optional].
-  string name = 4;
+  // This deprecated field is planned to be removed March 1, 2022.
+  string name = 4 [deprecated = true];
 
   // A value containing the body of the log record. Can be for example a human-readable
   // string message (including multi-line) describing the event in a free form or it can

--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -127,7 +127,8 @@ message LogRecord {
   // Short event identifier that does not contain varying parts. Name describes
   // what happened (e.g. "ProcessStarted"). Recommended to be no longer than 50
   // characters. Not guaranteed to be unique in any way. [Optional].
-  // This deprecated field is planned to be removed March 1, 2022.
+  // This deprecated field is planned to be removed March 15, 2022. Receivers can
+  // ignore this field.
   string name = 4 [deprecated = true];
 
   // A value containing the body of the log record. Can be for example a human-readable


### PR DESCRIPTION
The field is removed from the spec: https://github.com/open-telemetry/opentelemetry-specification/pull/2271

I am deprecating it for now, to give some time to existing users to get rid
of it (most notably in the Collector).

This will be removed soon (after the Collector cleanup).