### PR TITLE
Add W3C-specified trace flags to v1 Span proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 Full list of differences found in [this compare](https://github.com/open-telemetry/opentelemetry-proto/compare/v1.0.0...main).
 
+### Added
+
+* Add a field for W3C-specified Trace Context flags to the `Span` and `Link`.
+  [#503](https://github.com/open-telemetry/opentelemetry-proto/pull/503)
+
 ## 1.0.0 - 2023-07-03
 
 Full list of differences found in [this compare](https://github.com/open-telemetry/opentelemetry-proto/compare/v0.20.0...v1.0.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ Full list of differences found in [this compare](https://github.com/open-telemet
 Full list of differences found in [this compare](https://github.com/open-telemetry/opentelemetry-proto/compare/v0.20.0...v1.0.0).
 
 ### Maturity
- 
-* Add note about the possibility to have unstable components after 1.0.0 
+
+* Add note about the possibility to have unstable components after 1.0.0
   [#489](https://github.com/open-telemetry/opentelemetry-proto/pull/489)
 * Add maturity JSON entry per package
   [#490](https://github.com/open-telemetry/opentelemetry-proto/pull/490)

--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -104,9 +104,11 @@ enum SeverityNumber {
   SEVERITY_NUMBER_FATAL4 = 24;
 }
 
-// LogRecordFlags is defined as a protobuf 'uint32' type and is to be used as
-// bit-fields. Each non-zero value defined in this enum is a bit-mask.
-// To extract the bit-field, for example, use an expression like:
+// LogRecordFlags represents constants used to interpret the
+// LogRecord.flags field, which is protobuf 'fixed32' type and is to
+// be used as bit-fields. Each non-zero value defined in this enum is
+// a bit-mask.  To extract the bit-field, for example, use an
+// expression like:
 //
 //   (logRecord.flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK)
 //

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -76,7 +76,7 @@ message ScopeSpans {
 
 // A Span represents a single operation performed by a single component of the system.
 //
-// The next available field id is 18.
+// The next available field id is 17.
 message Span {
   // A unique identifier for a trace. All spans from the same trace share
   // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
@@ -107,7 +107,7 @@ message Span {
   // There are two flags defined in the W3C Trace Context Level 2 spec:
   // - sampled = 0x1
   // - random = 0x2
-  uint32 trace_flags = 17;
+  uint32 trace_flags = 16;
 
   // A description of the span's operation.
   //

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -302,6 +302,11 @@ message Status {
 //   (span.flags & SPAN_FLAGS_TRACE_FLAGS_MASK)
 //
 // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+//
+// Note that Span flags were introduced in version 1.1 of the
+// OpenTelemetry protocol.  Older Span producers do not set this
+// field, consequently consumers should not rely on the absence of a
+// particular flag bit to indicate the presence of a particular feature.
 enum SpanFlags {
   // The zero value for the enum. Should not be used for comparisons.
   // Instead use bitwise "and" with the appropriate mask as shown above.

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -112,9 +112,15 @@ message Span {
   // Flags, a bit field. 8 least significant bits are the trace
   // flags as defined in W3C Trace Context specification. Readers
   // MUST not assume that 24 most significant bits will be zero.
-  // When creating new spans, the most-significant 24-bits MUST be
-  // zero.  To read the 8-bit W3C trace flag (use flags &
-  // SPAN_FLAGS_TRACE_FLAGS_MASK).  [Optional].
+  // To read the 8-bit W3C trace flag, use `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
+  //
+  // When creating span messages, if the message is logically forwarded from another source
+  // with an equivalent flags fields (i.e., usually another OTLP span message), the field SHOULD
+  // be copied as-is. If creating from a source that does not have an equivalent flags field
+  // (such as a runtime representation of an OpenTelemetry span), the high 24 bits MUST
+  // be set to zero.
+  //
+  // [Optional].
   //
   // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
   fixed32 flags = 16;

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -106,11 +106,12 @@ message Span {
   // Flags, a bit field. 8 least significant bits are the trace flags as
   // defined in W3C Trace Context specification. 24 most significant bits are reserved
   // and must be set to 0. Readers must not assume that 24 most significant bits
-  // will be zero and must correctly mask the bits when reading 8-bit trace flag (use
-  // flags & SPAN_FLAGS_TRACE_FLAGS_MASK). [Optional].
+  // will be zero.  When writing new spans, SDKs must set the most-significant 24-bits
+  // to zero.  To read the 8-bit trace flag (use flags & SPAN_FLAGS_TRACE_FLAGS_MASK).
+  // [Optional].
   //
   // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
-  fixed32 flags = 16;
+  fixed32 flags = 18;
 
   // A description of the span's operation.
   //
@@ -249,8 +250,9 @@ message Span {
     // Flags, a bit field. 8 least significant bits are the trace flags as
     // defined in W3C Trace Context specification. 24 most significant bits are reserved
     // and must be set to 0. Readers must not assume that 24 most significant bits
-    // will be zero and must correctly mask the bits when reading 8-bit trace flag (use
-    // flags & SPAN_FLAGS_TRACE_FLAGS_MASK). [Optional].
+    // will be zero.  When writing new spans, SDKs must set the most-significant 24-bits
+    // to zero.  To read the 8-bit trace flag (use flags & SPAN_FLAGS_TRACE_FLAGS_MASK).
+    // [Optional].
     //
     // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
     fixed32 flags = 6;

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -76,7 +76,7 @@ message ScopeSpans {
 
 // A Span represents a single operation performed by a single component of the system.
 //
-// The next available field id is 17.
+// The next available field id is 18.
 message Span {
   // A unique identifier for a trace. All spans from the same trace share
   // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
@@ -102,6 +102,12 @@ message Span {
   // The `span_id` of this span's parent span. If this is a root span, then this
   // field must be empty. The ID is an 8-byte array.
   bytes parent_span_id = 4;
+
+  // Flags from the W3C traceparent, if provided.
+  // There are two flags defined in the W3C Trace Context Level 2 spec:
+  // - sampled = 0x1
+  // - random = 0x2
+  uint32 trace_flags = 17;
 
   // A description of the span's operation.
   //
@@ -236,6 +242,12 @@ message Span {
     // dropped_attributes_count is the number of dropped attributes. If the value is 0,
     // then no attributes were dropped.
     uint32 dropped_attributes_count = 5;
+
+    // Flags from the W3C traceparent, if provided.
+    // There are two flags defined in the W3C Trace Context Level 2 spec:
+    // - sampled = 0x1
+    // - random = 0x2
+    uint32 trace_flags = 6;
   }
 
   // links is a collection of Links, which are references from this span to a span

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -76,7 +76,7 @@ message ScopeSpans {
 
 // A Span represents a single operation performed by a single component of the system.
 //
-// The next available field id is 17.
+// The next available field id is 19.
 message Span {
   // A unique identifier for a trace. All spans from the same trace share
   // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
@@ -106,8 +106,8 @@ message Span {
   // Flags, a bit field. 8 least significant bits are the trace flags as
   // defined in W3C Trace Context specification. 24 most significant bits are reserved
   // and must be set to 0. Readers must not assume that 24 most significant bits
-  // will be zero.  When writing new spans, SDKs must set the most-significant 24-bits
-  // to zero.  To read the 8-bit trace flag (use flags & SPAN_FLAGS_TRACE_FLAGS_MASK).
+  // will be zero.  When writing new spans, the most-significant 24-bits MUST be
+  // zero.  To read the 8-bit W3C trace flag (use flags & SPAN_FLAGS_TRACE_FLAGS_MASK).
   // [Optional].
   //
   // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
@@ -250,8 +250,8 @@ message Span {
     // Flags, a bit field. 8 least significant bits are the trace flags as
     // defined in W3C Trace Context specification. 24 most significant bits are reserved
     // and must be set to 0. Readers must not assume that 24 most significant bits
-    // will be zero.  When writing new spans, SDKs must set the most-significant 24-bits
-    // to zero.  To read the 8-bit trace flag (use flags & SPAN_FLAGS_TRACE_FLAGS_MASK).
+    // will be zero.  When writing new spans, the most-significant 24-bits MUST be
+    // zero.  To read the 8-bit W3C trace flag (use flags & SPAN_FLAGS_TRACE_FLAGS_MASK).
     // [Optional].
     //
     // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -243,7 +243,7 @@ message Span {
     // then no attributes were dropped.
     uint32 dropped_attributes_count = 5;
 
-    // Flags from the W3C traceparent, if provided.
+    // Flags from the linked span's traceparent, if provided.
     // There are two flags defined in the W3C Trace Context Level 2 spec:
     // - sampled = 0x1
     // - random = 0x2

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -82,7 +82,7 @@ message ScopeSpans {
 
 // A Span represents a single operation performed by a single component of the system.
 //
-// The next available field id is 19.
+// The next available field id is 17.
 message Span {
   // A unique identifier for a trace. All spans from the same trace share
   // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
@@ -112,12 +112,12 @@ message Span {
   // Flags, a bit field. 8 least significant bits are the trace flags as
   // defined in W3C Trace Context specification. 24 most significant bits are reserved
   // and must be set to 0. Readers must not assume that 24 most significant bits
-  // will be zero.  When writing new spans, the most-significant 24-bits MUST be
+  // will be zero.  When creating new spans, the most-significant 24-bits MUST be
   // zero.  To read the 8-bit W3C trace flag (use flags & SPAN_FLAGS_TRACE_FLAGS_MASK).
   // [Optional].
   //
   // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
-  fixed32 flags = 18;
+  fixed32 flags = 16;
 
   // A description of the span's operation.
   //
@@ -256,7 +256,7 @@ message Span {
     // Flags, a bit field. 8 least significant bits are the trace flags as
     // defined in W3C Trace Context specification. 24 most significant bits are reserved
     // and must be set to 0. Readers must not assume that 24 most significant bits
-    // will be zero.  When writing new spans, the most-significant 24-bits MUST be
+    // will be zero.  When creating new spans, the most-significant 24-bits MUST be
     // zero.  To read the 8-bit W3C trace flag (use flags & SPAN_FLAGS_TRACE_FLAGS_MASK).
     // [Optional].
     //

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -103,11 +103,14 @@ message Span {
   // field must be empty. The ID is an 8-byte array.
   bytes parent_span_id = 4;
 
-  // Flags from the W3C traceparent, if provided.
-  // There are two flags defined in the W3C Trace Context Level 2 spec:
-  // - sampled = 0x1
-  // - random = 0x2
-  uint32 trace_flags = 16;
+  // Flags, a bit field. 8 least significant bits are the trace flags as
+  // defined in W3C Trace Context specification. 24 most significant bits are reserved
+  // and must be set to 0. Readers must not assume that 24 most significant bits
+  // will be zero and must correctly mask the bits when reading 8-bit trace flag (use
+  // flags & SPAN_FLAGS_TRACE_FLAGS_MASK). [Optional].
+  //
+  // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+  fixed32 flags = 16;
 
   // A description of the span's operation.
   //
@@ -243,11 +246,14 @@ message Span {
     // then no attributes were dropped.
     uint32 dropped_attributes_count = 5;
 
-    // Flags from the linked span's traceparent, if provided.
-    // There are two flags defined in the W3C Trace Context Level 2 spec:
-    // - sampled = 0x1
-    // - random = 0x2
-    uint32 trace_flags = 6;
+    // Flags, a bit field. 8 least significant bits are the trace flags as
+    // defined in W3C Trace Context specification. 24 most significant bits are reserved
+    // and must be set to 0. Readers must not assume that 24 most significant bits
+    // will be zero and must correctly mask the bits when reading 8-bit trace flag (use
+    // flags & SPAN_FLAGS_TRACE_FLAGS_MASK). [Optional].
+    //
+    // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+    fixed32 flags = 6;
   }
 
   // links is a collection of Links, which are references from this span to a span
@@ -285,4 +291,24 @@ message Status {
 
   // The status code.
   StatusCode code = 3;
+}
+
+// SpanFlags represents constants used to interpret the
+// Span.flags field, which is protobuf 'fixed32' type and is to
+// be used as bit-fields. Each non-zero value defined in this enum is
+// a bit-mask.  To extract the bit-field, for example, use an
+// expression like:
+//
+//   (span.flags & SPAN_FLAGS_TRACE_FLAGS_MASK)
+//
+// See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+enum SpanFlags {
+  // The zero value for the enum. Should not be used for comparisons.
+  // Instead use bitwise "and" with the appropriate mask as shown above.
+  SPAN_FLAGS_DO_NOT_USE = 0;
+
+  // Bits 0-7 are used for trace flags.
+  SPAN_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
+
+  // Bits 8-31 are reserved for future use.
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -109,12 +109,12 @@ message Span {
   // field must be empty. The ID is an 8-byte array.
   bytes parent_span_id = 4;
 
-  // Flags, a bit field. 8 least significant bits are the trace flags as
-  // defined in W3C Trace Context specification. 24 most significant bits are reserved
-  // and must be set to 0. Readers must not assume that 24 most significant bits
-  // will be zero.  When creating new spans, the most-significant 24-bits MUST be
-  // zero.  To read the 8-bit W3C trace flag (use flags & SPAN_FLAGS_TRACE_FLAGS_MASK).
-  // [Optional].
+  // Flags, a bit field. 8 least significant bits are the trace
+  // flags as defined in W3C Trace Context specification. Readers
+  // MUST not assume that 24 most significant bits will be zero.
+  // When creating new spans, the most-significant 24-bits MUST be
+  // zero.  To read the 8-bit W3C trace flag (use flags &
+  // SPAN_FLAGS_TRACE_FLAGS_MASK).  [Optional].
   //
   // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
   fixed32 flags = 16;
@@ -253,12 +253,12 @@ message Span {
     // then no attributes were dropped.
     uint32 dropped_attributes_count = 5;
 
-    // Flags, a bit field. 8 least significant bits are the trace flags as
-    // defined in W3C Trace Context specification. 24 most significant bits are reserved
-    // and must be set to 0. Readers must not assume that 24 most significant bits
-    // will be zero.  When creating new spans, the most-significant 24-bits MUST be
-    // zero.  To read the 8-bit W3C trace flag (use flags & SPAN_FLAGS_TRACE_FLAGS_MASK).
-    // [Optional].
+    // Flags, a bit field. 8 least significant bits are the trace
+    // flags as defined in W3C Trace Context specification. Readers
+    // MUST not assume that 24 most significant bits will be zero.
+    // When creating new spans, the most-significant 24-bits MUST be
+    // zero.  To read the 8-bit W3C trace flag (use flags &
+    // SPAN_FLAGS_TRACE_FLAGS_MASK).  [Optional].
     //
     // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
     fixed32 flags = 6;


### PR DESCRIPTION
As discussed in https://github.com/open-telemetry/opentelemetry-specification/issues/3411 and https://github.com/open-telemetry/opentelemetry-proto/issues/382, the OpenTelemetry Span object does not record the trace flags that were provided in its Trace Context. 

For a tail sampler to sample spans using mechanism consistent with head sampling, the flags must be available in the protocol. W3C reserves 8 bits for these flags, of which two are defined. I've added 32-bit fields in the protocol for the span and the span link here.