### PR TITLE
Add gauge subtype for prometheus unknown type

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -202,14 +202,14 @@ message Metric {
 message Gauge {
   repeated NumberDataPoint data_points = 1;
 
-  // sub_type provides additional type information for gauges.
+  // type provides additional type information for gauges.
   // 
   // When receiving from older producers of OTLP, it is safe to assume the
-  // zero-value for sub_type, GAUGE_TYPE_STANDARD. When sending OTLP to older
+  // zero-value for type, GAUGE_TYPE_STANDARD. When sending OTLP to older
   // consumers, it is safe for them to ignore the field. In both cases, the
-  // previous behavior without sub_type is maintained until producer and
+  // previous behavior without type is maintained until producer and
   // consumer are aware of the field.
-  GaugeType sub_type = 2;
+  GaugeType type = 2;
 }
 
 // Sum represents the type of a scalar metric that is calculated as a sum of all
@@ -347,19 +347,20 @@ enum DataPointFlags {
 }
 
 // GaugeType defines valid gauge "sub-types", which are used to describe
-// gauges which have additional properties. These sub-types generally apply
+// gauges which have additional properties. These types generally apply
 // to metrics which originate from protocols which support these additional
 // types, but are represented as gauges in OTLP.
 enum GaugeType {
-  // GAUGE_TYPE_STANDARD is the default GaugeType, which represents a gauge
-  // that does not have a sub_type. Since the OpenTelemetry API enforces types,
-  // this subtype is used for all metrics from OpenTelemetry instrumentation.
+  // GAUGE_TYPE_STANDARD is the default GaugeType, which represents a standard
+  // gauge. Since the OpenTelemetry API enforces types, this type is used for
+  // all metrics from OpenTelemetry instrumentation.
   GAUGE_TYPE_STANDARD = 0;
 
-  // GAUGE_TYPE_UNKNOWN is a GaugeType which represents a metric for
-  // which the type is not known, such as a Prometheus metric without a TYPE
-  // comment. For example, the metric may be a monotonically-increasing counter,
-  // or histogram, but type information was not included at the source.
+  // GAUGE_TYPE_UNKNOWN is a GaugeType which represents a metric for which the
+  // real type is not known, but is treated as a Gauge, such as a Prometheus
+  // metric without a TYPE comment. For example, the metric may be a
+  // monotonically-increasing sum, or histogram, but type information was not
+  // included at the source.
   GAUGE_TYPE_UNKNOWN = 1;
 }
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -201,6 +201,9 @@ message Metric {
 // "StartTimeUnixNano" is ignored for all data points.
 message Gauge {
   repeated NumberDataPoint data_points = 1;
+
+  // sub_type provides additional type information for gauges
+  GaugeSubType sub_type = 2;
 }
 
 // Sum represents the type of a scalar metric that is calculated as a sum of all
@@ -335,6 +338,22 @@ enum DataPointFlags {
   DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK = 1;
 
   // Bits 2-31 are reserved for future use.
+}
+
+// GaugeSubType defines valid gauge "sub-types", which are used to describe
+// "special" kinds of gauges which have additional properties. These sub-types
+// generally apply to metrics which originate from protocols which support
+// these additional types, but are represented as gauges in OTLP.
+enum GaugeSubType {
+  // GAUGE_SUBTYPE_NONE is the default GaugeSubType, which represents a gauge
+  // that does not have a sub_type.
+  GAUGE_SUBTYPE_NONE = 0;
+
+  // GAUGE_SUBTYPE_UNKNOWN is a GaugeSubType which represents a metric for
+  // which the type is not known, such as a Prometheus metric without a TYPE
+  // comment. For example, the metric may be a monotonically-increasing counter,
+  // or histogram, but type information was not included at the source.
+  GAUGE_SUBTYPE_UNKNOWN = 1;
 }
 
 // NumberDataPoint is a single data point in a timeseries that describes the

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -202,7 +202,13 @@ message Metric {
 message Gauge {
   repeated NumberDataPoint data_points = 1;
 
-  // sub_type provides additional type information for gauges
+  // sub_type provides additional type information for gauges.
+  // 
+  // When receiving from older producers of OTLP, it is safe to assume the
+  // zero-value for sub_type, GAUGE_SUBTYPE_NONE. When sending OTLP to older
+  // consumers, it is safe for them to ignore the field. In both cases, the
+  // previous behavior without sub_type is maintained until producer and
+  // consumer are aware of the field.
   GaugeSubType sub_type = 2;
 }
 

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -205,7 +205,7 @@ message Gauge {
   // sub_type provides additional type information for gauges.
   // 
   // When receiving from older producers of OTLP, it is safe to assume the
-  // zero-value for sub_type, GAUGE_TYPE_NONE. When sending OTLP to older
+  // zero-value for sub_type, GAUGE_TYPE_STANDARD. When sending OTLP to older
   // consumers, it is safe for them to ignore the field. In both cases, the
   // previous behavior without sub_type is maintained until producer and
   // consumer are aware of the field.
@@ -351,10 +351,10 @@ enum DataPointFlags {
 // to metrics which originate from protocols which support these additional
 // types, but are represented as gauges in OTLP.
 enum GaugeType {
-  // GAUGE_TYPE_NONE is the default GaugeType, which represents a gauge
+  // GAUGE_TYPE_STANDARD is the default GaugeType, which represents a gauge
   // that does not have a sub_type. Since the OpenTelemetry API enforces types,
   // this subtype is used for all metrics from OpenTelemetry instrumentation.
-  GAUGE_TYPE_NONE = 0;
+  GAUGE_TYPE_STANDARD = 0;
 
   // GAUGE_TYPE_UNKNOWN is a GaugeType which represents a metric for
   // which the type is not known, such as a Prometheus metric without a TYPE

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -352,7 +352,8 @@ enum DataPointFlags {
 // these additional types, but are represented as gauges in OTLP.
 enum GaugeSubType {
   // GAUGE_SUBTYPE_NONE is the default GaugeSubType, which represents a gauge
-  // that does not have a sub_type.
+  // that does not have a sub_type. Since the OpenTelemetry API enforces types,
+  // this subtype is used for all metrics from OpenTelemetry instrumentation.
   GAUGE_SUBTYPE_NONE = 0;
 
   // GAUGE_SUBTYPE_UNKNOWN is a GaugeSubType which represents a metric for

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -205,11 +205,11 @@ message Gauge {
   // sub_type provides additional type information for gauges.
   // 
   // When receiving from older producers of OTLP, it is safe to assume the
-  // zero-value for sub_type, GAUGE_SUBTYPE_NONE. When sending OTLP to older
+  // zero-value for sub_type, GAUGE_TYPE_NONE. When sending OTLP to older
   // consumers, it is safe for them to ignore the field. In both cases, the
   // previous behavior without sub_type is maintained until producer and
   // consumer are aware of the field.
-  GaugeSubType sub_type = 2;
+  GaugeType sub_type = 2;
 }
 
 // Sum represents the type of a scalar metric that is calculated as a sum of all
@@ -346,21 +346,21 @@ enum DataPointFlags {
   // Bits 2-31 are reserved for future use.
 }
 
-// GaugeSubType defines valid gauge "sub-types", which are used to describe
-// "special" kinds of gauges which have additional properties. These sub-types
-// generally apply to metrics which originate from protocols which support
-// these additional types, but are represented as gauges in OTLP.
-enum GaugeSubType {
-  // GAUGE_SUBTYPE_NONE is the default GaugeSubType, which represents a gauge
+// GaugeType defines valid gauge "sub-types", which are used to describe
+// gauges which have additional properties. These sub-types generally apply
+// to metrics which originate from protocols which support these additional
+// types, but are represented as gauges in OTLP.
+enum GaugeType {
+  // GAUGE_TYPE_NONE is the default GaugeType, which represents a gauge
   // that does not have a sub_type. Since the OpenTelemetry API enforces types,
   // this subtype is used for all metrics from OpenTelemetry instrumentation.
-  GAUGE_SUBTYPE_NONE = 0;
+  GAUGE_TYPE_NONE = 0;
 
-  // GAUGE_SUBTYPE_UNKNOWN is a GaugeSubType which represents a metric for
+  // GAUGE_TYPE_UNKNOWN is a GaugeType which represents a metric for
   // which the type is not known, such as a Prometheus metric without a TYPE
   // comment. For example, the metric may be a monotonically-increasing counter,
   // or histogram, but type information was not included at the source.
-  GAUGE_SUBTYPE_UNKNOWN = 1;
+  GAUGE_TYPE_UNKNOWN = 1;
 }
 
 // NumberDataPoint is a single data point in a timeseries that describes the


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-specification/issues/3058

This an attempt at defining a "subtype" for OTel metric types, as [suggested at the 2/7 Spec SIG meeting](https://github.com/open-telemetry/opentelemetry-specification/issues/3058#issuecomment-1615998755).

This is the Proposed solution described in the proposal here: https://github.com/open-telemetry/opentelemetry-specification/issues/3058#issuecomment-1622740102.