### PR TITLE
Use "example.com" where an example domain is needed

### DIFF
--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -172,8 +172,8 @@ message Span {
   //
   //     "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
   //     "/http/server_latency": 300
-  //     "abc.com/myattribute": true
-  //     "abc.com/score": 10.239
+  //     "example.com/myattribute": true
+  //     "example.com/score": 10.239
   //
   // The OpenTelemetry API specification further restricts the allowed value types:
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute


### PR DESCRIPTION
`example.com` is [reserved by IANA for example uses](https://www.iana.org/domains/reserved). `abc.com` is a real domain