### PR TITLE
Ensure helper enums are consistently declared

### DIFF
--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -152,8 +152,8 @@ enum SeverityNumber {
 
 // Masks for LogRecord.flags field.
 enum LogRecordFlags {
-  LOG_RECORD_FLAG_UNSPECIFIED = 0;
-  LOG_RECORD_FLAG_TRACE_FLAGS_MASK = 0x000000FF;
+  LOG_RECORD_FLAGS_UNSPECIFIED = 0;
+  LOG_RECORD_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
 }
 
 // A log record according to OpenTelemetry Log Data Model:

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -362,15 +362,15 @@ enum AggregationTemporality {
 // enum is a bit-mask.  To test the presence of a single flag in the flags of
 // a data point, for example, use an expression like:
 //
-//   (point.flags & FLAG_NO_RECORDED_VALUE) == FLAG_NO_RECORDED_VALUE
+//   (point.flags & DATA_POINTS_FLAGS_NO_RECORDED_VALUE) == DATA_POINTS_FLAGS_NO_RECORDED_VALUE
 //
 enum DataPointFlags {
-  FLAG_NONE = 0;
+  DATA_POINTS_FLAGS_NONE = 0;
 
   // This DataPoint is valid but has no recorded value.  This value
   // SHOULD be used to reflect explicitly missing data in a series, as
   // for an equivalent to the Prometheus "staleness marker".
-  FLAG_NO_RECORDED_VALUE = 1;
+  DATA_POINTS_FLAGS_NO_RECORDED_VALUE = 1;
 
   // Bits 2-31 are reserved for future use.
 }


### PR DESCRIPTION
The changes in this PR do not affect wire formats in any way
since these are helper enums. This is not a breaking change
for the protocol.

This is a breaking change for the generated code.

This change is the smaller subset of https://github.com/open-telemetry/opentelemetry-proto/pull/397