### PR TITLE
Indicate if a span's parent or link is remote using 2 bit flag as described in OTEP 0182

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ Full list of differences found in [this compare](https://github.com/open-telemet
 
 ### Added
 
-* Add `flags` field to `Span` and `Span/Link` for W3C-specified Trace Context flags .
+* Add `flags` field to `Span` and `Span/Link` for W3C-specified Trace Context flags.
   [#503](https://github.com/open-telemetry/opentelemetry-proto/pull/503)
+* Indicate if a `Span`'s parent or link is remote using 2 bit flag.
+  [#484](https://github.com/open-telemetry/opentelemetry-proto/pull/484)
 
 ### Changed
 

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -274,6 +274,10 @@ message Span {
     // SPAN_FLAGS_TRACE_FLAGS_MASK).  [Optional].
     //
     // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+    //
+    // Bits 8 and 9 represent the 3 states of whether the link
+    // is remote. The states are unknown, is not remote, is remote.
+    // To read the 2-bit flag, use `flags & SPAN_FLAGS_LINK_IS_REMOTE_MASK`.
     fixed32 flags = 6;
   }
 
@@ -340,6 +344,10 @@ enum SpanFlags {
   // See SpanFlagsParentIsRemote for the valid values.
   SPAN_FLAGS_PARENT_IS_REMOTE_MASK = 0x00000300;
 
+  // Bits 8 and 9 are used for for the link is remote flag.
+  // See SpanFlagsLinkIsRemote for the valid values.
+  SPAN_FLAGS_LINK_IS_REMOTE_MASK = 0x00000300;
+
   // Bits 10-31 are reserved for future use.
 }
 
@@ -357,4 +365,20 @@ enum SpanFlagsParentIsRemote {
   SPAN_FLAGS_PARENT_IS_REMOTE = 0x00000300;
   // The parent is not remote: 01
   SPAN_FLAGS_PARENT_IS_NOT_REMOTE = 0x00000100;
+}
+
+// SpanFlagsLinkIsRemote represents constants used to interpret
+// bits 8 and 9 of the Link.flags field. These two bits represent whether
+// the link is remote. Bit 8 represents whether the field has been
+// set and bit 9 represents whether the link is remote.
+// Once the bits have been read using SPAN_FLAGS_LINK_IS_REMOTE_MASK,
+// the following constants can be used to interpret them.
+enum SpanFlagsLinkIsRemote {
+  // Older clients may not set this field, so 00 represents that this value
+  // has not been set.
+  SPAN_FLAGS_LINK_IS_REMOTE_UNKNOWN = 0;
+  // The linked span is remote: 11
+  SPAN_FLAGS_LINK_IS_REMOTE = 0x00000300;
+  // The linked span is not remote: 01
+  SPAN_FLAGS_LINK_IS_NOT_REMOTE = 0x00000100;
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -353,7 +353,7 @@ enum SpanFlags {
 // remote.
 // Once the bits have been read using SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK,
 // the following constants can be used to interpret them.
-enum SpanFlagsParentOrLinkIsRemote {
+enum SpanFlagsContextIsRemote {
   // Older clients may not set this field, so 00 represents that this value
   // has not been set.
   SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_UNKNOWN = 0;

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -109,7 +109,9 @@ message Span {
   // field must be empty. The ID is an 8-byte array.
   bytes parent_span_id = 4;
 
-  // Flags, a bit field. Bits 0-7 (8 least significant bits) are the trace
+  // Flags, a bit field. 
+  //
+  // Bits 0-7 (8 least significant bits) are the trace
   // flags as defined in W3C Trace Context specification.
   // To read the 8-bit W3C trace flag, use `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
   //

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -285,7 +285,8 @@ message Span {
   // ParentSpanIsRemote indicates whether the span's parent is remote (true / false) or
   // if the field is unset.
   enum ParentSpanIsRemote {
-    // Unset.
+    // Unset. This value is expected from older clients. In which case, ParentSpanIsRemote
+    // can be derived by looking at the parent span and determining if it has a different Resource.
     PARENT_SPAN_IS_REMOTE_UNSET = 0;
 
     // The parent span is not remote.

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -358,8 +358,8 @@ enum SpanFlags {
 // Once the bits have been read using SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK,
 // the following constants can be used to interpret them.
 enum SpanFlagsContextIsRemote {
-  // Older clients may not set this field, so 00 represents that this value
-  // has not been set.
+  // Older client not supporting this flag, or not known whether parent or
+  // linked span is remote: 00
   SPAN_FLAGS_CONTEXT_IS_REMOTE_UNKNOWN = 0;
   // The parent or linked span is remote: 11
   SPAN_FLAGS_CONTEXT_IS_REMOTE = 0x00000300;

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -284,7 +284,7 @@ message Span {
 
   // ParentSpanIsRemote indicates whether the span's parent is remote (true / false) or
   // if the field is unset.
-  enum ParentIsRemote {
+  enum ParentSpanIsRemote {
     // Unset.
     PARENT_SPAN_IS_REMOTE_UNSET = 0;
 

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -123,6 +123,10 @@ message Span {
   // [Optional].
   //
   // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+  //
+  // Bits 8 and 9 are reserved for representing the 3 states of whether a span's parent
+  // is remote. The states are unknown, is not remote, is remote.
+  // To read the 2-bit flag, use `flags & SPAN_FLAGS_PARENT_IS_REMOTE_MASK`.
   fixed32 flags = 16;
 
   // A description of the span's operation.
@@ -329,5 +333,8 @@ enum SpanFlags {
   // Bits 0-7 are used for trace flags.
   SPAN_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
 
-  // Bits 8-31 are reserved for future use.
+  // Bits 8 and 9 are used for for the parent is remote flag.
+  SPAN_FLAGS_PARENT_IS_REMOTE_MASK = 0x00000300;
+
+  // Bits 10-31 are reserved for future use.
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -341,7 +341,7 @@ enum SpanFlags {
 
   // Bits 8 and 9 are used to indicate that the parent span or link span is remote.
   // See SpanFlagsParentOrLinkIsRemote for the valid values.
-  SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK = 0x00000300;
+  SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK = 0x00000300;
 
   // Bits 10-31 are reserved for future use.
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -119,7 +119,8 @@ message Span {
   //
   // Bits 8 and 9 represent the 3 states of whether a span's parent
   // is remote. The states are (unknown, is not remote, is remote).
-  // To read the 2-bit flag, use `flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK`.
+  // To read whether the value is known, use `flags & SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK`.
+  // To read whether the span is remote, use `flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK`.
   //
   // When creating span messages, if the message is logically forwarded from another source
   // with an equivalent flags fields (i.e., usually another OTLP span message), the field SHOULD
@@ -275,7 +276,8 @@ message Span {
     //
     // Bits 8 and 9 represent the 3 states of whether the link is remote. The states
     // are unknown, is not remote, is remote.
-    // To read the 2-bit flag, use `flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK`.
+    // To read whether the value is known, use `flags & SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK`.
+    // To read whether the link is remote, use `flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK`.
     //
     // Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero.
     // When creating new spans, bits 10-31 (most-significant 22-bits) MUST be zero.

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -344,25 +344,9 @@ enum SpanFlags {
   SPAN_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
 
   // Bits 8 and 9 are used to indicate that the parent span or link span is remote.
-  // See SpanFlagsContextIsRemote for the valid values.
+  // Bit 8 indicates whether the value is known. Bit 9 indicates whether the span
+  // or link is remote.
   SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK = 0x00000300;
 
   // Bits 10-31 are reserved for future use.
-}
-
-// SpanFlagsContextIsRemote represents constants used to interpret
-// bits 8 and 9 of the Spans.flags or Link.flags field. These two bits
-// represent whether the parent or link is remote. Bit 8 represents whether
-// the field has been set and bit 9 represents whether the parent or link is
-// remote.
-// Once the bits have been read using SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK,
-// the following constants can be used to interpret them.
-enum SpanFlagsContextIsRemote {
-  // Older client not supporting this flag, or not known whether parent or
-  // linked span is remote: 00
-  SPAN_FLAGS_CONTEXT_IS_REMOTE_UNKNOWN = 0;
-  // The parent or linked span is remote: 11
-  SPAN_FLAGS_CONTEXT_IS_REMOTE = 0x00000300;
-  // The parent or linked span is not remote: 01
-  SPAN_FLAGS_CONTEXT_IS_NOT_REMOTE = 0x00000100;
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -340,13 +340,13 @@ enum SpanFlags {
   SPAN_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
 
   // Bits 8 and 9 are used to indicate that the parent span or link span is remote.
-  // See SpanFlagsParentOrLinkIsRemote for the valid values.
+  // See SpanFlagsContextIsRemote for the valid values.
   SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK = 0x00000300;
 
   // Bits 10-31 are reserved for future use.
 }
 
-// SpanFlagsParentOrLinkIsRemote represents constants used to interpret
+// SpanFlagsContextIsRemote represents constants used to interpret
 // bits 8 and 9 of the Spans.flags or Link.flags field. These two bits
 // represent whether the parent or link is remote. Bit 8 represents whether
 // the field has been set and bit 9 represents whether the parent or link is

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -282,11 +282,24 @@ message Span {
   // span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0).
   Status status = 15;
 
+  // ParentSpanIsRemote indicates whether the span's parent is remote (true / false) or
+  // if the field is unset.
+  enum ParentIsRemote {
+    // Unset.
+    PARENT_SPAN_IS_REMOTE_UNSET = 0;
+
+    // The parent span is not remote.
+    PARENT_SPAN_IS_REMOTE_FALSE = 1;
+
+    // The parent span is remote.
+    PARENT_SPAN_IS_REMOTE_TRUE = 2;
+  }
+
   // parent_span_is_remote identifies whether a span's parent is remote or not.
   // This helps determine whether a span can be considered an entry-point span.
   // A span is an entry-point span if it has no parent (parent_span_id is empty),
-  // or if parent_span_is_remote is true.
-  bool parent_span_is_remote = 16;
+  // or if parent_is_remote is true.
+  ParentSpanIsRemote parent_span_is_remote = 16;
 }
 
 // The Status type defines a logical error model that is suitable for different

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -351,7 +351,7 @@ enum SpanFlags {
 // represent whether the parent or link is remote. Bit 8 represents whether
 // the field has been set and bit 9 represents whether the parent or link is
 // remote.
-// Once the bits have been read using SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK,
+// Once the bits have been read using SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK,
 // the following constants can be used to interpret them.
 enum SpanFlagsContextIsRemote {
   // Older clients may not set this field, so 00 represents that this value

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -356,9 +356,9 @@ enum SpanFlags {
 enum SpanFlagsContextIsRemote {
   // Older clients may not set this field, so 00 represents that this value
   // has not been set.
-  SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_UNKNOWN = 0;
+  SPAN_FLAGS_CONTEXT_IS_REMOTE_UNKNOWN = 0;
   // The parent or linked span is remote: 11
-  SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE = 0x00000300;
+  SPAN_FLAGS_CONTEXT_IS_REMOTE = 0x00000300;
   // The parent or linked span is not remote: 01
-  SPAN_FLAGS_PARENT_OR_LINK_IS_NOT_REMOTE = 0x00000100;
+  SPAN_FLAGS_CONTEXT_IS_NOT_REMOTE = 0x00000100;
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -109,11 +109,11 @@ message Span {
   // field must be empty. The ID is an 8-byte array.
   bytes parent_span_id = 4;
 
-  // Flags, a bit field. 
+  // Flags, a bit field.
   //
-  // Bits 0-7 (8 least significant bits) are the trace
-  // flags as defined in W3C Trace Context specification.
-  // To read the 8-bit W3C trace flag, use `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
+  // Bits 0-7 (8 least significant bits) are the trace flags as defined in W3C Trace
+  // Context specification. To read the 8-bit W3C trace flag, use
+  // `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
   //
   // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
   //
@@ -265,9 +265,11 @@ message Span {
     // then no attributes were dropped.
     uint32 dropped_attributes_count = 5;
 
-    // Flags, a bit field. Bits 0-7 (8 least significant bits) are the trace
-    // flags as defined in W3C Trace Context specification. To read the 8-bit W3C trace
-    // flag, use `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
+    // Flags, a bit field.
+    //
+    // Bits 0-7 (8 least significant bits) are the trace flags as defined in W3C Trace
+    // Context specification. To read the 8-bit W3C trace flag, use
+    // `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
     //
     // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
     //

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -344,9 +344,10 @@ enum SpanFlags {
   SPAN_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
 
   // Bits 8 and 9 are used to indicate that the parent span or link span is remote.
-  // Bit 8 indicates whether the value is known. Bit 9 indicates whether the span
-  // or link is remote.
-  SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK = 0x00000300;
+  // Bit 8 (`HAS_IS_REMOTE`) indicates whether the value is known.
+  // Bit 9 (`IS_REMOTE`) indicates whether the span or link is remote.
+  SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK = 0x00000100;
+  SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK = 0x00000200;
 
   // Bits 10-31 are reserved for future use.
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -286,13 +286,13 @@ message Span {
   // if the field is unset.
   enum ParentSpanIsRemote {
     // Unset. This value is expected from older clients.
-    PARENT_SPAN_IS_REMOTE_UNSET = 0;
+    PARENT_SPAN_UNKNOWN_REMOTE = 0;
 
     // The parent span is not remote.
-    PARENT_SPAN_IS_REMOTE_FALSE = 1;
+    PARENT_SPAN_NOT_REMOTE = 1;
 
     // The parent span is remote.
-    PARENT_SPAN_IS_REMOTE_TRUE = 2;
+    PARENT_SPAN_REMOTE = 2;
   }
 
   // parent_span_is_remote identifies whether a span's parent is remote or not.

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -118,7 +118,7 @@ message Span {
   // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
   //
   // Bits 8 and 9 represent the 3 states of whether a span's parent
-  // is remote. The states are unknown, is not remote, is remote.
+  // is remote. The states are (unknown, is not remote, is remote).
   // To read the 2-bit flag, use `flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK`.
   //
   // When creating span messages, if the message is logically forwarded from another source

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -281,6 +281,12 @@ message Span {
   // An optional final status for this span. Semantically when Status isn't set, it means
   // span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0).
   Status status = 15;
+
+  // parent_span_is_remote identifies whether a span's parent is remote or not.
+  // This helps determine whether a span can be considered an entry-point span.
+  // A span is an entry-point span if it has no parent (parent_span_id is empty),
+  // or if parent_span_is_remote is true.
+  bool parent_span_is_remote = 16;
 }
 
 // The Status type defines a logical error model that is suitable for different

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -127,9 +127,9 @@ message Span {
   // is remote. The states are unknown, is not remote, is remote.
   // To read the 2-bit flag, use `flags & SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK`.
   //
-  // [Optional].
+  // Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero.
   //
-  // Readers MUST not assume that bits 10-31 (22 most significant bits) will be zero.
+  // [Optional].
   fixed32 flags = 16;
 
   // A description of the span's operation.

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -113,20 +113,17 @@ message Span {
   // flags as defined in W3C Trace Context specification.
   // To read the 8-bit W3C trace flag, use `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
   //
-  // When creating span messages, if the message is logically forwarded from another source
-  // with an equivalent flags fields (i.e., usually another OTLP span message), the field SHOULD
-  // be copied as-is. If creating from a source that does not have an equivalent flags field
-  // (such as a runtime representation of an OpenTelemetry span), the high 22 bits MUST
-  // be set to zero.
-  //
-  // [Optional].
-  //
   // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
   //
   // Bits 8 and 9 represent the 3 states of whether a span's parent
   // is remote. The states are unknown, is not remote, is remote.
   // To read the 2-bit flag, use `flags & SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK`.
   //
+  // When creating span messages, if the message is logically forwarded from another source
+  // with an equivalent flags fields (i.e., usually another OTLP span message), the field SHOULD
+  // be copied as-is. If creating from a source that does not have an equivalent flags field
+  // (such as a runtime representation of an OpenTelemetry span), the high 22 bits MUST
+  // be set to zero.
   // Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero.
   //
   // [Optional].
@@ -266,18 +263,20 @@ message Span {
     // then no attributes were dropped.
     uint32 dropped_attributes_count = 5;
 
-    // Flags, a bit field. Bit 0-7 (8 least significant bits) are the trace
-    // flags as defined in W3C Trace Context specification. Readers
-    // MUST not assume that bits 10-31 (22 most significant bits) will be zero.
-    // When creating new spans, bits 10-31 (most-significant 22-bits) MUST be
-    // zero. To read the 8-bit W3C trace flag (use flags &
-    // SPAN_FLAGS_TRACE_FLAGS_MASK).  [Optional].
+    // Flags, a bit field. Bits 0-7 (8 least significant bits) are the trace
+    // flags as defined in W3C Trace Context specification. To read the 8-bit W3C trace
+    // flag, use `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
     //
     // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
     //
-    // Bits 8 and 9 represent the 3 states of whether the link
-    // is remote. The states are unknown, is not remote, is remote.
+    // Bits 8 and 9 represent the 3 states of whether the link is remote. The states
+    // are unknown, is not remote, is remote.
     // To read the 2-bit flag, use `flags & SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK`.
+    //
+    // Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero.
+    // When creating new spans, bits 10-31 (most-significant 22-bits) MUST be zero.
+    //
+    // [Optional].
     fixed32 flags = 6;
   }
 
@@ -340,7 +339,7 @@ enum SpanFlags {
   // Bits 0-7 are used for trace flags.
   SPAN_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
 
-  // Bits 8 and 9 are used for the parent or link is remote flag.
+  // Bits 8 and 9 are used to indicate that the parent span or link span is remote.
   // See SpanFlagsParentIsRemote and SpanFlagsLinkIsRemote for the
   // valid values.
   SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK = 0x00000300;

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -340,41 +340,25 @@ enum SpanFlags {
   SPAN_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
 
   // Bits 8 and 9 are used to indicate that the parent span or link span is remote.
-  // See SpanFlagsParentIsRemote and SpanFlagsLinkIsRemote for the
-  // valid values.
+  // See SpanFlagsParentOrLinkIsRemote for the valid values.
   SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK = 0x00000300;
 
   // Bits 10-31 are reserved for future use.
 }
 
-// SpanFlagsParentIsRemote represents constants used to interpret
-// bits 8 and 9 of the Span.flags field. These two bits represent whether
-// the span's parent is remote. Bit 8 represents whether the field has been
-// set and bit 9 represents whether the parent is remote.
+// SpanFlagsParentOrLinkIsRemote represents constants used to interpret
+// bits 8 and 9 of the Spans.flags or Link.flags field. These two bits
+// represent whether the parent or link is remote. Bit 8 represents whether
+// the field has been set and bit 9 represents whether the parent or link is
+// remote.
 // Once the bits have been read using SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK,
 // the following constants can be used to interpret them.
-enum SpanFlagsParentIsRemote {
+enum SpanFlagsParentOrLinkIsRemote {
   // Older clients may not set this field, so 00 represents that this value
   // has not been set.
-  SPAN_FLAGS_PARENT_IS_REMOTE_UNKNOWN = 0;
-  // The parent is remote: 11
-  SPAN_FLAGS_PARENT_IS_REMOTE = 0x00000300;
-  // The parent is not remote: 01
-  SPAN_FLAGS_PARENT_IS_NOT_REMOTE = 0x00000100;
-}
-
-// SpanFlagsLinkIsRemote represents constants used to interpret
-// bits 8 and 9 of the Link.flags field. These two bits represent whether
-// the link is remote. Bit 8 represents whether the field has been
-// set and bit 9 represents whether the link is remote.
-// Once the bits have been read using SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK,
-// the following constants can be used to interpret them.
-enum SpanFlagsLinkIsRemote {
-  // Older clients may not set this field, so 00 represents that this value
-  // has not been set.
-  SPAN_FLAGS_LINK_IS_REMOTE_UNKNOWN = 0;
-  // The linked span is remote: 11
-  SPAN_FLAGS_LINK_IS_REMOTE = 0x00000300;
-  // The linked span is not remote: 01
-  SPAN_FLAGS_LINK_IS_NOT_REMOTE = 0x00000100;
+  SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_UNKNOWN = 0;
+  // The parent or linked span is remote: 11
+  SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE = 0x00000300;
+  // The parent or linked span is not remote: 01
+  SPAN_FLAGS_PARENT_OR_LINK_IS_NOT_REMOTE = 0x00000100;
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -117,7 +117,7 @@ message Span {
   //
   // Bits 8 and 9 represent the 3 states of whether a span's parent
   // is remote. The states are unknown, is not remote, is remote.
-  // To read the 2-bit flag, use `flags & SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK`.
+  // To read the 2-bit flag, use `flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK`.
   //
   // When creating span messages, if the message is logically forwarded from another source
   // with an equivalent flags fields (i.e., usually another OTLP span message), the field SHOULD

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -285,8 +285,7 @@ message Span {
   // ParentSpanIsRemote indicates whether the span's parent is remote (true / false) or
   // if the field is unset.
   enum ParentSpanIsRemote {
-    // Unset. This value is expected from older clients. In which case, ParentSpanIsRemote
-    // can be derived by looking at the parent span and determining if it has a different Resource.
+    // Unset. This value is expected from older clients.
     PARENT_SPAN_IS_REMOTE_UNSET = 0;
 
     // The parent span is not remote.

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -125,7 +125,7 @@ message Span {
   //
   // Bits 8 and 9 represent the 3 states of whether a span's parent
   // is remote. The states are unknown, is not remote, is remote.
-  // To read the 2-bit flag, use `flags & SPAN_FLAGS_PARENT_IS_REMOTE_MASK`.
+  // To read the 2-bit flag, use `flags & SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK`.
   //
   // [Optional].
   //
@@ -277,7 +277,7 @@ message Span {
     //
     // Bits 8 and 9 represent the 3 states of whether the link
     // is remote. The states are unknown, is not remote, is remote.
-    // To read the 2-bit flag, use `flags & SPAN_FLAGS_LINK_IS_REMOTE_MASK`.
+    // To read the 2-bit flag, use `flags & SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK`.
     fixed32 flags = 6;
   }
 
@@ -340,13 +340,10 @@ enum SpanFlags {
   // Bits 0-7 are used for trace flags.
   SPAN_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
 
-  // Bits 8 and 9 are used for for the parent is remote flag.
-  // See SpanFlagsParentIsRemote for the valid values.
-  SPAN_FLAGS_PARENT_IS_REMOTE_MASK = 0x00000300;
-
-  // Bits 8 and 9 are used for for the link is remote flag.
-  // See SpanFlagsLinkIsRemote for the valid values.
-  SPAN_FLAGS_LINK_IS_REMOTE_MASK = 0x00000300;
+  // Bits 8 and 9 are used for the parent or link is remote flag.
+  // See SpanFlagsParentIsRemote and SpanFlagsLinkIsRemote for the
+  // valid values.
+  SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK = 0x00000300;
 
   // Bits 10-31 are reserved for future use.
 }
@@ -355,7 +352,7 @@ enum SpanFlags {
 // bits 8 and 9 of the Span.flags field. These two bits represent whether
 // the span's parent is remote. Bit 8 represents whether the field has been
 // set and bit 9 represents whether the parent is remote.
-// Once the bits have been read using SPAN_FLAGS_PARENT_IS_REMOTE_MASK,
+// Once the bits have been read using SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK,
 // the following constants can be used to interpret them.
 enum SpanFlagsParentIsRemote {
   // Older clients may not set this field, so 00 represents that this value
@@ -371,7 +368,7 @@ enum SpanFlagsParentIsRemote {
 // bits 8 and 9 of the Link.flags field. These two bits represent whether
 // the link is remote. Bit 8 represents whether the field has been
 // set and bit 9 represents whether the link is remote.
-// Once the bits have been read using SPAN_FLAGS_LINK_IS_REMOTE_MASK,
+// Once the bits have been read using SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK,
 // the following constants can be used to interpret them.
 enum SpanFlagsLinkIsRemote {
   // Older clients may not set this field, so 00 represents that this value

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -274,8 +274,8 @@ message Span {
     //
     // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
     //
-    // Bits 8 and 9 represent the 3 states of whether the link is remote. The states
-    // are unknown, is not remote, is remote.
+    // Bits 8 and 9 represent the 3 states of whether the link is remote.
+    // The states are (unknown, is not remote, is remote).
     // To read whether the value is known, use `flags & SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK`.
     // To read whether the link is remote, use `flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK`.
     //

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -271,7 +271,7 @@ message Span {
     //
     // Bits 8 and 9 represent the 3 states of whether the link is remote. The states
     // are unknown, is not remote, is remote.
-    // To read the 2-bit flag, use `flags & SPAN_FLAGS_PARENT_OR_LINK_IS_REMOTE_MASK`.
+    // To read the 2-bit flag, use `flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK`.
     //
     // Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero.
     // When creating new spans, bits 10-31 (most-significant 22-bits) MUST be zero.

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -281,25 +281,6 @@ message Span {
   // An optional final status for this span. Semantically when Status isn't set, it means
   // span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0).
   Status status = 15;
-
-  // ParentSpanIsRemote indicates whether the span's parent is remote (true / false) or
-  // if the field is unset.
-  enum ParentSpanIsRemote {
-    // Unset. This value is expected from older clients.
-    PARENT_SPAN_UNKNOWN_REMOTE = 0;
-
-    // The parent span is not remote.
-    PARENT_SPAN_NOT_REMOTE = 1;
-
-    // The parent span is remote.
-    PARENT_SPAN_REMOTE = 2;
-  }
-
-  // parent_span_is_remote identifies whether a span's parent is remote or not.
-  // This helps determine whether a span can be considered an entry-point span.
-  // A span is an entry-point span if it has no parent (parent_span_id is empty),
-  // or if parent_is_remote is true.
-  ParentSpanIsRemote parent_span_is_remote = 16;
 }
 
 // The Status type defines a logical error model that is suitable for different

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -109,24 +109,27 @@ message Span {
   // field must be empty. The ID is an 8-byte array.
   bytes parent_span_id = 4;
 
-  // Flags, a bit field. 8 least significant bits are the trace
-  // flags as defined in W3C Trace Context specification. Readers
-  // MUST not assume that 24 most significant bits will be zero.
+  // Flags, a bit field. Bits 0-7 (8 least significant bits) are the trace
+  // flags as defined in W3C Trace Context specification.
   // To read the 8-bit W3C trace flag, use `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
   //
   // When creating span messages, if the message is logically forwarded from another source
   // with an equivalent flags fields (i.e., usually another OTLP span message), the field SHOULD
   // be copied as-is. If creating from a source that does not have an equivalent flags field
-  // (such as a runtime representation of an OpenTelemetry span), the high 24 bits MUST
+  // (such as a runtime representation of an OpenTelemetry span), the high 22 bits MUST
   // be set to zero.
   //
   // [Optional].
   //
   // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
   //
-  // Bits 8 and 9 are reserved for representing the 3 states of whether a span's parent
+  // Bits 8 and 9 represent the 3 states of whether a span's parent
   // is remote. The states are unknown, is not remote, is remote.
   // To read the 2-bit flag, use `flags & SPAN_FLAGS_PARENT_IS_REMOTE_MASK`.
+  //
+  // [Optional].
+  //
+  // Readers MUST not assume that bits 10-31 (22 most significant bits) will be zero.
   fixed32 flags = 16;
 
   // A description of the span's operation.
@@ -263,11 +266,11 @@ message Span {
     // then no attributes were dropped.
     uint32 dropped_attributes_count = 5;
 
-    // Flags, a bit field. 8 least significant bits are the trace
+    // Flags, a bit field. Bit 0-7 (8 least significant bits) are the trace
     // flags as defined in W3C Trace Context specification. Readers
-    // MUST not assume that 24 most significant bits will be zero.
-    // When creating new spans, the most-significant 24-bits MUST be
-    // zero.  To read the 8-bit W3C trace flag (use flags &
+    // MUST not assume that bits 10-31 (22 most significant bits) will be zero.
+    // When creating new spans, bits 10-31 (most-significant 22-bits) MUST be
+    // zero. To read the 8-bit W3C trace flag (use flags &
     // SPAN_FLAGS_TRACE_FLAGS_MASK).  [Optional].
     //
     // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
@@ -334,7 +337,24 @@ enum SpanFlags {
   SPAN_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
 
   // Bits 8 and 9 are used for for the parent is remote flag.
+  // See SpanFlagsParentIsRemote for the valid values.
   SPAN_FLAGS_PARENT_IS_REMOTE_MASK = 0x00000300;
 
   // Bits 10-31 are reserved for future use.
+}
+
+// SpanFlagsParentIsRemote represents constants used to interpret
+// bits 8 and 9 of the Span.flags field. These two bits represent whether
+// the span's parent is remote. Bit 8 represents whether the field has been
+// set and bit 9 represents whether the parent is remote.
+// Once the bits have been read using SPAN_FLAGS_PARENT_IS_REMOTE_MASK,
+// the following constants can be used to interpret them.
+enum SpanFlagsParentIsRemote {
+  // Older clients may not set this field, so 00 represents that this value
+  // has not been set.
+  SPAN_FLAGS_PARENT_IS_REMOTE_UNKNOWN = 0;
+  // The parent is remote: 11
+  SPAN_FLAGS_PARENT_IS_REMOTE = 0x00000300;
+  // The parent is not remote: 01
+  SPAN_FLAGS_PARENT_IS_NOT_REMOTE = 0x00000100;
 }


### PR DESCRIPTION
~~This adds `parent_span_is_remote` field to Span message~~ introduced in OTEP 0182: https://github.com/open-telemetry/oteps/blob/main/text/0182-otlp-remote-parent.md

Update: The PR now uses 2 bits from `flags` to represent the 3 states of parent or link is remote: unknown, not remote, is remote.