### PR TITLE
fix(otlp-spec): Clarified "reject" meaning of the HTTP PartialSuccess explanation.

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -498,9 +498,15 @@ in case of a successful response.
 
 ##### Partial Success
 
-If the request is only partially accepted
-(i.e. when the server accepts only parts of the data and rejects the rest), the
-server MUST respond with `HTTP 200 OK`. The response body MUST be the same
+The partial success is when the request is only partially accepted (i.e. when the
+server accepts only parts of the data and fails the rest). In such a case:
+
+* If all of the samples were rejected (not-retryable failures), the server MUST
+respond with `HTTP 200 OK`. 
+* If any of the failed sample write attempts are retry-able, the server MUST
+respond with related retry-able status code mentioned below.
+
+In all cases the response body MUST be the same
 [Export\<signal>ServiceResponse](../opentelemetry/proto/collector)
 message as in the [Full Success](#full-success-1) case.
 
@@ -553,7 +559,7 @@ The requests that receive a response status code listed in following table SHOUL
 be retried.
 All other `4xx` or `5xx` response status codes MUST NOT be retried.
 
-|HTTP response status code|
+|Retryable HTTP response status code|
 |---------|
 |429 Too Many Requests|
 |502 Bad Gateway|

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -501,9 +501,9 @@ in case of a successful response.
 The partial success is when the request is only partially accepted (i.e. when the
 server accepts only parts of the data and fails the rest). In such a case:
 
-* If all of the samples were rejected (not-retryable failures), the server MUST
+- If all of the samples are rejected (not-retryable failures), the server MUST
 respond with `HTTP 200 OK`. 
-* If any of the failed sample write attempts are retry-able, the server MUST
+- If any of the failed sample write attempts are retry-able, the server MUST
 respond with related retry-able status code mentioned below.
 
 In all cases the response body MUST be the same


### PR DESCRIPTION
👋🏽 

I was studying the OTLP spec's partial success mechanism [proposed 2y ago](https://github.com/open-telemetry/opentelemetry-specification/pull/2696) for the Prometheus Remote Write 2.0 spec design purposes. I noticed one detail that might need clarification. The partial success mechanism has this specification regarding the "final" status code:

> If the request is only partially accepted
(i.e. when the server accepts only parts of the data and rejects the rest), the
server MUST respond with `HTTP 200 OK`.

Does it mean that if e.g. we write 10 samples and server writes successfully 9, but can't write 1 sample due to some tmp error (503), it should still provide 200 status code? Or that 503 code? It feels the latter make more sense to me, but this sentence is a bit fuzzy.

One way of interpreting the "reject" word in that sentence, is that server rejecting samples means not-retryable errors only (e.g. 400). If that's true then some clarification would be nice. I went ahead and proposed changes to make it explicit. Is my assumption here correct? Is this helpful? 

