### PR TITLE
Delete requirement to generate new trace/span id if an invalid id is received

### DIFF
--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -82,18 +82,12 @@ message Span {
   // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes
   // is considered invalid.
   //
-  // This field is semantically required. Receiver should generate new
-  // random trace_id if empty or invalid trace_id was received.
-  //
   // This field is required.
   bytes trace_id = 1;
 
   // A unique identifier for a span within a trace, assigned when the span
   // is created. The ID is an 8-byte array. An ID with all zeroes is considered
   // invalid.
-  //
-  // This field is semantically required. Receiver should generate new
-  // random span_id if empty or invalid span_id was received.
   //
   // This field is required.
   bytes span_id = 2;


### PR DESCRIPTION
This is considered an bug in the spec that was uncovered in the discussion here: https://github.com/open-telemetry/opentelemetry-proto/pull/442#discussion_r1061995668

I did some spelunking and the "generate" recommendation comes from the very first commit: https://github.com/open-telemetry/opentelemetry-proto/commit/b5bcfffce09c956b1419b2b56a9aaff384797517#diff-ef5f80fbf835dd57e14cb9264944f03d80cf6b04cc7671b0e7fb33167c67efcc where they were copied from Java repo, to which they were copied from OpenCensus https://github.com/open-telemetry/opentelemetry-java/pull/134 and in OpenCensus the wording first time appeared here https://github.com/census-instrumentation/opencensus-proto/pull/160 (authored by @SergeyKanzhelev, merged by @bogdandrutu).

We are deleting the requirement to generate a new trace id or span id if an invalid id is received. Instead the receivers can decide how they want to treat the invalid id (just like upon receiving any other invalid data), e.g. they may drop it, log an error, accept the invalid data, etc. We are not going to prescribe a particular receiver behavior when invalid trace/span id is received.