### PR TITLE
Make it possible to indicate partial success in an OTLP export response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Full list of differences found in [this compare](https://github.com/open-telemet
 ### Added
 
 * Introduce Scope Attributes. [#395](https://github.com/open-telemetry/opentelemetry-proto/pull/395)
+* Introduce partial success fields in `Export*ServiceResponse`.
+ [#390](https://github.com/open-telemetry/opentelemetry-proto/pull/390)
 
 ### Removed
 

--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -56,7 +56,16 @@ message ExportLogsServiceResponse {
 
 message ExportLogsPartialSuccess {
   // The number of accepted log records
-  int64 accepted_log_records = 1;
+  //
+  // If the request is partially successful and the number of
+  // accepted log records is known, the server MUST set
+  // the accepted_log_records field.
+  // 
+  // The value '0' indicates that all log records were dropped by the server.
+  //
+  // Since the value '0' is meaningful, the field is marked as 'optional'
+  // so it is possible to distinguish between the not set value and the default.
+  optional int64 accepted_log_records = 1;
 
   // A developer-facing human-readable error message in English. It should
   // explain why the server rejected parts of the data,

--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -44,9 +44,13 @@ message ExportLogsServiceRequest {
 
 message ExportLogsServiceResponse {
   // The details of a partially successful export request.
-  // When the request is only partially successful (due to e.g. invalid/bad data),
-  // the server MUST populate the partial_success property with a
-  // developer-facing error message along with the number of accepted log records.
+  // If the processing of the request is partially successful
+  // (i.e. when the server accepts only parts of the data and rejects the rest)
+  // and the number of accepted log records is known, the server MUST initialize
+  // the partial_success field and MUST set the accepted_log_records.
+
+  // When the export request is processed successfully, the server MUST leave
+  // the partial_success field unset.
   ExportLogsPartialSuccess partial_success = 1;
 }
 
@@ -55,6 +59,7 @@ message ExportLogsPartialSuccess {
   int64 accepted_log_records = 1;
 
   // A developer-facing human-readable error message in English. It should
-  // both explain the error and offer an actionable resolution to it.
-  string error_message = 2;
+  // explain why the server rejected parts of the data,
+  // and might offer guidance on how users can address the issues.
+  optional string error_message = 2;
 }

--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -42,4 +42,18 @@ message ExportLogsServiceRequest {
 }
 
 message ExportLogsServiceResponse {
+  // The details of a partially successfull export request.
+  // When the request is only partially successfull (due to e.g. invalid/bad data),
+  // the server MUST populate the details property with a developer-facing error
+  // message along with the number of accepted log records.
+  ExportLogsPartialSuccess details = 1;
+}
+
+message ExportLogsPartialSuccess {
+  // The number of accepted log records
+  int64 accepted_log_records = 1;
+
+  // A developer-facing human-readable error message in English. It should
+  // both explain the error and offer an actionable resolution to it.
+  string error_message = 2;
 }

--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -61,5 +61,8 @@ message ExportLogsPartialSuccess {
   // A developer-facing human-readable error message in English. It should
   // explain why the server rejected parts of the data,
   // and might offer guidance on how users can address the issues.
-  optional string error_message = 2;
+  //
+  // error_message is an optional field. An error_message with an empty value
+  // is equivalent of it not being set.
+  string error_message = 2;
 }

--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -42,11 +42,11 @@ message ExportLogsServiceRequest {
 }
 
 message ExportLogsServiceResponse {
-  // The details of a partially successfull export request.
-  // When the request is only partially successfull (due to e.g. invalid/bad data),
-  // the server MUST populate the details property with a developer-facing error
-  // message along with the number of accepted log records.
-  ExportLogsPartialSuccess details = 1;
+  // The details of a partially successful export request.
+  // When the request is only partially successful (due to e.g. invalid/bad data),
+  // the server MUST populate the partial_success property with a
+  // developer-facing error message along with the number of accepted log records.
+  ExportLogsPartialSuccess partial_success = 1;
 }
 
 message ExportLogsPartialSuccess {

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -61,5 +61,8 @@ message ExportMetricsPartialSuccess {
   // A developer-facing human-readable error message in English. It should
   // explain why the server rejected parts of the data,
   // and might offer guidance on how users can address the issues.
-  optional string error_message = 2;
+  //
+  // error_message is an optional field. An error_message with an empty value
+  // is equivalent of it not being set.
+  string error_message = 2;
 }

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -42,4 +42,18 @@ message ExportMetricsServiceRequest {
 }
 
 message ExportMetricsServiceResponse {
+  // The details of a partially successfull export request.
+  // When the request is only partially successfull (due to e.g. invalid/bad data),
+  // the server MUST populate the details property with a developer-facing error
+  // message along with the number of accepted data points.
+  ExportMetricsPartialSuccess details = 1;
+}
+
+message ExportMetricsPartialSuccess {
+  // The number of accepted data points
+  int64 accepted_data_points = 1;
+
+  // A developer-facing human-readable error message in English. It should
+  // both explain the error and offer an actionable resolution to it.
+  string error_message = 2;
 }

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -56,7 +56,16 @@ message ExportMetricsServiceResponse {
 
 message ExportMetricsPartialSuccess {
   // The number of accepted data points
-  int64 accepted_data_points = 1;
+  //
+  // If the request is partially successful and the number of
+  // accepted data points is known, the server MUST set
+  // the accepted_data_points field.
+  // 
+  // The value '0' indicates that all data points were dropped by the server.
+  //
+  // Since the value '0' is meaningful, the field is marked as 'optional'
+  // so it is possible to distinguish between the not set value and the default.
+  optional int64 accepted_data_points = 1;
 
   // A developer-facing human-readable error message in English. It should
   // explain why the server rejected parts of the data,

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -44,9 +44,13 @@ message ExportMetricsServiceRequest {
 
 message ExportMetricsServiceResponse {
   // The details of a partially successful export request.
-  // When the request is only partially successful (due to e.g. invalid/bad data),
-  // the server MUST populate the partial_success property with a
-  // developer-facing error message along with the number of accepted data points.
+  // If the processing of the request is partially successful
+  // (i.e. when the server accepts only parts of the data and rejects the rest)
+  // and the number of accepted data points is known, the server MUST initialize
+  // the partial_success field and MUST set the accepted_data_points.
+
+  // When the export request is processed successfully, the server MUST leave
+  // the partial_success field unset.
   ExportMetricsPartialSuccess partial_success = 1;
 }
 
@@ -55,6 +59,7 @@ message ExportMetricsPartialSuccess {
   int64 accepted_data_points = 1;
 
   // A developer-facing human-readable error message in English. It should
-  // both explain the error and offer an actionable resolution to it.
-  string error_message = 2;
+  // explain why the server rejected parts of the data,
+  // and might offer guidance on how users can address the issues.
+  optional string error_message = 2;
 }

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -42,11 +42,11 @@ message ExportMetricsServiceRequest {
 }
 
 message ExportMetricsServiceResponse {
-  // The details of a partially successfull export request.
-  // When the request is only partially successfull (due to e.g. invalid/bad data),
-  // the server MUST populate the details property with a developer-facing error
-  // message along with the number of accepted data points.
-  ExportMetricsPartialSuccess details = 1;
+  // The details of a partially successful export request.
+  // When the request is only partially successful (due to e.g. invalid/bad data),
+  // the server MUST populate the partial_success property with a
+  // developer-facing error message along with the number of accepted data points.
+  ExportMetricsPartialSuccess partial_success = 1;
 }
 
 message ExportMetricsPartialSuccess {

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -61,5 +61,8 @@ message ExportTracePartialSuccess {
   // A developer-facing human-readable error message in English. It should
   // explain why the server rejected parts of the data,
   // and might offer guidance on how users can address the issues.
-  optional string error_message = 2;
+  //
+  // error_message is an optional field. An error_message with an empty value
+  // is equivalent of it not being set.
+  string error_message = 2;
 }

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -44,9 +44,13 @@ message ExportTraceServiceRequest {
 
 message ExportTraceServiceResponse {
   // The details of a partially successful export request.
-  // When the request is only partially successful (due to e.g. invalid/bad data),
-  // the server MUST populate the partial_success property with a
-  // developer-facing error message along with the number of accepted spans.
+  // If the processing of the request is partially successful
+  // (i.e. when the server accepts only parts of the data and rejects the rest)
+  // and the number of accepted spans is known, the server MUST initialize
+  // the partial_success field and MUST set the accepted_spans.
+
+  // When the export request is processed successfully, the server MUST leave
+  // the partial_success field unset.
   ExportTracePartialSuccess partial_success = 1;
 }
 
@@ -55,6 +59,7 @@ message ExportTracePartialSuccess {
   int64 accepted_spans = 1;
 
   // A developer-facing human-readable error message in English. It should
-  // both explain the error and offer an actionable resolution to it.
-  string error_message = 2;
+  // explain why the server rejected parts of the data,
+  // and might offer guidance on how users can address the issues.
+  optional string error_message = 2;
 }

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -56,7 +56,16 @@ message ExportTraceServiceResponse {
 
 message ExportTracePartialSuccess {
   // The number of accepted spans
-  int64 accepted_spans = 1;
+  //
+  // If the request is partially successful and the number of
+  // accepted spans is known, the server MUST set
+  // the accepted_spans field.
+  // 
+  // The value '0' indicates that all spans were dropped by the server.
+  //
+  // Since the value '0' is meaningful, the field is marked as 'optional'
+  // so it is possible to distinguish between the not set value and the default.
+  optional int64 accepted_spans = 1;
 
   // A developer-facing human-readable error message in English. It should
   // explain why the server rejected parts of the data,

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -42,11 +42,11 @@ message ExportTraceServiceRequest {
 }
 
 message ExportTraceServiceResponse {
-  // The details of a partially successfull export request.
-  // When the request is only partially successfull (due to e.g. invalid/bad data),
-  // the server MUST populate the details property with a developer-facing error
-  // message along with the number of accepted spans.
-  ExportTracePartialSuccess details = 1;
+  // The details of a partially successful export request.
+  // When the request is only partially successful (due to e.g. invalid/bad data),
+  // the server MUST populate the partial_success property with a
+  // developer-facing error message along with the number of accepted spans.
+  ExportTracePartialSuccess partial_success = 1;
 }
 
 message ExportTracePartialSuccess {

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -42,4 +42,18 @@ message ExportTraceServiceRequest {
 }
 
 message ExportTraceServiceResponse {
+  // The details of a partially successfull export request.
+  // When the request is only partially successfull (due to e.g. invalid/bad data),
+  // the server MUST populate the details property with a developer-facing error
+  // message along with the number of accepted spans.
+  ExportTracePartialSuccess details = 1;
+}
+
+message ExportTracePartialSuccess {
+  // The number of accepted spans
+  int64 accepted_spans = 1;
+
+  // A developer-facing human-readable error message in English. It should
+  // both explain the error and offer an actionable resolution to it.
+  string error_message = 2;
 }


### PR DESCRIPTION
This PR is a first attempt in solving/addressing https://github.com/open-telemetry/opentelemetry-specification/issues/2454.

At first, I tried having "top-level" properties under the `Export*ServiceResponse` types like so:

```proto
message ExportMetricsServiceResponse {
  optional int64 accepted_data_points = 1;
  optional string error_message = 2;
}
```

But in my view, this has a drawback. OTLP exporters/senders using the new protos would have to always check the [explicit presence](https://github.com/protocolbuffers/protobuf/blob/main/docs/field_presence.md?rgh-link-date=2022-04-27T13%3A13%3A21Z#presence-in-proto3-apis) of the new fields (e.g. `HasAcceptedDatapoints`) since they don't know which proto version the server is using. Also, since there's more than one field, would it need to check both? What if we add new fields later?

Then I thought having a new type that combines these two new fields is a better compromise. This way, it only needs to check if the new field is not null. If it's not null, we can have some guarantee that the other fields are there (we indicate it with a MUST in the spec, for ex)

I did some tests with sample apps to confirm the cases for backwards compatibility: (code here [joaopgrassi/otlp-partial-success-experimental](https://github.com/joaopgrassi/otlp-partial-success-experimental)).

## 1. Old exporters working with receivers/servers using the new protos

All works, as the exporters were not expecting the new fields. They will not have the fields, so they can't inform the user of a partial success - status quo.

## 2. New exporters working with receivers/servers using the old protos

Exporters MUST check if the `Details` field is not null to be able to log a message with the details for troubleshooting.

```csharp
var client = new MetricsService.MetricsServiceClient(channel);
var req = new ExportMetricsServiceRequest();
var response = client.Export(req);

if (response.Details != null)
{
	Console.WriteLine("Number of lines accepted: {0}", response.Details.AcceptedDataPoints);
	Console.WriteLine("Error message: {0}", response.Details.ErrorMessage);
}
```

## 3. New exporters working with receivers/servers using the new protos

Since exporters don't know the proto version servers are sending back, it always have to perform the check on point 2 above.

