### PR TITLE
Rename AnyValue to Value, this should not be on the wire breaking change

### DIFF
--- a/opentelemetry/proto/common/v1/common.proto
+++ b/opentelemetry/proto/common/v1/common.proto
@@ -22,12 +22,12 @@ option java_package = "io.opentelemetry.proto.common.v1";
 option java_outer_classname = "CommonProto";
 option go_package = "go.opentelemetry.io/proto/otlp/common/v1";
 
-// AnyValue is used to represent any type of attribute value. AnyValue may contain a
+// Value is used to represent any type of attribute value. Value may contain a
 // primitive value such as a string or integer or it may contain an arbitrary nested
 // object containing arrays, key-value lists and primitives.
-message AnyValue {
+message Value {
   // The value is one of the listed fields. It is valid for all values to be unspecified
-  // in which case this AnyValue is considered to be "empty".
+  // in which case this Value is considered to be "empty".
   oneof value {
     string string_value = 1;
     bool bool_value = 2;
@@ -39,15 +39,15 @@ message AnyValue {
   }
 }
 
-// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
-// since oneof in AnyValue does not allow repeated fields.
+// ArrayValue is a list of Value messages. We need ArrayValue as a message
+// since oneof in Value does not allow repeated fields.
 message ArrayValue {
   // Array of values. The array may be empty (contain 0 elements).
-  repeated AnyValue values = 1;
+  repeated Value values = 1;
 }
 
 // KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
-// since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need
+// since `oneof` in Value does not allow repeated fields. Everywhere else where we need
 // a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
 // avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
 // are semantically equivalent.
@@ -63,7 +63,7 @@ message KeyValueList {
 // attributes, etc.
 message KeyValue {
   string key = 1;
-  AnyValue value = 2;
+  Value value = 2;
 }
 
 // InstrumentationScope is a message representing the instrumentation scope information

--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -148,7 +148,7 @@ message LogRecord {
   // A value containing the body of the log record. Can be for example a human-readable
   // string message (including multi-line) describing the event in a free form or it can
   // be a structured data composed of arrays and maps of other values. [Optional].
-  opentelemetry.proto.common.v1.AnyValue body = 5;
+  opentelemetry.proto.common.v1.Value body = 5;
 
   // Additional attributes that describe the specific event occurrence. [Optional].
   // Attribute keys MUST be unique (it is not allowed to have more than one


### PR DESCRIPTION
Message names are not used in JSON or Protobuf encoding, so this is a no-op for both json and proto wire encoding.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>