### PR TITLE
docs: update references to logging exporter

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -19,20 +19,20 @@ receivers:
       http:
 
 exporters:
-  logging:
+  debug:
     verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
     metrics:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
     logs:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
 ```
 
 Then send a curl request to the collector (e.g. for Logs):


### PR DESCRIPTION
This exporter has been replaced by the debug exporter and will be removed soon

Related to https://github.com/open-telemetry/opentelemetry-collector/pull/11037