### PR TITLE
Declare logs Stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ metrics/\*<br>collector/metrics/*    | Stable   |
 resource/*                           | Stable   |
 trace/trace.proto<br>collector/trace/* | Stable   |
 trace/trace_config.proto             | Alpha    |
-logs/\*<br>collector/logs/*          | Beta     |
+logs/\*<br>collector/logs/*          | Stable   |
 **JSON encoding**                    |          |
 All messages                         | Alpha    |
 


### PR DESCRIPTION
The log data model is now declared Stable: https://github.com/open-telemetry/opentelemetry-specification/pull/2387

The OTLP proto in this repository now matches the log data model
in the specification.

This PR declares OTLP proto for logs Stable as well.

--

Please review the messages related to logs in this repository and make sure they match the log data model in the spec.
If you have any other concerns with regards to declaring the logs Stable please voice them.