### PR TITLE
Split common package into value and scope

### DIFF
--- a/opentelemetry/proto/common/v1/scope.proto
+++ b/opentelemetry/proto/common/v1/scope.proto
@@ -1,0 +1,35 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.common.v1;
+
+import "opentelemetry/proto/common/v1/value.proto";
+
+option csharp_namespace = "OpenTelemetry.Proto.Common.V1";
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.common.v1";
+option java_outer_classname = "CommonProto";
+option go_package = "go.opentelemetry.io/proto/otlp/common/v1";
+
+// InstrumentationScope is a message representing the instrumentation scope information
+// such as the fully qualified name and version.
+message InstrumentationScope {
+  // An empty instrumentation scope name means the name is unknown.
+  string name = 1;
+  string version = 2;
+  repeated KeyValue attributes = 3;
+  uint32 dropped_attributes_count = 4;
+}

--- a/opentelemetry/proto/common/v1/value.proto
+++ b/opentelemetry/proto/common/v1/value.proto
@@ -65,13 +65,3 @@ message KeyValue {
   string key = 1;
   AnyValue value = 2;
 }
-
-// InstrumentationScope is a message representing the instrumentation scope information
-// such as the fully qualified name and version. 
-message InstrumentationScope {
-  // An empty instrumentation scope name means the name is unknown.
-  string name = 1;
-  string version = 2;
-  repeated KeyValue attributes = 3;
-  uint32 dropped_attributes_count = 4;
-}

--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -16,7 +16,8 @@ syntax = "proto3";
 
 package opentelemetry.proto.logs.v1;
 
-import "opentelemetry/proto/common/v1/common.proto";
+import "opentelemetry/proto/common/v1/value.proto";
+import "opentelemetry/proto/common/v1/scope.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
 option csharp_namespace = "OpenTelemetry.Proto.Logs.V1";

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -16,7 +16,8 @@ syntax = "proto3";
 
 package opentelemetry.proto.metrics.v1;
 
-import "opentelemetry/proto/common/v1/common.proto";
+import "opentelemetry/proto/common/v1/value.proto";
+import "opentelemetry/proto/common/v1/scope.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
 option csharp_namespace = "OpenTelemetry.Proto.Metrics.V1";

--- a/opentelemetry/proto/resource/v1/resource.proto
+++ b/opentelemetry/proto/resource/v1/resource.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package opentelemetry.proto.resource.v1;
 
-import "opentelemetry/proto/common/v1/common.proto";
+import "opentelemetry/proto/common/v1/value.proto";
 
 option csharp_namespace = "OpenTelemetry.Proto.Resource.V1";
 option java_multiple_files = true;

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -16,7 +16,8 @@ syntax = "proto3";
 
 package opentelemetry.proto.trace.v1;
 
-import "opentelemetry/proto/common/v1/common.proto";
+import "opentelemetry/proto/common/v1/value.proto";
+import "opentelemetry/proto/common/v1/scope.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
 option csharp_namespace = "OpenTelemetry.Proto.Trace.V1";


### PR DESCRIPTION
This is a no-op for generated code, but helps within the collector pdata where we want to replace the generated code for the value (remove the entire value file essentially).

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>