### PR TITLE
Update CODEOWNERS to reflect spec sponsor role

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,16 +13,7 @@
 #
 
 # Global owners, will be the owners for everything in the repo. Membership is tracked via https://github.com/open-telemetry/community/blob/main/community-members.md 
-*   @open-telemetry/specs-approvers
-
-# Trace owners (global + trace)
-opentelemetry/proto/trace/    @open-telemetry/specs-approvers @open-telemetry/specs-trace-approvers
-
-# Metrics owners (global + metrics)
-opentelemetry/proto/metrics/  @open-telemetry/specs-approvers @open-telemetry/specs-metrics-approvers
-
-# Logs owners (global + logs)
-opentelemetry/proto/logs/     @open-telemetry/specs-approvers @open-telemetry/specs-logs-approvers
+*   @open-telemetry/spec-sponsors
 
 # Profiles owners (global + profiles)
-opentelemetry/proto/profiles  @open-telemetry/specs-approvers @open-telemetry/profiling-maintainers
+opentelemetry/proto/profiles  @open-telemetry/spec-sponsors @open-telemetry/profiling-maintainers


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-specification/pull/4170 for details.

Upon merging this PR, I will grant @open-telemetry/spec-sponsors write permissions to this repo.