### PR TITLE
[CI] Report link-check error when external URL used for local doc page

### DIFF
--- a/.markdown_link_check_config.json
+++ b/.markdown_link_check_config.json
@@ -6,8 +6,12 @@
   ],
   "replacementPatterns": [
     {
-        "pattern": "^/",
-        "replacement": "{{BASEURL}}/"
+      "pattern": "^/",
+      "replacement": "{{BASEURL}}/"
+    },
+    {
+      "pattern": "^https://github.com/open-telemetry/opentelemetry-proto/(blob|tree)/[^/]+/docs/",
+      "replacement": "LINK-CHECK-ERROR-USE-LOCAL-PATH-TO-DOC-PAGE-NOT-EXTERNAL-URL/"
     }
   ],
   "retryOn429": true,


### PR DESCRIPTION
- Adds markdown-link-check rule to ensure that external links aren't used to refer to local doc pages.
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/2429