### PR TITLE
profiles: drop Location.type_index

### DIFF
--- a/opentelemetry/proto/profiles/v1experimental/pprofextended.proto
+++ b/opentelemetry/proto/profiles/v1experimental/pprofextended.proto
@@ -354,9 +354,6 @@ message Location {
   // profile changes.
   bool is_folded = 5;
 
-  // Type of frame (e.g. kernel, native, python, hotspot, php). Index into string table.
-  int64 type_index = 6;
-
   // References to attributes in Profile.attribute_table. [optional]
   repeated uint64 attributes = 7;
 }


### PR DESCRIPTION
With https://github.com/open-telemetry/semantic-conventions/pull/1188 the semantic convention for Profiles that introduces frame types and well known values is about to be merged.

Therefore,  `Location.type_index` is no longer needed.

FYI: @open-telemetry/profiling-maintainers

Similar to https://github.com/open-telemetry/opentelemetry-proto/pull/575 this is a breaking change. And CI can only pass, once https://github.com/open-telemetry/opentelemetry-proto/pull/576 is merged.