### PR TITLE
Remove irrelevant comments from metric name field

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -168,7 +168,7 @@ message ScopeMetrics {
 message Metric {
   reserved 4, 6, 8;
 
-  // name of the metric, including its DNS name prefix. It must be unique.
+  // name of the metric.
   string name = 1;
 
   // description of the metric, which can be used in documentation.


### PR DESCRIPTION
The comment was incorrect and misleading.

Fixes https://github.com/open-telemetry/opentelemetry-proto/issues/511