### PR TITLE
Make the exponential histogram sum optional, like its counterpart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Full list of differences found in [this compare](https://github.com/open-telemet
 ### Changed
 
 * Metrics ExponentialHistogramDataPoint makes the `sum` optional
-  (follows the same change in HistogramDataPOint in 0.15).
+  (follows the same change in HistogramDataPOint in 0.15). [#392](https://github.com/open-telemetry/opentelemetry-proto/pull/392)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Full list of differences found in [this compare](https://github.com/open-telemet
 
 ### Changed
 
-* Remove if no changes for this section before release.
+* Metrics ExponentialHistogramDataPoint makes the `sum` optional
+  (follows the same change in HistogramDataPOint in 0.15).
 
 ### Added
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -538,7 +538,7 @@ message ExponentialHistogramDataPoint {
   // Negative events *can* be recorded, but sum should not be filled out when
   // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
   // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
-  double sum = 5;
+  optional double sum = 5;
   
   // scale describes the resolution of the histogram.  Boundaries are
   // located at powers of the base, where:


### PR DESCRIPTION
The OTLP exponential histogram data point should resemble the histogram data point. When the sum was made optional in v0.15, it should have applied to both points. This corrects the problem.