### PR TITLE
profiles: drop Sample.stacktrace_id_index

### DIFF
--- a/opentelemetry/proto/profiles/v1experimental/pprofextended.proto
+++ b/opentelemetry/proto/profiles/v1experimental/pprofextended.proto
@@ -234,8 +234,6 @@ message Sample {
   // locations_length along with locations_start_index refers to a slice of locations in Profile.location.
   // Supersedes location_index.
   uint64 locations_length = 8;
-  // A 128bit id that uniquely identifies this stacktrace, globally. Index into string table. [optional]
-  uint32 stacktrace_id_index = 9;
   // The type and unit of each value is defined by the corresponding
   // entry in Profile.sample_type. All samples must have the same
   // number of values, the same as the length of Profile.sample_type.


### PR DESCRIPTION
The value for Sample.stacktrace_id_index is hardly defined except for its length. It is also not defined how this value should be generated, interpreted and could be used.

Some kind of stacktrace_id can be most efficient in stateful protocols, where transmitting duplicate information should be avoided. As the OTel Profiling protocol is a stateless protocol, this element can be droped.

The proposed change is a breaking change. As the OTel Profiling signal is still marked as experimental this should be fine? Please let me know.

FYI: @open-telemetry/profiling-maintainers 