### PR TITLE
Fix path to Go packages

### DIFF
--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -24,7 +24,7 @@ import "opentelemetry/proto/logs/v1/logs.proto";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.collector.logs.v1";
 option java_outer_classname = "LogsServiceProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/logs/v1";
+option go_package = "go.opentelemetry.io/proto/otlp/collector/logs/v1";
 
 // Service that can be used to push logs between one Application instrumented with
 // OpenTelemetry and an collector, or between an collector and a central collector (in this

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -21,7 +21,7 @@ import "opentelemetry/proto/metrics/v1/metrics.proto";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.collector.metrics.v1";
 option java_outer_classname = "MetricsServiceProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/metrics/v1";
+option go_package = "go.opentelemetry.io/proto/otlp/collector/metrics/v1";
 
 // Service that can be used to push metrics between one Application
 // instrumented with OpenTelemetry and a collector, or between a collector and a

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -21,7 +21,7 @@ import "opentelemetry/proto/trace/v1/trace.proto";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.collector.trace.v1";
 option java_outer_classname = "TraceServiceProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/trace/v1";
+option go_package = "go.opentelemetry.io/proto/otlp/collector/trace/v1";
 
 // Service that can be used to push spans between one Application instrumented with
 // OpenTelemetry and a collector, or between a collector and a central collector (in this

--- a/opentelemetry/proto/common/v1/common.proto
+++ b/opentelemetry/proto/common/v1/common.proto
@@ -19,7 +19,7 @@ package opentelemetry.proto.common.v1;
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.common.v1";
 option java_outer_classname = "CommonProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1";
+option go_package = "go.opentelemetry.io/proto/otlp/common/v1";
 
 // AnyValue is used to represent any type of attribute value. AnyValue may contain a
 // primitive value such as a string or integer or it may contain an arbitrary nested

--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -22,7 +22,7 @@ import "opentelemetry/proto/resource/v1/resource.proto";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.logs.v1";
 option java_outer_classname = "LogsProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/logs/v1";
+option go_package = "go.opentelemetry.io/proto/otlp/logs/v1";
 
 // LogsData represents the logs data that can be stored in a persistent storage,
 // OR can be embedded by other protocols that transfer OTLP logs data but do not

--- a/opentelemetry/proto/metrics/experimental/metrics_config_service.proto
+++ b/opentelemetry/proto/metrics/experimental/metrics_config_service.proto
@@ -21,7 +21,7 @@ import "opentelemetry/proto/resource/v1/resource.proto";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.metrics.experimental";
 option java_outer_classname = "MetricConfigServiceProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/experimental";
+option go_package = "go.opentelemetry.io/proto/otlp/metrics/experimental";
 
 // MetricConfig is a service that enables updating metric schedules, trace
 // parameters, and other configurations on the SDK without having to restart the

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -22,7 +22,7 @@ import "opentelemetry/proto/resource/v1/resource.proto";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.metrics.v1";
 option java_outer_classname = "MetricsProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/v1";
+option go_package = "go.opentelemetry.io/proto/otlp/metrics/v1";
 
 // MetricsData represents the metrics data that can be stored in a persistent
 // storage, OR can be embedded by other protocols that transfer OTLP metrics

--- a/opentelemetry/proto/resource/v1/resource.proto
+++ b/opentelemetry/proto/resource/v1/resource.proto
@@ -21,7 +21,7 @@ import "opentelemetry/proto/common/v1/common.proto";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.resource.v1";
 option java_outer_classname = "ResourceProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/resource/v1";
+option go_package = "go.opentelemetry.io/proto/otlp/resource/v1";
 
 // Resource information.
 message Resource {

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -22,7 +22,7 @@ import "opentelemetry/proto/resource/v1/resource.proto";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.trace.v1";
 option java_outer_classname = "TraceProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/trace/v1";
+option go_package = "go.opentelemetry.io/proto/otlp/trace/v1";
 
 // TracesData represents the traces data that can be stored in a persistent storage,
 // OR can be embedded by other protocols that transfer OTLP traces data but do

--- a/opentelemetry/proto/trace/v1/trace_config.proto
+++ b/opentelemetry/proto/trace/v1/trace_config.proto
@@ -19,7 +19,7 @@ package opentelemetry.proto.trace.v1;
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.trace.v1";
 option java_outer_classname = "TraceConfigProto";
-option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/trace/v1";
+option go_package = "go.opentelemetry.io/proto/otlp/collector/trace/v1";
 
 // Global configuration of the trace service. All fields must be specified, or
 // the default (zero) values will be used for each type.


### PR DESCRIPTION
The go pacakges now correctly point to https://github.com/open-telemetry/opentelemetry-proto-go
repository where we have the generated files for Go.

Resolves https://github.com/open-telemetry/opentelemetry-proto/issues/353