### PR TITLE
[editorial] Drop or adjust Hugo front matter in doc pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,3 @@
-<!--- Hugo front matter used to generate the website version of this page:
-linkTitle: OTLP
-aliases:
-  - /docs/reference/specification/protocol
-  - /docs/specs/otel/protocol
-spelling: cSpell:ignore otel OTLP
---->
-
 # OpenTelemetry Protocol (OTLP)
 
 This is the specification of the OpenTelemetry Protocol (OTLP).

--- a/docs/design-goals.md
+++ b/docs/design-goals.md
@@ -1,11 +1,3 @@
-<!--- Hugo front matter used to generate the website version of this page:
-linkTitle: Design goals
-aliases:
-  - /docs/reference/specification/protocol/design-goals
-  - /docs/specs/otel/protocol/design-goals
-spelling: cSpell:ignore backpressure otel
---->
-
 # Design Goals for OpenTelemetry Wire Protocol
 
 We want to design a telemetry data exchange protocol that has the following characteristics:

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,11 +1,3 @@
-<!--- Hugo front matter used to generate the website version of this page:
-linkTitle: Requirements
-aliases:
-  - /docs/reference/specification/protocol/requirements
-  - /docs/specs/otel/protocol/requirements
-spelling: cSpell:ignore backpressure dealocations otel reconnections
---->
-
 # OpenTelemetry Protocol Requirements
 
 This document will drive OpenTelemetry Protocol design and RFC.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,11 +1,20 @@
 <!--- Hugo front matter used to generate the website version of this page:
 title: OTLP Specification
-linkTitle: Specification
+linkTitle: OTLP
 aliases:
   - /docs/reference/specification/protocol/otlp
   - /docs/specs/otel/protocol/otlp
 spelling:
-  cSpell:ignore backpressure dealocations otel otlp protobuf reconnections retryable OTEP
+  cSpell:ignore backoff backpressure dealocations errdetails nanos proto reconnections retryable
+cascade:
+  body_class: otel-docs-spec
+  github_repo: &repo https://github.com/open-telemetry/opentelemetry-proto
+  github_subdir: docs
+  path_base_for_github_subdir: content/en/docs/specs/otlp/
+  github_project_repo: *repo
+path_base_for_github_subdir:
+  from: content/en/docs/specs/otlp/_index.md
+  to: specification.md
 --->
 
 # OpenTelemetry Protocol Specification


### PR DESCRIPTION
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/2642
- Drops Hugo front matter from files that are no longer being published on the OTel website
- Fixes the Hugo front matter of the spec page