### PR TITLE
[editorial] spec: escape HTML chars in markdown link syntax

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -169,7 +169,7 @@ If the server receives an empty request (a request that does not carry
 any telemetry data) the server SHOULD respond with success.
 
 On success, the server response MUST be a
-[Export<signal>ServiceResponse](../opentelemetry/proto/collector)
+[Export\<signal>ServiceResponse](../opentelemetry/proto/collector)
 message (`ExportTraceServiceResponse` for traces,
 `ExportMetricsServiceResponse` for metrics and
 `ExportLogsServiceResponse` for logs).
@@ -182,7 +182,7 @@ in case of a successful response.
 If the request is only partially accepted
 (i.e. when the server accepts only parts of the data and rejects the rest), the
 server response MUST be the same
-[Export<signal>ServiceResponse](../opentelemetry/proto/collector)
+[Export\<signal>ServiceResponse](../opentelemetry/proto/collector)
 message as in the [Full Success](#full-success) case.
 
 Additionally, the server MUST initialize the `partial_success` field
@@ -492,7 +492,7 @@ If the server receives an empty request (a request that does not carry
 any telemetry data) the server SHOULD respond with success.
 
 On success, the server MUST respond with `HTTP 200 OK`. The response body MUST be
-a Protobuf-encoded [Export<signal>ServiceResponse](../opentelemetry/proto/collector)
+a Protobuf-encoded [Export\<signal>ServiceResponse](../opentelemetry/proto/collector)
 message (`ExportTraceServiceResponse` for traces,
 `ExportMetricsServiceResponse` for metrics and
 `ExportLogsServiceResponse` for logs).
@@ -505,7 +505,7 @@ in case of a successful response.
 If the request is only partially accepted
 (i.e. when the server accepts only parts of the data and rejects the rest), the
 server MUST respond with `HTTP 200 OK`. The response body MUST be the same
-[Export<signal>ServiceResponse](../opentelemetry/proto/collector)
+[Export\<signal>ServiceResponse](../opentelemetry/proto/collector)
 message as in the [Full Success](#full-success-1) case.
 
 Additionally, the server MUST initialize the `partial_success` field


### PR DESCRIPTION
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/1170

---
 
Notice how the link text is fixed in the "after" screenshot. If we don't escape the `<signal>` then it's processed as an HTML tag.

### Before

> <img width="733" alt="image" src="https://github.com/open-telemetry/opentelemetry-proto/assets/4140793/eb603c5d-5be8-4140-bf34-6fcffbc035f3">

### After

> <img width="728" alt="image" src="https://github.com/open-telemetry/opentelemetry-proto/assets/4140793/982fa305-d701-41b9-8679-00f46759292e">

/cc @svrnm @cartermp 
