### PR TITLE
Clarify that symbolic guarantees go into effect from 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,21 @@ Components marked `Stable` provide the following guarantees:
 
 - Field types, numbers and names will not change.
 - Service names and service package names will not change.
-- Service method names will not change.
-- Service method parameter names will not change.
-- Service method parameter types and return types will not change.
+- Service method names will not change. [from 1.0.0]
+- Service method parameter names will not change. [from 1.0.0]
+- Service method parameter types and return types will not change. [from 1.0.0] 
 - Service method kind (unary vs streaming) will not change.
-- Names of messages and enums will not change.
-- Names of enum choices and numbers assigned to enum choices will not change.
+- Names of messages and enums will not change. [from 1.0.0]
+- Numbers assigned to enum choices will not change.
+- Names of enum choices will not change. [from 1.0.0]
 - The location of messages and enums, i.e. whether they are declared at the top lexical
-  scope or nested inside another message will not change.
-- Package names and directory structure will not change.
-- `optional` and `repeated` declarators of existing fields will not change.
-- No existing symbol will be deleted.
+  scope or nested inside another message will not change. [from 1.0.0]
+- Package names and directory structure will not change. [from 1.0.0]
+- `optional` and `repeated` declarators of existing fields will not change. [from 1.0.0]
+- No existing symbol will be deleted.  [from 1.0.0]
+
+Note: guarantees marked [from 1.0.0] will go into effect when this repository is tagged
+with version number 1.0.0.
 
 The following additive changes are allowed:
 


### PR DESCRIPTION
We merged the https://github.com/open-telemetry/opentelemetry-proto/pull/432 without clarifying when exactly the guarantees start applying. The intent was that the guarantees are needed for 1.0 release but we didn't make this explicit.

We are now making this explicit and until 1.0 released we should be free to fix the remaining known issues listed here:
https://github.com/open-telemetry/opentelemetry-proto/issues/456

Once 1.0 release is made we can remove the [from 1.0.0] labels from the README.md.