### PR TITLE
add protoc-gen-swift to Makefile to update proto files for opentelemetry-swift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endef
 
 # Generate all implementations
 .PHONY: gen-all
-gen-all: gen-cpp gen-csharp gen-go gen-java gen-kotlin gen-objc gen-openapi gen-php gen-python gen-ruby
+gen-all: gen-cpp gen-csharp gen-go gen-java gen-kotlin gen-objc gen-openapi gen-php gen-python gen-ruby gen-swift
 
 OTEL_DOCKER_PROTOBUF ?= otel/build-protobuf:0.9.0
 PROTOC := docker run --rm -u ${shell id -u} -v${PWD}:${PWD} -w${PWD} ${OTEL_DOCKER_PROTOBUF} --proto_path=${PWD}
@@ -31,6 +31,7 @@ PROTO_GEN_OPENAPI_DIR ?= $(GENDIR)/openapi
 PROTO_GEN_PHP_DIR ?= $(GENDIR)/php
 PROTO_GEN_PYTHON_DIR ?= $(GENDIR)/python
 PROTO_GEN_RUBY_DIR ?= $(GENDIR)/ruby
+PROTO_GEN_SWIFT_DIR ?= $(GENDIR)/swift
 
 # Docker pull image.
 .PHONY: docker-pull
@@ -139,3 +140,13 @@ gen-ruby:
 	$(PROTOC) --ruby_out=./$(PROTO_GEN_RUBY_DIR) --grpc-ruby_out=./$(PROTO_GEN_RUBY_DIR) opentelemetry/proto/collector/trace/v1/trace_service.proto
 	$(PROTOC) --ruby_out=./$(PROTO_GEN_RUBY_DIR) --grpc-ruby_out=./$(PROTO_GEN_RUBY_DIR) opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(PROTOC) --ruby_out=./$(PROTO_GEN_RUBY_DIR) --grpc-ruby_out=./$(PROTO_GEN_RUBY_DIR) opentelemetry/proto/collector/logs/v1/logs_service.proto
+
+# Generate gRPC/Protobuf implementation for Swift.
+.PHONY: gen-swift
+gen-swift:
+	rm -rf ./$(PROTO_GEN_SWIFT_DIR)
+	mkdir -p ./$(PROTO_GEN_SWIFT_DIR)
+	$(foreach file,$(PROTO_FILES),$(call exec-command, $(PROTOC) --swift_out=./$(PROTO_GEN_SWIFT_DIR) $(file)))
+	$(PROTOC) --swift_out=./$(PROTO_GEN_SWIFT_DIR) --grpc-swift_out=./$(PROTO_GEN_SWIFT_DIR) opentelemetry/proto/collector/trace/v1/trace_service.proto
+	$(PROTOC) --swift_out=./$(PROTO_GEN_SWIFT_DIR) --grpc-swift_out=./$(PROTO_GEN_SWIFT_DIR) opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+	$(PROTOC) --swift_out=./$(PROTO_GEN_SWIFT_DIR) --grpc-swift_out=./$(PROTO_GEN_SWIFT_DIR) opentelemetry/proto/collector/logs/v1/logs_service.proto

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ To generate the raw gRPC client libraries, use `make gen-${LANGUAGE}`. Currently
 * php
 * python
 * ruby
+* swift
 
 ## Maturity Level
 


### PR DESCRIPTION
I would like to add a gen-swift task in the Makefile, so we can update the protobuf files for opentelemetry-swift when a change happens in the proto repo:
How do I add the swift's protoc (https://github.com/apple/swift-protobuf) in the build process. Looks like its using the docker image otel/build-protobuf . I get this error when I run `make gen-swift`

```
Please specify a program using absolute path or make sure the program is available in your PATH system variable
--swift_out: protoc-gen-swift: Plugin failed with status code 1.
make: *** [gen-swift] Error 1
```

The build is using a docker image otel/build-protobuf:0.9.0 which has protoc for other languages but not one for swift. How do I add swift's protoc (https://github.com/apple/swift-protobuf) so we can use it to build the protobuf files for swift as well?

Thanks
