### PR TITLE
Fix EOF and invalid character issue in metrics payload

### DIFF
--- a/examples/metrics.json
+++ b/examples/metrics.json
@@ -29,7 +29,7 @@
             {
               "name": "my.counter",
               "unit": "1",
-              "description": "I`m a Counter",
+              "description": "I am a Counter",
               "sum": {
                 "aggregationTemporality": 1,
                 "isMonotonic": true,
@@ -53,7 +53,7 @@
             {
               "name": "my.gauge",
               "unit": "1",
-              "description": "I`m a Gauge",
+              "description": "I am a Gauge",
               "gauge": {
                 "dataPoints": [
                   {
@@ -74,7 +74,7 @@
             {
               "name": "my.histogram",
               "unit": "1",
-              "description": "I`m a Histogram",
+              "description": "I am a Histogram",
               "histogram": {
                 "aggregationTemporality": 1,
                 "dataPoints": [

--- a/examples/metrics.json
+++ b/examples/metrics.json
@@ -29,7 +29,7 @@
             {
               "name": "my.counter",
               "unit": "1",
-              "description": "I'm a Counter",
+              "description": "I`m a Counter",
               "sum": {
                 "aggregationTemporality": 1,
                 "isMonotonic": true,
@@ -53,7 +53,7 @@
             {
               "name": "my.gauge",
               "unit": "1",
-              "description": "I'm a Gauge",
+              "description": "I`m a Gauge",
               "gauge": {
                 "dataPoints": [
                   {
@@ -74,7 +74,7 @@
             {
               "name": "my.histogram",
               "unit": "1",
-              "description": "I'm a Histogram",
+              "description": "I`m a Histogram",
               "histogram": {
                 "aggregationTemporality": 1,
                 "dataPoints": [


### PR DESCRIPTION
The metrics example uses "I'm" which causes havoc with curl on WSL2 resulting in a EOF error. Changing to "I`m" resolves this annoying issue :)