### PR TITLE
 Update breaking-change to check against last published version

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -88,6 +88,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    # breaking-change checks against last published release which is determined
+    # using the last published tag
+    - name: Get tags
+      run: git fetch --tags origin
     - name: Run make breaking-change with json output to annotate PR
       # Formats JSON output into Github workflow commands
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,10 @@ BUF_DOCKER ?= bufbuild/buf:1.7.0
 
 PROTOC := docker run --rm -u ${shell id -u} -v${PWD}:${PWD} -w${PWD} ${OTEL_DOCKER_PROTOBUF} --proto_path=${PWD}
 BUF := docker run --rm -v "${PWD}:/workspace" -w /workspace ${BUF_DOCKER}
-# When checking for protobuf breaking changes, check against the upstream repo's main branch.
+# When checking for protobuf breaking changes, check against the latest release tag
+LAST_RELEASE_TAG := $(shell git tag --sort=committerdate | tail -1)
 # Options are described in https://docs.buf.build/breaking/usage#git
-BUF_AGAINST ?= "https://github.com/open-telemetry/opentelemetry-proto.git"
+BUF_AGAINST ?= "https://github.com/open-telemetry/opentelemetry-proto.git\#tag=$(LAST_RELEASE_TAG)"
 
 PROTO_GEN_CPP_DIR ?= $(GENDIR)/cpp
 PROTO_GEN_CSHARP_DIR ?= $(GENDIR)/csharp


### PR DESCRIPTION
`breaking-change` currently checks compatibility against main when it should really check against the last published tag.

See [this build failure](https://github.com/open-telemetry/opentelemetry-proto/actions/runs/4417897856/jobs/7744262242) for an example. The commit fixes a change that has yet to be released, but still fails.