### PR TITLE
change the collector trace endpoint to /v1/traces

### DIFF
--- a/opentelemetry/proto/collector/trace/v1/trace_service_http.yaml
+++ b/opentelemetry/proto/collector/trace/v1/trace_service_http.yaml
@@ -5,5 +5,5 @@ config_version: 3
 http:
  rules:
  - selector: opentelemetry.proto.collector.trace.v1.TraceService.Export
-   post: /v1/trace
+   post: /v1/traces
    body: "*"


### PR DESCRIPTION
The OTLP spec requires that traces are sent to /v1/traces when using HTTP.

https://opentelemetry.io/docs/reference/specification/protocol/otlp/#otlphttp-request