### PR TITLE
Make it possible to indicate partial success in an OTLP export response [2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Full list of differences found in [this compare](https://github.com/open-telemet
 ### Added
 
 * Introduce Scope Attributes. [#395](https://github.com/open-telemetry/opentelemetry-proto/pull/395)
+* Introduce partial success fields in `Export<signal>ServiceResponse`.
+ [#?](https://github.com/open-telemetry/opentelemetry-proto/pull/?)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Full list of differences found in [this compare](https://github.com/open-telemet
 
 * Introduce Scope Attributes. [#395](https://github.com/open-telemetry/opentelemetry-proto/pull/395)
 * Introduce partial success fields in `Export<signal>ServiceResponse`.
- [#?](https://github.com/open-telemetry/opentelemetry-proto/pull/?)
+ [#414](https://github.com/open-telemetry/opentelemetry-proto/pull/414)
 
 ### Removed
 

--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -57,13 +57,10 @@ message ExportLogsServiceResponse {
 
 message ExportLogsPartialSuccess {
   // The number of rejected log records.
-  //
-  // If the request is only partially accepted, the server MUST set
-  // the `rejected_log_records` field.
   // 
-  // Given the server should only initialize the `partial_success` field
+  // Given the server MUST only initialize the `partial_success` field
   // when it rejects parts of the data, a `rejected_log_records` with
-  // value = '0' is considered an invalid result. Senders should
+  // value = '0' is considered an invalid result. Senders MUST
   // interpret such responses from a server as if all log records were accepted.
   int64 rejected_log_records = 1;
 

--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -48,25 +48,26 @@ message ExportLogsServiceResponse {
   // If the request is only partially accepted
   // (i.e. when the server accepts only parts of the data and rejects the rest)
   // the server MUST initialize the `partial_success` field and MUST
-  // set the `rejected_log_records` with the number of log records it rejected.
+  // set the `rejected_<signal>` with the number of items it rejected.
   //
-  // The server MUST NOT set the `partial_success` field when the
-  // request was accepted in its entirety.
+  // Servers MAY also make use of the `partial_success` field to convey
+  // warnings/suggestions to senders when the request was fully accepted.
+  // In such cases, the `rejected_<signal>` MUST have a value of `0` and
+  // the `error_message` MUST be non-empty.
   ExportLogsPartialSuccess partial_success = 1;
 }
 
 message ExportLogsPartialSuccess {
   // The number of rejected log records.
   // 
-  // Given the server MUST only initialize the `partial_success` field
-  // when it rejects parts of the data, a `rejected_log_records` with
-  // value = '0' is considered an invalid result. Senders MUST
-  // interpret such responses from a server as if all log records were accepted.
+  // A `rejected_<signal>` field holding a `0` value indicates that the
+  // request was fully accepted.
   int64 rejected_log_records = 1;
 
-  // A developer-facing human-readable error message in English. It should
-  // explain why the server rejected parts of the data,
-  // and might offer guidance on how users can address the issues.
+  // A developer-facing human-readable message in English. It should be used
+  // either to explain why the server rejected parts of the data during a partial
+  // success or to convey warnings/suggestions during a full success. The message
+  // should offer guidance on how users can address such issues.
   //
   // error_message is an optional field. An error_message with an empty value
   // is equivalent of it not being set.

--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -43,4 +43,35 @@ message ExportLogsServiceRequest {
 }
 
 message ExportLogsServiceResponse {
+  // The details of a partially successful export request.
+  //
+  // If the request is only partially accepted
+  // (i.e. when the server accepts only parts of the data and rejects the rest)
+  // the server MUST initialize the `partial_success` field and MUST
+  // set the `rejected_log_records` with the number of log records it rejected.
+  //
+  // The server MUST NOT set the `partial_success` field when the
+  // request was accepted in its entirety.
+  ExportLogsPartialSuccess partial_success = 1;
+}
+
+message ExportLogsPartialSuccess {
+  // The number of rejected log records.
+  //
+  // If the request is only partially accepted, the server MUST set
+  // the `rejected_log_records` field.
+  // 
+  // Given the server should only initialize the `partial_success` field
+  // when it rejects parts of the data, a `rejected_log_records` with
+  // value = '0' is considered an invalid result. Senders should
+  // interpret such responses from a server as if all log records were accepted.
+  int64 rejected_log_records = 1;
+
+  // A developer-facing human-readable error message in English. It should
+  // explain why the server rejected parts of the data,
+  // and might offer guidance on how users can address the issues.
+  //
+  // error_message is an optional field. An error_message with an empty value
+  // is equivalent of it not being set.
+  string error_message = 2;
 }

--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -51,7 +51,7 @@ message ExportLogsServiceResponse {
   // set the `rejected_<signal>` with the number of items it rejected.
   //
   // Servers MAY also make use of the `partial_success` field to convey
-  // warnings/suggestions to senders when the request was fully accepted.
+  // warnings/suggestions to senders even when the request was fully accepted.
   // In such cases, the `rejected_<signal>` MUST have a value of `0` and
   // the `error_message` MUST be non-empty.
   ExportLogsPartialSuccess partial_success = 1;

--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -54,12 +54,16 @@ message ExportLogsServiceResponse {
   // warnings/suggestions to senders even when the request was fully accepted.
   // In such cases, the `rejected_<signal>` MUST have a value of `0` and
   // the `error_message` MUST be non-empty.
+  //
+  // A `partial_success` message with an empty value (rejected_<signal> = 0 and
+  // `error_message` = "") is equivalent to it not being set/present. Senders
+  // SHOULD interpret it the same way as in the full success case.
   ExportLogsPartialSuccess partial_success = 1;
 }
 
 message ExportLogsPartialSuccess {
   // The number of rejected log records.
-  // 
+  //
   // A `rejected_<signal>` field holding a `0` value indicates that the
   // request was fully accepted.
   int64 rejected_log_records = 1;
@@ -70,6 +74,6 @@ message ExportLogsPartialSuccess {
   // should offer guidance on how users can address such issues.
   //
   // error_message is an optional field. An error_message with an empty value
-  // is equivalent of it not being set.
+  // is equivalent to it not being set.
   string error_message = 2;
 }

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -43,4 +43,35 @@ message ExportMetricsServiceRequest {
 }
 
 message ExportMetricsServiceResponse {
+  // The details of a partially successful export request.
+  //
+  // If the request is only partially accepted
+  // (i.e. when the server accepts only parts of the data and rejects the rest)
+  // the server MUST initialize the `partial_success` field and MUST
+  // set the `rejected_data_points` with the number of data points it rejected.
+  //
+  // The server MUST NOT set the `partial_success` field when the
+  // request was accepted in its entirety.
+  ExportMetricsPartialSuccess partial_success = 1;
+}
+
+message ExportMetricsPartialSuccess {
+  // The number of rejected data points.
+  //
+  // If the request is only partially accepted, the server MUST set
+  // the `rejected_data_points` field.
+  // 
+  // Given the server should only initialize the `partial_success` field
+  // when it rejects parts of the data, a `rejected_data_points` with
+  // value = '0' is considered an invalid result. Senders should
+  // interpret such responses from a server as if all data points were accepted.
+  int64 rejected_data_points = 1;
+
+  // A developer-facing human-readable error message in English. It should
+  // explain why the server rejected parts of the data,
+  // and might offer guidance on how users can address the issues.
+  //
+  // error_message is an optional field. An error_message with an empty value
+  // is equivalent of it not being set.
+  string error_message = 2;
 }

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -54,6 +54,10 @@ message ExportMetricsServiceResponse {
   // warnings/suggestions to senders even when the request was fully accepted.
   // In such cases, the `rejected_<signal>` MUST have a value of `0` and
   // the `error_message` MUST be non-empty.
+  //
+  // A `partial_success` message with an empty value (rejected_<signal> = 0 and
+  // `error_message` = "") is equivalent to it not being set/present. Senders
+  // SHOULD interpret it the same way as in the full success case.
   ExportMetricsPartialSuccess partial_success = 1;
 }
 
@@ -70,6 +74,6 @@ message ExportMetricsPartialSuccess {
   // should offer guidance on how users can address such issues.
   //
   // error_message is an optional field. An error_message with an empty value
-  // is equivalent of it not being set.
+  // is equivalent to it not being set.
   string error_message = 2;
 }

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -48,25 +48,26 @@ message ExportMetricsServiceResponse {
   // If the request is only partially accepted
   // (i.e. when the server accepts only parts of the data and rejects the rest)
   // the server MUST initialize the `partial_success` field and MUST
-  // set the `rejected_data_points` with the number of data points it rejected.
+  // set the `rejected_<signal>` with the number of items it rejected.
   //
-  // The server MUST NOT set the `partial_success` field when the
-  // request was accepted in its entirety.
+  // Servers MAY also make use of the `partial_success` field to convey
+  // warnings/suggestions to senders when the request was fully accepted.
+  // In such cases, the `rejected_<signal>` MUST have a value of `0` and
+  // the `error_message` MUST be non-empty.
   ExportMetricsPartialSuccess partial_success = 1;
 }
 
 message ExportMetricsPartialSuccess {
   // The number of rejected data points.
   //
-  // Given the server MUST only initialize the `partial_success` field
-  // when it rejects parts of the data, a `rejected_data_points` with
-  // value = '0' is considered an invalid result. Senders MUST
-  // interpret such responses from a server as if all data points were accepted.
+  // A `rejected_<signal>` field holding a `0` value indicates that the
+  // request was fully accepted.
   int64 rejected_data_points = 1;
 
-  // A developer-facing human-readable error message in English. It should
-  // explain why the server rejected parts of the data,
-  // and might offer guidance on how users can address the issues.
+  // A developer-facing human-readable message in English. It should be used
+  // either to explain why the server rejected parts of the data during a partial
+  // success or to convey warnings/suggestions during a full success. The message
+  // should offer guidance on how users can address such issues.
   //
   // error_message is an optional field. An error_message with an empty value
   // is equivalent of it not being set.

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -58,12 +58,9 @@ message ExportMetricsServiceResponse {
 message ExportMetricsPartialSuccess {
   // The number of rejected data points.
   //
-  // If the request is only partially accepted, the server MUST set
-  // the `rejected_data_points` field.
-  // 
-  // Given the server should only initialize the `partial_success` field
+  // Given the server MUST only initialize the `partial_success` field
   // when it rejects parts of the data, a `rejected_data_points` with
-  // value = '0' is considered an invalid result. Senders should
+  // value = '0' is considered an invalid result. Senders MUST
   // interpret such responses from a server as if all data points were accepted.
   int64 rejected_data_points = 1;
 

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -51,7 +51,7 @@ message ExportMetricsServiceResponse {
   // set the `rejected_<signal>` with the number of items it rejected.
   //
   // Servers MAY also make use of the `partial_success` field to convey
-  // warnings/suggestions to senders when the request was fully accepted.
+  // warnings/suggestions to senders even when the request was fully accepted.
   // In such cases, the `rejected_<signal>` MUST have a value of `0` and
   // the `error_message` MUST be non-empty.
   ExportMetricsPartialSuccess partial_success = 1;

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -58,12 +58,9 @@ message ExportTraceServiceResponse {
 message ExportTracePartialSuccess {
   // The number of rejected spans.
   //
-  // If the request is only partially accepted, the server MUST set
-  // the `rejected_spans` field.
-  // 
-  // Given the server should only initialize the `partial_success` field
+  // Given the server MUST only initialize the `partial_success` field
   // when it rejects parts of the data, a `rejected_spans` with
-  // value = '0' is considered an invalid result. Senders should
+  // value = '0' is considered an invalid result. Senders MUST
   // interpret such responses from a server as if all spans were accepted.
   int64 rejected_spans = 1;
 

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -54,6 +54,10 @@ message ExportTraceServiceResponse {
   // warnings/suggestions to senders even when the request was fully accepted.
   // In such cases, the `rejected_<signal>` MUST have a value of `0` and
   // the `error_message` MUST be non-empty.
+  //
+  // A `partial_success` message with an empty value (rejected_<signal> = 0 and
+  // `error_message` = "") is equivalent to it not being set/present. Senders
+  // SHOULD interpret it the same way as in the full success case.
   ExportTracePartialSuccess partial_success = 1;
 }
 
@@ -70,6 +74,6 @@ message ExportTracePartialSuccess {
   // should offer guidance on how users can address such issues.
   //
   // error_message is an optional field. An error_message with an empty value
-  // is equivalent of it not being set.
+  // is equivalent to it not being set.
   string error_message = 2;
 }

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -51,7 +51,7 @@ message ExportTraceServiceResponse {
   // set the `rejected_<signal>` with the number of items it rejected.
   //
   // Servers MAY also make use of the `partial_success` field to convey
-  // warnings/suggestions to senders when the request was fully accepted.
+  // warnings/suggestions to senders even when the request was fully accepted.
   // In such cases, the `rejected_<signal>` MUST have a value of `0` and
   // the `error_message` MUST be non-empty.
   ExportTracePartialSuccess partial_success = 1;

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -43,4 +43,35 @@ message ExportTraceServiceRequest {
 }
 
 message ExportTraceServiceResponse {
+  // The details of a partially successful export request.
+  //
+  // If the request is only partially accepted
+  // (i.e. when the server accepts only parts of the data and rejects the rest)
+  // the server MUST initialize the `partial_success` field and MUST
+  // set the `rejected_spans` with the number of spans it rejected.
+  //
+  // The server MUST NOT set the `partial_success` field when the
+  // request was accepted in its entirety.
+  ExportTracePartialSuccess partial_success = 1;
+}
+
+message ExportTracePartialSuccess {
+  // The number of rejected spans.
+  //
+  // If the request is only partially accepted, the server MUST set
+  // the `rejected_spans` field.
+  // 
+  // Given the server should only initialize the `partial_success` field
+  // when it rejects parts of the data, a `rejected_spans` with
+  // value = '0' is considered an invalid result. Senders should
+  // interpret such responses from a server as if all spans were accepted.
+  int64 rejected_spans = 1;
+
+  // A developer-facing human-readable error message in English. It should
+  // explain why the server rejected parts of the data,
+  // and might offer guidance on how users can address the issues.
+  //
+  // error_message is an optional field. An error_message with an empty value
+  // is equivalent of it not being set.
+  string error_message = 2;
 }

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -48,25 +48,26 @@ message ExportTraceServiceResponse {
   // If the request is only partially accepted
   // (i.e. when the server accepts only parts of the data and rejects the rest)
   // the server MUST initialize the `partial_success` field and MUST
-  // set the `rejected_spans` with the number of spans it rejected.
+  // set the `rejected_<signal>` with the number of items it rejected.
   //
-  // The server MUST NOT set the `partial_success` field when the
-  // request was accepted in its entirety.
+  // Servers MAY also make use of the `partial_success` field to convey
+  // warnings/suggestions to senders when the request was fully accepted.
+  // In such cases, the `rejected_<signal>` MUST have a value of `0` and
+  // the `error_message` MUST be non-empty.
   ExportTracePartialSuccess partial_success = 1;
 }
 
 message ExportTracePartialSuccess {
   // The number of rejected spans.
   //
-  // Given the server MUST only initialize the `partial_success` field
-  // when it rejects parts of the data, a `rejected_spans` with
-  // value = '0' is considered an invalid result. Senders MUST
-  // interpret such responses from a server as if all spans were accepted.
+  // A `rejected_<signal>` field holding a `0` value indicates that the
+  // request was fully accepted.
   int64 rejected_spans = 1;
 
-  // A developer-facing human-readable error message in English. It should
-  // explain why the server rejected parts of the data,
-  // and might offer guidance on how users can address the issues.
+  // A developer-facing human-readable message in English. It should be used
+  // either to explain why the server rejected parts of the data during a partial
+  // success or to convey warnings/suggestions during a full success. The message
+  // should offer guidance on how users can address such issues.
   //
   // error_message is an optional field. An error_message with an empty value
   // is equivalent of it not being set.


### PR DESCRIPTION
This PR is a second attempt in solving/addressing https://github.com/open-telemetry/opentelemetry-specification/issues/2454. This uses the `rejected` semantics instead of `accepted` as discussed in the initial PR https://github.com/open-telemetry/opentelemetry-proto/pull/390. 

Related spec PR: https://github.com/open-telemetry/opentelemetry-specification/pull/2696

The need for this new PR was that with `accepted` we were running into problems with the `0` value being the same as the default/not set, plus general intention to avoid having `optional` on the fields.

I did some tests with sample apps to confirm the cases for backwards compatibility. Those can be checked in: [joaopgrassi/otlp-partial-success-experimental](https://github.com/joaopgrassi/otlp-partial-success-experimental). **The TL;DR:** Since it's a new field no breaking change is introduced. New sender will always have to check if the `partial_success` is set because they can be working with servers using the old protos.

Some context on why this feature is desired:

This feature **IS** intended to help in the following scenarios:

- Enable servers to provide information to users about a partial success without having to return a `400 - BadRequest` (status quo today)
- Enable senders to generate metrics about themselves (`otlp.exporter.rejected.data_points=x`)
- Enable senders to log messages when a partial success is encountered (very useful to troubleshoot things quickly, without having to reach/search for your vendor's logs for ex)
- Capture situations that are not necessarily client or server errors. 
  - Change the type of metric instrument after an initial submission - Gauge > Counter
  - Customers reaching their quotas in the middle of an export request
  - Data not conforming with vendor's constraints - metric keys with not accepted characters coming from a library outside the application's owner control (with the errors they can rename them with a view for ex)
  - OTLP data arriving with timestamp in the past - no explicit contract for this in OTel. Might be tricky for users to debug what's going on

  
This feature **IS NOT** intended to help in the following scenarios:

- Enable clients to retry a partial success request
   - Complicated to handle. Needs more structure, semantic convention on typical errors. Was discussed [in the initial proto PR](https://github.com/open-telemetry/opentelemetry-proto/pull/390#discussion_r871989856)
   - This can always be added later on in a non-breaking manner. I started a separated discussion on this topic for metrics [here](https://github.com/open-telemetry/opentelemetry-proto/issues/404)
- Identify which exact log line/data point/span was rejected. Similar to the point above, it needs more discussion on how this can be done and which structure we should have. Always can be done/improved later

cc @tigrannajaryan @jmacd @jsuereth @jack-berg @reyang 


