### PR TITLE
Fix JSON field capitalization in trace.json example

### DIFF
--- a/examples/trace.json
+++ b/examples/trace.json
@@ -1,5 +1,5 @@
 {
-  "resource_spans": [
+  "resourceSpans": [
     {
       "resource": {
         "attributes": [
@@ -11,7 +11,7 @@
           }
         ]
       },
-      "scope_spans": [
+      "scopeSpans": [
         {
           "scope": {
             "name": "my.library",


### PR DESCRIPTION
Indirectly related to https://github.com/open-telemetry/opentelemetry-proto/issues/476

The spec requires that:

>The keys of JSON objects are field names converted to lowerCamelCase.

See https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#json-protobuf-encoding