### PR TITLE
Added json example for exponential histogram

### DIFF
--- a/examples/metrics.json
+++ b/examples/metrics.json
@@ -98,6 +98,39 @@
                   }
                 ]
               }
+            },
+            {
+              "name": "my.exponential.histogram",
+              "unit": "1",
+              "description": "I am an Exponential Histogram",
+              "exponentialHistogram": {
+                "aggregationTemporality": 1,
+                "dataPoints": [
+                  {
+                    "startTimeUnixNano": "1544712660300000000",
+                    "timeUnixNano": "1544712660300000000",
+                    "count": 3,
+                    "sum": 10,
+                    "scale": 0,
+                    "zeroCount": 1,
+                    "positive": {
+                      "offset": 1,
+                      "bucketCounts": [0,2]
+                    },
+                    "min": 0,
+                    "max": 5,
+                    "zeroThreshold": 0,
+                    "attributes": [
+                      {
+                        "key": "my.exponential.histogram.attr",
+                        "value": {
+                          "stringValue": "some value"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
             }
           ]
         }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-proto/issues/544

The exponential histogram datapoint in this commit, when sent to otel col, produces this log
```
Metric #0
Descriptor:
     -> Name: my.exponential.histogram
     -> Description: I am an Exponential Histogram
     -> Unit: 1
     -> DataType: ExponentialHistogram
     -> AggregationTemporality: Delta
ExponentialHistogramDataPoints #0
Data point attributes:
     -> my.exponential.histogram.attr: Str(some value)
StartTimestamp: 2018-12-13 14:51:00.3 +0000 UTC
Timestamp: 2018-12-13 14:51:00.3 +0000 UTC
Count: 3
Sum: 10.000000
Min: 0.000000
Max: 5.000000
Bucket [0, 0], Count: 1
Bucket (2.000000, 4.000000], Count: 0
Bucket (4.000000, 8.000000], Count: 2
```
The actual datapoint values are {0, 5, 5}