### PR TITLE
Use short keys for OTLP/JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Full list of differences found in [this compare](https://github.com/open-telemet
   InstrumentationLibraryMetrics messages. Delete deprecated
   instrumentation_library_logs, instrumentation_library_spans and
   instrumentation_library_metrics fields.
+* :stop_sign: [BREAKING] Use short keys for OTLP/JSON.
 
 ### Added
 

--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -39,7 +39,7 @@ message ExportLogsServiceRequest {
   // element. Intermediary nodes (such as OpenTelemetry Collector) that receive
   // data from multiple origins typically batch the data before forwarding further and
   // in that case this array will contain multiple elements.
-  repeated opentelemetry.proto.logs.v1.ResourceLogs resource_logs = 1;
+  repeated opentelemetry.proto.logs.v1.ResourceLogs resource_logs = 1 [json_name="l"];
 }
 
 message ExportLogsServiceResponse {

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -39,7 +39,7 @@ message ExportMetricsServiceRequest {
   // element. Intermediary nodes (such as OpenTelemetry Collector) that receive
   // data from multiple origins typically batch the data before forwarding further and
   // in that case this array will contain multiple elements.
-  repeated opentelemetry.proto.metrics.v1.ResourceMetrics resource_metrics = 1;
+  repeated opentelemetry.proto.metrics.v1.ResourceMetrics resource_metrics = 1 [json_name="m"];
 }
 
 message ExportMetricsServiceResponse {

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -39,7 +39,7 @@ message ExportTraceServiceRequest {
   // element. Intermediary nodes (such as OpenTelemetry Collector) that receive
   // data from multiple origins typically batch the data before forwarding further and
   // in that case this array will contain multiple elements.
-  repeated opentelemetry.proto.trace.v1.ResourceSpans resource_spans = 1;
+  repeated opentelemetry.proto.trace.v1.ResourceSpans resource_spans = 1 [json_name="s"];
 }
 
 message ExportTraceServiceResponse {

--- a/opentelemetry/proto/common/v1/common.proto
+++ b/opentelemetry/proto/common/v1/common.proto
@@ -29,13 +29,13 @@ message AnyValue {
   // The value is one of the listed fields. It is valid for all values to be unspecified
   // in which case this AnyValue is considered to be "empty".
   oneof value {
-    string string_value = 1;
-    bool bool_value = 2;
-    int64 int_value = 3;
-    double double_value = 4;
-    ArrayValue array_value = 5;
-    KeyValueList kvlist_value = 6;
-    bytes bytes_value = 7;
+    string string_value = 1 [json_name="s"];
+    bool bool_value = 2 [json_name="b"];
+    int64 int_value = 3 [json_name="i"];
+    double double_value = 4 [json_name="d"];
+    ArrayValue array_value = 5 [json_name="a"];
+    KeyValueList kvlist_value = 6 [json_name="l"];
+    bytes bytes_value = 7 [json_name="by"];
   }
 }
 
@@ -43,7 +43,7 @@ message AnyValue {
 // since oneof in AnyValue does not allow repeated fields.
 message ArrayValue {
   // Array of values. The array may be empty (contain 0 elements).
-  repeated AnyValue values = 1;
+  repeated AnyValue values = 1 [json_name="v"];
 }
 
 // KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
@@ -56,22 +56,22 @@ message KeyValueList {
   // contain 0 elements).
   // The keys MUST be unique (it is not allowed to have more than one
   // value with the same key).
-  repeated KeyValue values = 1;
+  repeated KeyValue values = 1 [json_name="v"];
 }
 
 // KeyValue is a key-value pair that is used to store Span attributes, Link
 // attributes, etc.
 message KeyValue {
-  string key = 1;
-  AnyValue value = 2;
+  string key = 1 [json_name="k"];
+  AnyValue value = 2 [json_name="v"];
 }
 
 // InstrumentationScope is a message representing the instrumentation scope information
 // such as the fully qualified name and version. 
 message InstrumentationScope {
   // An empty instrumentation scope name means the name is unknown.
-  string name = 1;
-  string version = 2;
-  repeated KeyValue attributes = 3;
-  uint32 dropped_attributes_count = 4;
+  string name = 1 [json_name="n"];
+  string version = 2 [json_name="v"];
+  repeated KeyValue attributes = 3 [json_name="a"];
+  uint32 dropped_attributes_count = 4 [json_name="da"];
 }

--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -41,7 +41,7 @@ message LogsData {
   // one element. Intermediary nodes that receive data from multiple origins
   // typically batch the data before forwarding further and in that case this
   // array will contain multiple elements.
-  repeated ResourceLogs resource_logs = 1;
+  repeated ResourceLogs resource_logs = 1 [json_name="l"];
 }
 
 // A collection of ScopeLogs from a Resource.
@@ -50,14 +50,14 @@ message ResourceLogs {
 
   // The resource for the logs in this message.
   // If this field is not set then resource info is unknown.
-  opentelemetry.proto.resource.v1.Resource resource = 1;
+  opentelemetry.proto.resource.v1.Resource resource = 1 [json_name="r"];
 
   // A list of ScopeLogs that originate from a resource.
-  repeated ScopeLogs scope_logs = 2;
+  repeated ScopeLogs scope_logs = 2 [json_name="l"];
 
   // This schema_url applies to the data in the "resource" field. It does not apply
   // to the data in the "scope_logs" field which have their own schema_url field.
-  string schema_url = 3;
+  string schema_url = 3 [json_name="u"];
 }
 
 // A collection of Logs produced by a Scope.
@@ -65,13 +65,13 @@ message ScopeLogs {
   // The instrumentation scope information for the logs in this message.
   // Semantically when InstrumentationScope isn't set, it is equivalent with
   // an empty instrumentation scope name (unknown).
-  opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
+  opentelemetry.proto.common.v1.InstrumentationScope scope = 1 [json_name="i"];
 
   // A list of log records.
-  repeated LogRecord log_records = 2;
+  repeated LogRecord log_records = 2 [json_name="l"];
 
   // This schema_url applies to all logs in the "logs" field.
-  string schema_url = 3;
+  string schema_url = 3 [json_name="u"];
 }
 
 // Possible values for LogRecord.SeverityNumber.
@@ -118,7 +118,7 @@ message LogRecord {
   // time_unix_nano is the time when the event occurred.
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   // Value of 0 indicates unknown or missing timestamp.
-  fixed64 time_unix_nano = 1;
+  fixed64 time_unix_nano = 1 [json_name="t"];
 
   // Time when the event was observed by the collection system.
   // For events that originate in OpenTelemetry (e.g. using OpenTelemetry Logging SDK)
@@ -135,43 +135,43 @@ message LogRecord {
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   // Value of 0 indicates unknown or missing timestamp.
-  fixed64 observed_time_unix_nano = 11;
+  fixed64 observed_time_unix_nano = 11 [json_name="o"];
 
   // Numerical value of the severity, normalized to values described in Log Data Model.
   // [Optional].
-  SeverityNumber severity_number = 2;
+  SeverityNumber severity_number = 2 [json_name="sn"];
 
   // The severity text (also known as log level). The original string representation as
   // it is known at the source. [Optional].
-  string severity_text = 3;
+  string severity_text = 3 [json_name="st"];
 
   // A value containing the body of the log record. Can be for example a human-readable
   // string message (including multi-line) describing the event in a free form or it can
   // be a structured data composed of arrays and maps of other values. [Optional].
-  opentelemetry.proto.common.v1.AnyValue body = 5;
+  opentelemetry.proto.common.v1.AnyValue body = 5 [json_name="b"];
 
   // Additional attributes that describe the specific event occurrence. [Optional].
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  repeated opentelemetry.proto.common.v1.KeyValue attributes = 6;
-  uint32 dropped_attributes_count = 7;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 6 [json_name="a"];
+  uint32 dropped_attributes_count = 7 [json_name="da"];
 
   // Flags, a bit field. 8 least significant bits are the trace flags as
   // defined in W3C Trace Context specification. 24 most significant bits are reserved
   // and must be set to 0. Readers must not assume that 24 most significant bits
   // will be zero and must correctly mask the bits when reading 8-bit trace flag (use
   // flags & TRACE_FLAGS_MASK). [Optional].
-  fixed32 flags = 8;
+  fixed32 flags = 8 [json_name="f"];
 
   // A unique identifier for a trace. All logs from the same trace share
   // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes
   // is considered invalid. Can be set for logs that are part of request processing
   // and have an assigned trace id. [Optional].
-  bytes trace_id = 9;
+  bytes trace_id = 9 [json_name="ti"];
 
   // A unique identifier for a span within a trace, assigned when the span
   // is created. The ID is an 8-byte array. An ID with all zeroes is considered
   // invalid. Can be set for logs that are part of a particular processing span.
   // If span_id is present trace_id SHOULD be also present. [Optional].
-  bytes span_id = 10;
+  bytes span_id = 10 [json_name="si"];
 }

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -41,7 +41,7 @@ message MetricsData {
   // one element. Intermediary nodes that receive data from multiple origins
   // typically batch the data before forwarding further and in that case this
   // array will contain multiple elements.
-  repeated ResourceMetrics resource_metrics = 1;
+  repeated ResourceMetrics resource_metrics = 1 [json_name="m"];
 }
 
 // A collection of ScopeMetrics from a Resource.
@@ -50,14 +50,14 @@ message ResourceMetrics {
 
   // The resource for the metrics in this message.
   // If this field is not set then no resource info is known.
-  opentelemetry.proto.resource.v1.Resource resource = 1;
+  opentelemetry.proto.resource.v1.Resource resource = 1 [json_name="r"];
 
   // A list of metrics that originate from a resource.
-  repeated ScopeMetrics scope_metrics = 2;
+  repeated ScopeMetrics scope_metrics = 2 [json_name="m"];
 
   // This schema_url applies to the data in the "resource" field. It does not apply
   // to the data in the "scope_metrics" field which have their own schema_url field.
-  string schema_url = 3;
+  string schema_url = 3 [json_name="u"];
 }
 
 // A collection of Metrics produced by an Scope.
@@ -65,13 +65,13 @@ message ScopeMetrics {
   // The instrumentation scope information for the metrics in this message.
   // Semantically when InstrumentationScope isn't set, it is equivalent with
   // an empty instrumentation scope name (unknown).
-  opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
+  opentelemetry.proto.common.v1.InstrumentationScope scope = 1 [json_name="i"];
 
   // A list of metrics that originate from an instrumentation library.
-  repeated Metric metrics = 2;
+  repeated Metric metrics = 2 [json_name="m"];
 
   // This schema_url applies to all metrics in the "metrics" field.
-  string schema_url = 3;
+  string schema_url = 3 [json_name="u"];
 }
 
 // Defines a Metric which has one or more timeseries.  The following is a
@@ -163,24 +163,24 @@ message Metric {
   reserved 4, 6, 8;
 
   // name of the metric, including its DNS name prefix. It must be unique.
-  string name = 1;
+  string name = 1 [json_name="n"];
 
   // description of the metric, which can be used in documentation.
-  string description = 2;
+  string description = 2 [json_name="d"];
 
   // unit in which the metric value is reported. Follows the format
   // described by http://unitsofmeasure.org/ucum.html.
-  string unit = 3;
+  string unit = 3 [json_name="u"];
 
   // Data determines the aggregation type (if any) of the metric, what is the
   // reported value type for the data points, as well as the relatationship to
   // the time interval over which they are reported.
   oneof data {
-    Gauge gauge = 5;
-    Sum sum = 7;
-    Histogram histogram = 9;
-    ExponentialHistogram exponential_histogram = 10;
-    Summary summary = 11;
+    Gauge gauge = 5 [json_name="g"];
+    Sum sum = 7 [json_name="s"];
+    Histogram histogram = 9 [json_name="h"];
+    ExponentialHistogram exponential_histogram = 10 [json_name="eh"];
+    Summary summary = 11 [json_name="su"];
   }
 }
 
@@ -194,40 +194,40 @@ message Metric {
 // AggregationTemporality is not included. Consequently, this also means
 // "StartTimeUnixNano" is ignored for all data points.
 message Gauge {
-  repeated NumberDataPoint data_points = 1;
+  repeated NumberDataPoint data_points = 1 [json_name="d"];
 }
 
 // Sum represents the type of a scalar metric that is calculated as a sum of all
 // reported measurements over a time interval.
 message Sum {
-  repeated NumberDataPoint data_points = 1;
+  repeated NumberDataPoint data_points = 1 [json_name="d"];
 
   // aggregation_temporality describes if the aggregator reports delta changes
   // since last report time, or cumulative changes since a fixed start time.
-  AggregationTemporality aggregation_temporality = 2;
+  AggregationTemporality aggregation_temporality = 2 [json_name="a"];
 
   // If "true" means that the sum is monotonic.
-  bool is_monotonic = 3;
+  bool is_monotonic = 3 [json_name="m"];
 }
 
 // Histogram represents the type of a metric that is calculated by aggregating
 // as a Histogram of all reported measurements over a time interval.
 message Histogram {
-  repeated HistogramDataPoint data_points = 1;
+  repeated HistogramDataPoint data_points = 1 [json_name="d"];
 
   // aggregation_temporality describes if the aggregator reports delta changes
   // since last report time, or cumulative changes since a fixed start time.
-  AggregationTemporality aggregation_temporality = 2;
+  AggregationTemporality aggregation_temporality = 2 [json_name="a"];
 }
 
 // ExponentialHistogram represents the type of a metric that is calculated by aggregating
 // as a ExponentialHistogram of all reported double measurements over a time interval.
 message ExponentialHistogram {
-  repeated ExponentialHistogramDataPoint data_points = 1;
+  repeated ExponentialHistogramDataPoint data_points = 1 [json_name="d"];
 
   // aggregation_temporality describes if the aggregator reports delta changes
   // since last report time, or cumulative changes since a fixed start time.
-  AggregationTemporality aggregation_temporality = 2;
+  AggregationTemporality aggregation_temporality = 2 [json_name="a"];
 }
 
 // Summary metric data are used to convey quantile summaries,
@@ -237,7 +237,7 @@ message ExponentialHistogram {
 // While they can be useful in some applications, histogram data points are
 // recommended for new applications.
 message Summary {
-  repeated SummaryDataPoint data_points = 1;
+  repeated SummaryDataPoint data_points = 1 [json_name="d"];
 }
 
 // AggregationTemporality defines how a metric aggregator reports aggregated
@@ -338,35 +338,35 @@ message NumberDataPoint {
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 7 [json_name="a"];
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
   // the detailed comments above Metric.
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.
-  fixed64 start_time_unix_nano = 2;
+  fixed64 start_time_unix_nano = 2 [json_name="s"];
 
   // TimeUnixNano is required, see the detailed comments above Metric.
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.
-  fixed64 time_unix_nano = 3;
+  fixed64 time_unix_nano = 3 [json_name="t"];
 
   // The value itself.  A point is considered invalid when one of the recognized
   // value fields is not present inside this oneof.
   oneof value {
-    double as_double = 4;
-    sfixed64 as_int = 6;
+    double as_double = 4 [json_name="d"];
+    sfixed64 as_int = 6 [json_name="i"];
   }
 
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point
-  repeated Exemplar exemplars = 5;
+  repeated Exemplar exemplars = 5 [json_name="e"];
 
   // Flags that apply to this specific data point.  See DataPointFlags
   // for the available flags and their meaning.
-  uint32 flags = 8;
+  uint32 flags = 8 [json_name="f"];
 }
 
 // HistogramDataPoint is a single data point in a timeseries that describes the
@@ -386,25 +386,25 @@ message HistogramDataPoint {
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 9 [json_name="a"];
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
   // the detailed comments above Metric.
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.
-  fixed64 start_time_unix_nano = 2;
+  fixed64 start_time_unix_nano = 2 [json_name="s"];
 
   // TimeUnixNano is required, see the detailed comments above Metric.
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.
-  fixed64 time_unix_nano = 3;
+  fixed64 time_unix_nano = 3 [json_name="t"];
 
   // count is the number of values in the population. Must be non-negative. This
   // value must be equal to the sum of the "count" fields in buckets if a
   // histogram is provided.
-  fixed64 count = 4;
+  fixed64 count = 4 [json_name="c"];
 
   // sum of the values in the population. If count is zero then this field
   // must be zero.
@@ -414,7 +414,7 @@ message HistogramDataPoint {
   // Negative events *can* be recorded, but sum should not be filled out when
   // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
   // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
-  optional double sum = 5;
+  optional double sum = 5 [json_name="su"];
 
   // bucket_counts is an optional field contains the count values of histogram
   // for each bucket.
@@ -423,7 +423,7 @@ message HistogramDataPoint {
   //
   // The number of elements in bucket_counts array must be by one greater than
   // the number of elements in explicit_bounds array.
-  repeated fixed64 bucket_counts = 6;
+  repeated fixed64 bucket_counts = 6 [json_name="b"];
 
   // explicit_bounds specifies buckets with explicitly defined bounds for values.
   //
@@ -438,21 +438,21 @@ message HistogramDataPoint {
   // Histogram buckets are inclusive of their upper boundary, except the last
   // bucket where the boundary is at infinity. This format is intentionally
   // compatible with the OpenMetrics histogram definition.
-  repeated double explicit_bounds = 7;
+  repeated double explicit_bounds = 7 [json_name="eb"];
 
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point
-  repeated Exemplar exemplars = 8;
+  repeated Exemplar exemplars = 8 [json_name="e"];
 
   // Flags that apply to this specific data point.  See DataPointFlags
   // for the available flags and their meaning.
-  uint32 flags = 10;
+  uint32 flags = 10 [json_name="f"];
 
   // min is the minimum value over (start_time, end_time].
-  optional double min = 11;
+  optional double min = 11 [json_name="mi"];
 
   // max is the maximum value over (start_time, end_time].
-  optional double max = 12;
+  optional double max = 12 [json_name="ma"];
 }
 
 // ExponentialHistogramDataPoint is a single data point in a timeseries that describes the
@@ -465,25 +465,25 @@ message ExponentialHistogramDataPoint {
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 1 [json_name="a"];
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
   // the detailed comments above Metric.
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.
-  fixed64 start_time_unix_nano = 2;
+  fixed64 start_time_unix_nano = 2 [json_name="s"];
 
   // TimeUnixNano is required, see the detailed comments above Metric.
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.
-  fixed64 time_unix_nano = 3;
+  fixed64 time_unix_nano = 3 [json_name="t"];
 
   // count is the number of values in the population. Must be
   // non-negative. This value must be equal to the sum of the "bucket_counts"
   // values in the positive and negative Buckets plus the "zero_count" field.
-  fixed64 count = 4;
+  fixed64 count = 4 [json_name="c"];
 
   // sum of the values in the population. If count is zero then this field
   // must be zero.
@@ -493,7 +493,7 @@ message ExponentialHistogramDataPoint {
   // Negative events *can* be recorded, but sum should not be filled out when
   // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
   // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
-  optional double sum = 5;
+  optional double sum = 5 [json_name="su"];
   
   // scale describes the resolution of the histogram.  Boundaries are
   // located at powers of the base, where:
@@ -510,7 +510,7 @@ message ExponentialHistogramDataPoint {
   //
   // scale is not restricted by the protocol, as the permissible
   // values depend on the range of the data.
-  sint32 scale = 6;
+  sint32 scale = 6 [json_name="sc"];
 
   // zero_count is the count of values that are either exactly zero or
   // within the region considered zero by the instrumentation at the
@@ -520,13 +520,13 @@ message ExponentialHistogramDataPoint {
   //
   // Implementations MAY consider the zero bucket to have probability
   // mass equal to (zero_count / count).
-  fixed64 zero_count = 7;
+  fixed64 zero_count = 7 [json_name="z"];
 
   // positive carries the positive range of exponential bucket counts.
-  Buckets positive = 8;
+  Buckets positive = 8 [json_name="p"];
 
   // negative carries the negative range of exponential bucket counts.
-  Buckets negative = 9;
+  Buckets negative = 9 [json_name="n"];
 
   // Buckets are a set of bucket counts, encoded in a contiguous array
   // of counts.
@@ -534,7 +534,7 @@ message ExponentialHistogramDataPoint {
     // Offset is the bucket index of the first entry in the bucket_counts array.
     // 
     // Note: This uses a varint encoding as a simple form of compression.
-    sint32 offset = 1;
+    sint32 offset = 1 [json_name="o"];
 
     // Count is an array of counts, where count[i] carries the count
     // of the bucket at index (offset+i).  count[i] is the count of
@@ -545,22 +545,22 @@ message ExponentialHistogramDataPoint {
     // fixed64.  This field is expected to have many buckets,
     // especially zeros, so uint64 has been selected to ensure
     // varint encoding.
-    repeated uint64 bucket_counts = 2;
+    repeated uint64 bucket_counts = 2 [json_name="b"];
   } 
 
   // Flags that apply to this specific data point.  See DataPointFlags
   // for the available flags and their meaning.
-  uint32 flags = 10;
+  uint32 flags = 10 [json_name="f"];
 
   // (Optional) List of exemplars collected from
   // measurements that were used to form the data point
-  repeated Exemplar exemplars = 11;
+  repeated Exemplar exemplars = 11 [json_name="e"];
 
   // min is the minimum value over (start_time, end_time].
-  optional double min = 12;
+  optional double min = 12 [json_name="mi"];
 
   // max is the maximum value over (start_time, end_time].
-  optional double max = 13;
+  optional double max = 13 [json_name="ma"];
 }
 
 // SummaryDataPoint is a single data point in a timeseries that describes the
@@ -572,23 +572,23 @@ message SummaryDataPoint {
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 7 [json_name="a"];
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
   // the detailed comments above Metric.
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.
-  fixed64 start_time_unix_nano = 2;
+  fixed64 start_time_unix_nano = 2 [json_name="s"];
 
   // TimeUnixNano is required, see the detailed comments above Metric.
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.
-  fixed64 time_unix_nano = 3;
+  fixed64 time_unix_nano = 3 [json_name="t"];
 
   // count is the number of values in the population. Must be non-negative.
-  fixed64 count = 4;
+  fixed64 count = 4 [json_name="c"];
 
   // sum of the values in the population. If count is zero then this field
   // must be zero.
@@ -598,7 +598,7 @@ message SummaryDataPoint {
   // Negative events *can* be recorded, but sum should not be filled out when
   // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
   // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
-  double sum = 5;
+  double sum = 5 [json_name="su"];
 
   // Represents the value at a given quantile of a distribution.
   //
@@ -611,21 +611,21 @@ message SummaryDataPoint {
   message ValueAtQuantile {
     // The quantile of a distribution. Must be in the interval
     // [0.0, 1.0].
-    double quantile = 1;
+    double quantile = 1 [json_name="q"];
 
     // The value at the given quantile of a distribution.
     //
     // Quantile values must NOT be negative.
-    double value = 2;
+    double value = 2 [json_name="v"];
   }
 
   // (Optional) list of values at different quantiles of the distribution calculated
   // from the current snapshot. The quantiles must be strictly increasing.
-  repeated ValueAtQuantile quantile_values = 6;
+  repeated ValueAtQuantile quantile_values = 6 [json_name="q"];
 
   // Flags that apply to this specific data point.  See DataPointFlags
   // for the available flags and their meaning.
-  uint32 flags = 8;
+  uint32 flags = 8 [json_name="f"];
 }
 
 // A representation of an exemplar, which is a sample input measurement.
@@ -638,29 +638,29 @@ message Exemplar {
   // The set of key/value pairs that were filtered out by the aggregator, but
   // recorded alongside the original measurement. Only key/value pairs that were
   // filtered out by the aggregator should be included
-  repeated opentelemetry.proto.common.v1.KeyValue filtered_attributes = 7;
+  repeated opentelemetry.proto.common.v1.KeyValue filtered_attributes = 7 [json_name="f"];
 
   // time_unix_nano is the exact time when this exemplar was recorded
   //
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   // 1970.
-  fixed64 time_unix_nano = 2;
+  fixed64 time_unix_nano = 2 [json_name="t"];
 
   // The value of the measurement that was recorded. An exemplar is
   // considered invalid when one of the recognized value fields is not present
   // inside this oneof.
   oneof value {
-    double as_double = 3;
-    sfixed64 as_int = 6;
+    double as_double = 3 [json_name="d"];
+    sfixed64 as_int = 6 [json_name="i"];
   }
 
   // (Optional) Span ID of the exemplar trace.
   // span_id may be missing if the measurement is not recorded inside a trace
   // or if the trace is not sampled.
-  bytes span_id = 4;
+  bytes span_id = 4 [json_name="si"];
 
   // (Optional) Trace ID of the exemplar trace.
   // trace_id may be missing if the measurement is not recorded inside a trace
   // or if the trace is not sampled.
-  bytes trace_id = 5;
+  bytes trace_id = 5 [json_name="ti"];
 }

--- a/opentelemetry/proto/resource/v1/resource.proto
+++ b/opentelemetry/proto/resource/v1/resource.proto
@@ -29,9 +29,9 @@ message Resource {
   // Set of attributes that describe the resource.
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 1 [json_name="a"];
 
   // dropped_attributes_count is the number of dropped attributes. If the value is 0, then
   // no attributes were dropped.
-  uint32 dropped_attributes_count = 2;
+  uint32 dropped_attributes_count = 2 [json_name="da"];
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -41,7 +41,7 @@ message TracesData {
   // one element. Intermediary nodes that receive data from multiple origins
   // typically batch the data before forwarding further and in that case this
   // array will contain multiple elements.
-  repeated ResourceSpans resource_spans = 1;
+  repeated ResourceSpans resource_spans = 1 [json_name="s"];
 }
 
 // A collection of ScopeSpans from a Resource.
@@ -50,14 +50,14 @@ message ResourceSpans {
 
   // The resource for the spans in this message.
   // If this field is not set then no resource info is known.
-  opentelemetry.proto.resource.v1.Resource resource = 1;
+  opentelemetry.proto.resource.v1.Resource resource = 1 [json_name="r"];
 
   // A list of ScopeSpans that originate from a resource.
-  repeated ScopeSpans scope_spans = 2;
+  repeated ScopeSpans scope_spans = 2 [json_name="s"];
 
   // This schema_url applies to the data in the "resource" field. It does not apply
   // to the data in the "scope_spans" field which have their own schema_url field.
-  string schema_url = 3;
+  string schema_url = 3 [json_name="u"];
 }
 
 // A collection of Spans produced by an InstrumentationScope.
@@ -65,13 +65,13 @@ message ScopeSpans {
   // The instrumentation scope information for the spans in this message.
   // Semantically when InstrumentationScope isn't set, it is equivalent with
   // an empty instrumentation scope name (unknown).
-  opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
+  opentelemetry.proto.common.v1.InstrumentationScope scope = 1 [json_name="i"];
 
   // A list of Spans that originate from an instrumentation scope.
-  repeated Span spans = 2;
+  repeated Span spans = 2 [json_name="s"];
 
   // This schema_url applies to all spans and span events in the "spans" field.
-  string schema_url = 3;
+  string schema_url = 3 [json_name="u"];
 }
 
 // A Span represents a single operation performed by a single component of the system.
@@ -86,7 +86,7 @@ message Span {
   // random trace_id if empty or invalid trace_id was received.
   //
   // This field is required.
-  bytes trace_id = 1;
+  bytes trace_id = 1 [json_name="ti"];
 
   // A unique identifier for a span within a trace, assigned when the span
   // is created. The ID is an 8-byte array. An ID with all zeroes is considered
@@ -96,16 +96,16 @@ message Span {
   // random span_id if empty or invalid span_id was received.
   //
   // This field is required.
-  bytes span_id = 2;
+  bytes span_id = 2 [json_name="si"];
 
   // trace_state conveys information about request position in multiple distributed tracing graphs.
   // It is a trace_state in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
   // See also https://github.com/w3c/distributed-tracing for more details about this field.
-  string trace_state = 3;
+  string trace_state = 3 [json_name="ts"];
 
   // The `span_id` of this span's parent span. If this is a root span, then this
   // field must be empty. The ID is an 8-byte array.
-  bytes parent_span_id = 4;
+  bytes parent_span_id = 4 [json_name="p"];
 
   // A description of the span's operation.
   //
@@ -118,7 +118,7 @@ message Span {
   // Empty value is equivalent to an unknown span name.
   //
   // This field is required.
-  string name = 5;
+  string name = 5 [json_name="n"];
 
   // SpanKind is the type of span. Can be used to specify additional relationships between spans
   // in addition to a parent/child relationship.
@@ -153,7 +153,7 @@ message Span {
   // Distinguishes between spans generated in a particular context. For example,
   // two spans with the same name may be distinguished using `CLIENT` (caller)
   // and `SERVER` (callee) to identify queueing latency associated with the span.
-  SpanKind kind = 6;
+  SpanKind kind = 6 [json_name="k"];
 
   // start_time_unix_nano is the start time of the span. On the client side, this is the time
   // kept by the local machine where the span execution starts. On the server side, this
@@ -161,7 +161,7 @@ message Span {
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
   // This field is semantically required and it is expected that end_time >= start_time.
-  fixed64 start_time_unix_nano = 7;
+  fixed64 start_time_unix_nano = 7 [json_name="s"];
 
   // end_time_unix_nano is the end time of the span. On the client side, this is the time
   // kept by the local machine where the span execution ends. On the server side, this
@@ -169,7 +169,7 @@ message Span {
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
   // This field is semantically required and it is expected that end_time >= start_time.
-  fixed64 end_time_unix_nano = 8;
+  fixed64 end_time_unix_nano = 8 [json_name="e"];
 
   // attributes is a collection of key/value pairs. Note, global attributes
   // like server name can be set using the resource API. Examples of attributes:
@@ -183,39 +183,39 @@ message Span {
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 9 [json_name="a"];
 
   // dropped_attributes_count is the number of attributes that were discarded. Attributes
   // can be discarded because their keys are too long or because there are too many
   // attributes. If this value is 0, then no attributes were dropped.
-  uint32 dropped_attributes_count = 10;
+  uint32 dropped_attributes_count = 10 [json_name="da"];
 
   // Event is a time-stamped annotation of the span, consisting of user-supplied
   // text description and key-value pairs.
   message Event {
     // time_unix_nano is the time the event occurred.
-    fixed64 time_unix_nano = 1;
+    fixed64 time_unix_nano = 1 [json_name="t"];
 
     // name of the event.
     // This field is semantically required to be set to non-empty string.
-    string name = 2;
+    string name = 2 [json_name="n"];
 
     // attributes is a collection of attribute key/value pairs on the event.
     // Attribute keys MUST be unique (it is not allowed to have more than one
     // attribute with the same key).
-    repeated opentelemetry.proto.common.v1.KeyValue attributes = 3;
+    repeated opentelemetry.proto.common.v1.KeyValue attributes = 3 [json_name="a"];
 
     // dropped_attributes_count is the number of dropped attributes. If the value is 0,
     // then no attributes were dropped.
-    uint32 dropped_attributes_count = 4;
+    uint32 dropped_attributes_count = 4 [json_name="da"];
   }
 
   // events is a collection of Event items.
-  repeated Event events = 11;
+  repeated Event events = 11 [json_name="ev"];
 
   // dropped_events_count is the number of dropped events. If the value is 0, then no
   // events were dropped.
-  uint32 dropped_events_count = 12;
+  uint32 dropped_events_count = 12 [json_name="de"];
 
   // A pointer from the current span to another span in the same trace or in a
   // different trace. For example, this can be used in batching operations,
@@ -224,35 +224,35 @@ message Span {
   message Link {
     // A unique identifier of a trace that this linked span is part of. The ID is a
     // 16-byte array.
-    bytes trace_id = 1;
+    bytes trace_id = 1 [json_name="ti"];
 
     // A unique identifier for the linked span. The ID is an 8-byte array.
-    bytes span_id = 2;
+    bytes span_id = 2 [json_name="si"];
 
     // The trace_state associated with the link.
-    string trace_state = 3;
+    string trace_state = 3 [json_name="ts"];
 
     // attributes is a collection of attribute key/value pairs on the link.
     // Attribute keys MUST be unique (it is not allowed to have more than one
     // attribute with the same key).
-    repeated opentelemetry.proto.common.v1.KeyValue attributes = 4;
+    repeated opentelemetry.proto.common.v1.KeyValue attributes = 4 [json_name="a"];
 
     // dropped_attributes_count is the number of dropped attributes. If the value is 0,
     // then no attributes were dropped.
-    uint32 dropped_attributes_count = 5;
+    uint32 dropped_attributes_count = 5 [json_name="da"];
   }
 
   // links is a collection of Links, which are references from this span to a span
   // in the same or different trace.
-  repeated Link links = 13;
+  repeated Link links = 13 [json_name="l"];
 
   // dropped_links_count is the number of dropped links after the maximum size was
   // enforced. If this value is 0, then no links were dropped.
-  uint32 dropped_links_count = 14;
+  uint32 dropped_links_count = 14 [json_name="dl"];
 
   // An optional final status for this span. Semantically when Status isn't set, it means
   // span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0).
-  Status status = 15;
+  Status status = 15 [json_name="st"];
 }
 
 // The Status type defines a logical error model that is suitable for different
@@ -261,7 +261,7 @@ message Status {
   reserved 1;
 
   // A developer-facing human readable error message.
-  string message = 2;
+  string message = 2 [json_name="m"];
 
   // For the semantics of status codes see
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
@@ -276,5 +276,5 @@ message Status {
   };
 
   // The status code.
-  StatusCode code = 3;
+  StatusCode code = 3 [json_name="c"];
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-proto/issues/412

This change sets short one or two letter keys for all fields when JSON
encoding is used. This results in about 1.3-1.5 times smaller uncompressed
payload.

Here is size comparison using some sample data from exp-otelproto test bench:

```
===== Encoded sizes                                                       
Encoding                       Uncomp/json[Improved]   zlib/json[Improved]
OTLP 0.18/Logs                 52577 by   [1.000]      4601 by [1.000]    
ShortKeys/Logs                 39668 by   [1.325]      4344 by [1.059]    
                                                                          
Encoding                       Uncomp/json[Improved]   zlib/json[Improved]
OTLP 0.18/Trace/Attribs        41704 by   [1.000]      3189 by [1.000]    
ShortKeys/Trace/Attribs        31998 by   [1.303]      3060 by [1.042]    
                                                                          
Encoding                       Uncomp/json[Improved]   zlib/json[Improved]
OTLP 0.18/Trace/Events         49302 by   [1.000]      1917 by [1.000]    
ShortKeys/Trace/Events         34396 by   [1.433]      1806 by [1.061]    
                                                                          
Encoding                       Uncomp/json[Improved]   zlib/json[Improved]
OTLP 0.18/Metric/Histogram     42376 by   [1.000]      1067 by [1.000]    
ShortKeys/Metric/Histogram     27071 by   [1.565]       839 by [1.272]    
                                                                          
Encoding                       Uncomp/json[Improved]   zlib/json[Improved]
OTLP 0.18/Metric/MixOne       184836 by   [1.000]      2778 by [1.000]    
ShortKeys/Metric/MixOne       119031 by   [1.553]      2143 by [1.296]    
                                                                          
Encoding                       Uncomp/json[Improved]   zlib/json[Improved]
OTLP 0.18/Metric/MixSeries    707615 by   [1.000]     11482 by [1.000]    
ShortKeys/Metric/MixSeries    457010 by   [1.548]      9829 by [1.168]    
```

Unfortunately **this is a breaking change** for default configuration of
Protobuf/JSON marshaler, which marshals field names in lowerCamelCase.
This is not a breaking change for marshalers which use the "OrigName=true"
JSON marshalling option. Nothing changes in the output when "OrigName=true"
is used.

I do not see an easy way to make this change gracefully. It will require
duplicating the entire proto, give the duplicate messages different names,
then handle the duplicates in the receivers. It is quite a lot of work
that can be also error prone. I think in this particular case we should
not attempt to handle it gracefully and simply stick to our formal
stability guarantees, which for JSON are "Alpha" and allow any changes
any time.

### Example Outputs

Current JSON output before this change, using default lowerCamelCase marshaler:

```json
{
    "resourceSpans": [
        {
            "resource": {
                "attributes": [
                    {
                        "key": "StartTimeUnixnano",
                        "value": {
                            "intValue": "12345678"
                        }
                    },
                    {
                        "key": "Pid",
                        "value": {
                            "intValue": "1234"
                        }
                    },
                    {
                        "key": "HostName",
                        "value": {
                            "stringValue": "fakehost"
                        }
                    },
                    {
                        "key": "ServiceName",
                        "value": {
                            "stringValue": "generator"
                        }
                    }
                ]
            },
            "scopeSpans": [
                {
                    "scope": {
                        "name": "io.opentelemetry"
                    },
                    "spans": [
                        {
                            "traceId": "AQAAAAAAAADw3rwKeFY0Eg==",
                            "spanId": "AQAAAAAAAAA=",
                            "name": "load-generator-span",
                            "kind": "SPAN_KIND_CLIENT",
                            "startTimeUnixNano": "1572516672000000013",
                            "endTimeUnixNano": "1572516672000000013",
                            "attributes": [
                                {
                                    "key": "db.mongodb.collection",
                                    "value": {
                                        "stringValue": "!##$"
                                    }
                                }
                            ],
                            "events": [
                                {
                                    "timeUnixNano": "1572516672000000013",
                                    "attributes": [
                                        {
                                            "key": "te",
                                            "value": {
                                                "intValue": "1"
                                            }
                                        }
                                    ]
                                }
                            ]
                        }
                    ]
                }
            ]
        }
    ]
}
```

JSON output before and after this change, using OrigName=true marshaler.

```json
{
    "resource_spans": [
        {
            "resource": {
                "attributes": [
                    {
                        "key": "StartTimeUnixnano",
                        "value": {
                            "int_value": "12345678"
                        }
                    },
                    {
                        "key": "Pid",
                        "value": {
                            "int_value": "1234"
                        }
                    },
                    {
                        "key": "HostName",
                        "value": {
                            "string_value": "fakehost"
                        }
                    },
                    {
                        "key": "ServiceName",
                        "value": {
                            "string_value": "generator"
                        }
                    }
                ]
            },
            "scope_spans": [
                {
                    "scope": {
                        "name": "io.opentelemetry"
                    },
                    "spans": [
                        {
                            "trace_id": "AQAAAAAAAADw3rwKeFY0Eg==",
                            "span_id": "AQAAAAAAAAA=",
                            "name": "load-generator-span",
                            "kind": "SPAN_KIND_CLIENT",
                            "start_time_unix_nano": "1572516672000000013",
                            "end_time_unix_nano": "1572516672000000013",
                            "attributes": [
                                {
                                    "key": "db.mongodb.collection",
                                    "value": {
                                        "string_value": "!##$"
                                    }
                                }
                            ],
                            "events": [
                                {
                                    "time_unix_nano": "1572516672000000013",
                                    "attributes": [
                                        {
                                            "key": "te",
                                            "value": {
                                                "int_value": "1"
                                            }
                                        }
                                    ]
                                }
                            ]
                        }
                    ]
                }
            ]
        }
    ]
}
```

JSON output after this change, using proposed short keys and default
lowerCamelCase marshaler:

```json
{
    "s": [
        {
            "r": {
                "a": [
                    {
                        "k": "StartTimeUnixnano",
                        "v": {
                            "i": "12345678"
                        }
                    },
                    {
                        "k": "Pid",
                        "v": {
                            "i": "1234"
                        }
                    },
                    {
                        "k": "HostName",
                        "v": {
                            "s": "fakehost"
                        }
                    },
                    {
                        "k": "ServiceName",
                        "v": {
                            "s": "generator"
                        }
                    }
                ]
            },
            "s": [
                {
                    "i": {
                        "n": "io.opentelemetry"
                    },
                    "s": [
                        {
                            "ti": "AQAAAAAAAADw3rwKeFY0Eg==",
                            "si": "AQAAAAAAAAA=",
                            "n": "load-generator-span",
                            "k": "SPAN_KIND_CLIENT",
                            "s": "1572516672000000013",
                            "e": "1572516672000000013",
                            "a": [
                                {
                                    "k": "db.mongodb.collection",
                                    "v": {
                                        "s": "!##$"
                                    }
                                }
                            ],
                            "ev": [
                                {
                                    "t": "1572516672000000013",
                                    "a": [
                                        {
                                            "k": "te",
                                            "v": {
                                                "i": "1"
                                            }
                                        }
                                    ]
                                }
                            ]
                        }
                    ]
                }
            ]
        }
    ]
}
```