### PR TITLE
fix: OTLP JSON examples

### DIFF
--- a/examples/logs.json
+++ b/examples/logs.json
@@ -27,8 +27,9 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": 1544712660300000000,
-              "observedTimeUnixNano": 1544712660300000000,
+              "timeUnixNano": "1544712660300000000",
+              "observedTimeUnixNano": "1544712660300000000",
+              "severityNumber": 10,
               "severityText": "Information",
               "traceId": "5B8EFFF798038103D269B633813FC60C",
               "spanId": "EEE19B7EC3C1B174",
@@ -51,7 +52,7 @@
                 {
                   "key": "int.attribute",
                   "value": {
-                    "intValue": 10
+                    "intValue": "10"
                   }
                 },
                 {

--- a/examples/metrics.json
+++ b/examples/metrics.json
@@ -36,8 +36,8 @@
                 "dataPoints": [
                   {
                     "asDouble": 5,
-                    "startTimeUnixNano": 1544712660300000000,
-                    "timeUnixNano": 1544712660300000000,
+                    "startTimeUnixNano": "1544712660300000000",
+                    "timeUnixNano": "1544712660300000000",
                     "attributes": [
                       {
                         "key": "my.counter.attr",
@@ -58,7 +58,7 @@
                 "dataPoints": [
                   {
                     "asDouble": 10,
-                    "timeUnixNano": 1544712660300000000,
+                    "timeUnixNano": "1544712660300000000",
                     "attributes": [
                       {
                         "key": "my.gauge.attr",
@@ -79,8 +79,8 @@
                 "aggregationTemporality": 1,
                 "dataPoints": [
                   {
-                    "startTimeUnixNano": 1544712660300000000,
-                    "timeUnixNano": 1544712660300000000,
+                    "startTimeUnixNano": "1544712660300000000",
+                    "timeUnixNano": "1544712660300000000",
                     "count": 2,
                     "sum": 2,
                     "bucketCounts": [1,1],

--- a/examples/trace.json
+++ b/examples/trace.json
@@ -31,8 +31,8 @@
               "spanId": "EEE19B7EC3C1B174",
               "parentSpanId": "EEE19B7EC3C1B173",
               "name": "I'm a server span",
-              "startTimeUnixNano": 1544712660000000000,
-              "endTimeUnixNano": 1544712661000000000,
+              "startTimeUnixNano": "1544712660000000000",
+              "endTimeUnixNano": "1544712661000000000",
               "kind": 2,
               "attributes": [
                 {


### PR DESCRIPTION
# Why
The example files do not follow the specification. 64 bit integers must be [string
encoded](https://protobuf.dev/programming-guides/proto3/#json).

# What

 - Fix the encoding in the examples
 - Add an example for log `severityNumber` to point at the enum encoding rules (to help folks with cases [like these](https://github.com/open-telemetry/opentelemetry-proto/issues/517)).