### PR TITLE
Introduce an optional `zero_threshold` field to `ExponentialHistogramDataPoint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Full list of differences found in [this compare](https://github.com/open-telemet
 
 ### Added
 
-* Remove if no changes for this section before release.
+* Introduce an optional `zero_threshold` field to `ExponentialHistogramDataPoint`.
+  [(#440)](https://github.com/open-telemetry/opentelemetry-proto/issues/440)
 
 ### Removed
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -562,10 +562,11 @@ message ExponentialHistogramDataPoint {
   // max is the maximum value over (start_time, end_time].
   optional double max = 13;
 
-  // ZeroTolerance may be optionally set to convey the width of the
-  // zero region. When ZeroTolerance is unset or 0, this bucket stores values
-  // that cannot be expressed using the standard exponential formula as well
-  // as values that have been rounded to zero.
+  // ZeroThreshold may be optionally set to convey the width of the
+  // zero region.
+  // When ZeroThreshold is unset or 0, zero count bucket stores
+  // values that cannot be expressed using the standard exponential formula as
+  // well as values that have been rounded to zero.
   optional double zero_threshold = 14;
 }
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -562,8 +562,9 @@ message ExponentialHistogramDataPoint {
   // max is the maximum value over (start_time, end_time].
   optional double max = 13;
 
-  // ZeroThreshold may be optionally set to convey the width of the
-  // zero region.
+  // ZeroThreshold may be optionally set to convey the width of the zero
+  // region. Where the zero region is defined as the closed interval
+  // [-ZeroThreshold, ZeroThreshold].
   // When ZeroThreshold is unset or 0, zero count bucket stores
   // values that cannot be expressed using the standard exponential formula as
   // well as values that have been rounded to zero.

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -561,6 +561,12 @@ message ExponentialHistogramDataPoint {
 
   // max is the maximum value over (start_time, end_time].
   optional double max = 13;
+
+  // ZeroTolerance may be optionally set to convey the width of the
+  // zero region. When ZeroTolerance is unset or 0, this bucket stores values
+  // that cannot be expressed using the standard exponential formula as well
+  // as values that have been rounded to zero.
+  optional double zero_threshold = 14;
 }
 
 // SummaryDataPoint is a single data point in a timeseries that describes the


### PR DESCRIPTION
Introduce an optional `zero_threshold` field to `ExponentialHistogramDataPoint`.
See [Zero Count and Zero Threshold](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md?plain=1#L622-L640).

Resolves #440 