### PR TITLE
profiles: fix versioning in selector

### DIFF
--- a/opentelemetry/proto/collector/profiles/v1experimental/profiles_service_http.yaml
+++ b/opentelemetry/proto/collector/profiles/v1experimental/profiles_service_http.yaml
@@ -4,6 +4,6 @@ type: google.api.Service
 config_version: 3
 http:
  rules:
- - selector: opentelemetry.proto.collector.profiles.v1.ProfilesService.Export
+ - selector: opentelemetry.proto.collector.profiles.v1experimental.ProfilesService.Export
    post: /v1experimental/profiles
    body: "*"


### PR DESCRIPTION
Creating Go dependencies for the Profiles signal fails, as the selector uses `v1` instead of `v1experimental`.

```
$ docker run --rm -u 1000 -v/home/flehner/go/src/github.com/open-telemetry/opentelemetry-proto-go:/home/flehner/go/src/github.com/open-telemetry/opentelemetry-proto-go -w/home/flehner/go/src/github.com/open-telemetry/opentelemetry-proto-go otel/build-protobuf:0.23.0 --proto_path="gen/proto" --grpc-gateway_out=logtostderr=true,grpc_api_configuration=opentelemetry-proto/opentelemetry/proto/collector/profiles/v1experimental/profiles_service_http.yaml:./gen/go --go_out=./gen/go --go-grpc_out=./gen/go gen/proto/opentelemetry/proto/collector/profiles/v1experimental/profiles_service.proto
--grpc-gateway_out: HTTP rules without a matching selector: .opentelemetry.proto.collector.profiles.v1.ProfilesService.Export
``` 

I noticed this issue while working on https://github.com/open-telemetry/opentelemetry-proto-go/pull/166.