### PR TITLE
Fix the incorrect histogram example in metrics.json

### DIFF
--- a/examples/metrics.json
+++ b/examples/metrics.json
@@ -81,11 +81,11 @@
                   {
                     "startTimeUnixNano": 1544712660300000000,
                     "timeUnixNano": 1544712660300000000,
-                    "count": 3,
-                    "sum": 3,
-                    "bucketCounts": [1,1,1],
+                    "count": 2,
+                    "sum": 2,
+                    "bucketCounts": [1,1],
                     "explicitBounds": [1],
-                    "min": 1,
+                    "min": 0,
                     "max": 1,
                     "attributes": [
                       {

--- a/examples/metrics.json
+++ b/examples/metrics.json
@@ -86,7 +86,7 @@
                     "bucketCounts": [1,1],
                     "explicitBounds": [1],
                     "min": 0,
-                    "max": 1,
+                    "max": 2,
                     "attributes": [
                       {
                         "key": "my.histogram.attr",


### PR DESCRIPTION
There are 2 buckets (-inf, 1), [1, +inf) but 3 bucket counts.