### PR TITLE
Define csharp_namespace option

### DIFF
--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -18,6 +18,7 @@ package opentelemetry.proto.collector.logs.v1;
 
 import "opentelemetry/proto/logs/v1/logs.proto";
 
+option csharp_namespace = "OpenTelemetry.Proto.Collector.Logs.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.collector.logs.v1";
 option java_outer_classname = "LogsServiceProto";

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -18,6 +18,7 @@ package opentelemetry.proto.collector.metrics.v1;
 
 import "opentelemetry/proto/metrics/v1/metrics.proto";
 
+option csharp_namespace = "OpenTelemetry.Proto.Collector.Metrics.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.collector.metrics.v1";
 option java_outer_classname = "MetricsServiceProto";

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -18,6 +18,7 @@ package opentelemetry.proto.collector.trace.v1;
 
 import "opentelemetry/proto/trace/v1/trace.proto";
 
+option csharp_namespace = "OpenTelemetry.Proto.Collector.Trace.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.collector.trace.v1";
 option java_outer_classname = "TraceServiceProto";

--- a/opentelemetry/proto/common/v1/common.proto
+++ b/opentelemetry/proto/common/v1/common.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package opentelemetry.proto.common.v1;
 
+option csharp_namespace = "OpenTelemetry.Proto.Common.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.common.v1";
 option java_outer_classname = "CommonProto";

--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -19,6 +19,7 @@ package opentelemetry.proto.logs.v1;
 import "opentelemetry/proto/common/v1/common.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
+option csharp_namespace = "OpenTelemetry.Proto.Logs.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.logs.v1";
 option java_outer_classname = "LogsProto";

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -19,6 +19,7 @@ package opentelemetry.proto.metrics.v1;
 import "opentelemetry/proto/common/v1/common.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
+option csharp_namespace = "OpenTelemetry.Proto.Metrics.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.metrics.v1";
 option java_outer_classname = "MetricsProto";

--- a/opentelemetry/proto/resource/v1/resource.proto
+++ b/opentelemetry/proto/resource/v1/resource.proto
@@ -18,6 +18,7 @@ package opentelemetry.proto.resource.v1;
 
 import "opentelemetry/proto/common/v1/common.proto";
 
+option csharp_namespace = "OpenTelemetry.Proto.Resource.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.resource.v1";
 option java_outer_classname = "ResourceProto";

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -19,6 +19,7 @@ package opentelemetry.proto.trace.v1;
 import "opentelemetry/proto/common/v1/common.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
+option csharp_namespace = "OpenTelemetry.Proto.Trace.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.trace.v1";
 option java_outer_classname = "TraceProto";

--- a/opentelemetry/proto/trace/v1/trace_config.proto
+++ b/opentelemetry/proto/trace/v1/trace_config.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package opentelemetry.proto.trace.v1;
 
+option csharp_namespace = "OpenTelemetry.Proto.Collector.Trace.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.trace.v1";
 option java_outer_classname = "TraceConfigProto";


### PR DESCRIPTION
Fixes generated C# namespaces to have the prefix `OpenTelemetry` instead of `Opentelemetry`