### PR TITLE
Adjust gauge StartTimeUnixNano description to accommodate sync gauges

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -188,11 +188,13 @@ message Metric {
 // "current value" for every data point. It should be used for an "unknown"
 // aggregation.
 //
-// A Gauge does not support different aggregation temporalities. Given the
-// aggregation is unknown, points cannot be combined using the same
-// aggregation, regardless of aggregation temporalities. Therefore,
-// AggregationTemporality is not included. Consequently, this also means
-// "StartTimeUnixNano" is ignored for all data points.
+// A Gauge does not support different aggregation temporalities.
+// However, its "StartTimeUnixNano" may follow the semantics of a temporality
+// selection. E.g. "StartTimeUnixNano" may be the time of last collection when
+// temporality is delta, versus time of first observation for when temporality
+// is cumulative. Given the aggregation is unknown, points cannot be combined
+// using the same aggregation, regardless of aggregation temporalities.
+// Therefore, AggregationTemporality is not included.
 message Gauge {
   repeated NumberDataPoint data_points = 1;
 }


### PR DESCRIPTION
Adjust gauge description to indicate that StartTimeUnixNano may be influenced by aggregation temporality.