### PR TITLE
Add maturity JSON entry per package

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,13 @@ To generate the raw gRPC client libraries, use `make gen-${LANGUAGE}`. Currently
 1.0.0 and newer releases from this repository may contain unstable (alpha or beta)
 components as indicated by the Maturity table below.
 
-Component                            | Maturity                                                                                                                                |
--------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-**Binary Protobuf Encoding**         |                                                                                                                                         |
-common/*                             | Stable                                                                                                                                  |
-metrics/\*<br>collector/metrics/*    | Stable                                                                                                                                  |
-resource/*                           | Stable                                                                                                                                  |
-trace/\*<br>collector/trace/* | Stable                                                                                                                                  |
-logs/\*<br>collector/logs/*          | Stable                                                                                                                                  |
-**JSON encoding**                    |                                                                                                                                         |
-All messages                         | [Stable](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#json-protobuf-encoding) |
+| Component | Binary Protobuf Maturity | JSON Maturity |
+| --------- |--------------- | ------------- |
+| common/* | Stable | [Stable](docs/specification.md#json-protobuf-encoding) |
+| resource/* | Stable | [Stable](docs/specification.md#json-protobuf-encoding) |
+| metrics/\*<br>collector/metrics/* | Stable | [Stable](docs/specification.md#json-protobuf-encoding) |
+| trace/\*<br>collector/trace/* | Stable | [Stable](docs/specification.md#json-protobuf-encoding) |
+| logs/\*<br>collector/logs/* | Stable | [Stable](docs/specification.md#json-protobuf-encoding) |
 
 (See [maturity-matrix.yaml](https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f466a58bd2bb94edc72/maturity-matrix.yaml#L57)
 for definition of maturity levels).


### PR DESCRIPTION
This is because otherwise, when merged a new package will be automatically stable as JSON.

Also: Fix link to specification.