### PR TITLE
Makefile: exclude Profiles protocol from breaking-changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,10 +159,11 @@ gen-ruby:
 	$(PROTOC) --ruby_out=./$(PROTO_GEN_RUBY_DIR) --grpc-ruby_out=./$(PROTO_GEN_RUBY_DIR) opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(PROTOC) --ruby_out=./$(PROTO_GEN_RUBY_DIR) --grpc-ruby_out=./$(PROTO_GEN_RUBY_DIR) opentelemetry/proto/collector/logs/v1/logs_service.proto
 	$(PROTOC) --ruby_out=./$(PROTO_GEN_RUBY_DIR) --grpc-ruby_out=./$(PROTO_GEN_RUBY_DIR) opentelemetry/proto/collector/profiles/v1experimental/profiles_service.proto
-	
+
+# The Profiling protocol is still experimental. So it is excluded from the breaking-change check.
 .PHONY: breaking-change
 breaking-change:
-	$(BUF) breaking --against $(BUF_AGAINST) $(BUF_FLAGS)
+	$(BUF) breaking --against $(BUF_AGAINST) --config '{"version":"v1","breaking":{"ignore":["opentelemetry/proto/profiles"]}}' $(BUF_FLAGS)
 
 
 ALL_DOCS := $(shell find . -type f -name '*.md' -not -path './.github/*' -not -path './node_modules/*' | sort)


### PR DESCRIPTION
The Profiles protocol is still experimental. Exclude it from the breaking-changes check as such changes are expected at this stage.