### PR TITLE
profiles: Make mapping in Profile optional

### DIFF
--- a/opentelemetry/proto/profiles/v1development/pprofextended.proto
+++ b/opentelemetry/proto/profiles/v1development/pprofextended.proto
@@ -79,6 +79,8 @@ message Profile {
   repeated Sample sample = 2;
   // Mapping from address ranges to the image/binary/library mapped
   // into that address range.  mapping[0] will be the main binary.
+  // If multiple binaries contribute to the Profile and no main
+  // binary can be identified, mapping is optional.
   repeated Mapping mapping = 3;
   // Locations referenced by samples via location_indices.
   repeated Location location = 4;

--- a/opentelemetry/proto/profiles/v1development/pprofextended.proto
+++ b/opentelemetry/proto/profiles/v1development/pprofextended.proto
@@ -80,7 +80,7 @@ message Profile {
   // Mapping from address ranges to the image/binary/library mapped
   // into that address range.  mapping[0] will be the main binary.
   // If multiple binaries contribute to the Profile and no main
-  // binary can be identified, mapping is optional.
+  // binary can be identified, mapping[0] has no special meaning.
   repeated Mapping mapping = 3;
   // Locations referenced by samples via location_indices.
   repeated Location location = 4;


### PR DESCRIPTION
As commented in [0] and discussed in the OTel Profiling SIG meeting, there are situations where a main binary for a Profile can not be identified. For these cases mark the field optional.

FYI: @brancz @petethepig @open-telemetry/profiling-maintainers 

[0]: https://github.com/open-telemetry/opentelemetry-proto/pull/534#discussion_r1561141336