### PR TITLE
Remove HTTP 1.1 restriction from Protocol Details

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -72,7 +72,7 @@ OTLP defines the encoding of telemetry data and the protocol used to exchange
 data between the client and the server.
 
 This specification defines how OTLP is implemented over
-[gRPC](https://grpc.io/) and HTTP 1.1 transports and specifies
+[gRPC](https://grpc.io/) and HTTP transports and specifies
 [Protocol Buffers schema](https://developers.google.com/protocol-buffers/docs/overview)
 that is used for the payloads.
 


### PR DESCRIPTION
In the `Protocol Details` section the spec states that it defines how OTLP is implemented over grpc and **http 1.1**, but later in the document in section `OTLP/HTTP` it states "Implementations MAY use HTTP/1.1 or HTTP/2 transports."

This may confuse end readers and I suggest that it is easier to drop the 1.1 in the Protocol Details section