### PR TITLE
Fix urls which can not access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Full list of differences found in [this compare](https://github.com/open-telemet
 
 * Add `csharp_namespace` option to protos.
   ([#399](https://github.com/open-telemetry/opentelemetry-proto/pull/399))
+* Fix some out-of-date urls which link to [specification](https://github.com/open-telemetry/opentelemetry-specification). ([#402](https://github.com/open-telemetry/opentelemetry-proto/pull/402))
 
 ### Added
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -123,7 +123,7 @@ message InstrumentationLibraryMetrics {
 // Defines a Metric which has one or more timeseries.  The following is a
 // brief summary of the Metric data model.  For more details, see:
 //
-//   https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md
+//   https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md
 //
 //
 // The data model and relation between entities is shown in the

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -232,7 +232,7 @@ message Span {
   //     "abc.com/score": 10.239
   //
   // The OpenTelemetry API specification further restricts the allowed value types:
-  // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;


### PR DESCRIPTION
- Fix some out-of-date urls which link to [specification](https://github.com/open-telemetry/opentelemetry-specification).
- .../metrics/datamodel.md -> .../metrics/data-model.md
- .../common/common.md#attributes -> .../common/README.md#attribute