### PR TITLE
Fix broken link to community contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 Read OpenTelemetry project [contributing
-guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)
+guide](https://github.com/open-telemetry/community/blob/main/guides/contributor/README.md)
 for general information about the project.
 
 ## Prerequisites


### PR DESCRIPTION
Build is currently [broken](https://github.com/open-telemetry/opentelemetry-proto/actions/runs/10201602933/job/28223830468?pr=572) after https://github.com/open-telemetry/community/pull/2051 moved the community contributor guide.