### PR TITLE
Rename profiles v1experimental to v1development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ gen-cpp:
 	$(PROTOC) --cpp_out=./$(PROTO_GEN_CPP_DIR) --grpc-cpp_out=./$(PROTO_GEN_CPP_DIR) opentelemetry/proto/collector/trace/v1/trace_service.proto
 	$(PROTOC) --cpp_out=./$(PROTO_GEN_CPP_DIR) --grpc-cpp_out=./$(PROTO_GEN_CPP_DIR) opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(PROTOC) --cpp_out=./$(PROTO_GEN_CPP_DIR) --grpc-cpp_out=./$(PROTO_GEN_CPP_DIR) opentelemetry/proto/collector/logs/v1/logs_service.proto
-	$(PROTOC) --cpp_out=./$(PROTO_GEN_CPP_DIR) --grpc-cpp_out=./$(PROTO_GEN_CPP_DIR) opentelemetry/proto/collector/profiles/v1experimental/profiles_service.proto
+	$(PROTOC) --cpp_out=./$(PROTO_GEN_CPP_DIR) --grpc-cpp_out=./$(PROTO_GEN_CPP_DIR) opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
 
 # Generate gRPC/Protobuf implementation for C#.
 .PHONY: gen-csharp
@@ -68,7 +68,7 @@ gen-csharp:
 	$(PROTOC) --csharp_out=./$(PROTO_GEN_CSHARP_DIR) --grpc-csharp_out=./$(PROTO_GEN_CSHARP_DIR) opentelemetry/proto/collector/trace/v1/trace_service.proto
 	$(PROTOC) --csharp_out=./$(PROTO_GEN_CSHARP_DIR) --grpc-csharp_out=./$(PROTO_GEN_CSHARP_DIR) opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(PROTOC) --csharp_out=./$(PROTO_GEN_CSHARP_DIR) --grpc-csharp_out=./$(PROTO_GEN_CSHARP_DIR) opentelemetry/proto/collector/logs/v1/logs_service.proto
-	$(PROTOC) --csharp_out=./$(PROTO_GEN_CSHARP_DIR) --grpc-csharp_out=./$(PROTO_GEN_CSHARP_DIR) opentelemetry/proto/collector/profiles/v1experimental/profiles_service.proto
+	$(PROTOC) --csharp_out=./$(PROTO_GEN_CSHARP_DIR) --grpc-csharp_out=./$(PROTO_GEN_CSHARP_DIR) opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
 
 # Generate gRPC/Protobuf implementation for Go.
 .PHONY: gen-go
@@ -79,7 +79,7 @@ gen-go:
 	$(PROTOC) --grpc-gateway_out=logtostderr=true,grpc_api_configuration=opentelemetry/proto/collector/trace/v1/trace_service_http.yaml:./$(PROTO_GEN_GO_DIR) opentelemetry/proto/collector/trace/v1/trace_service.proto
 	$(PROTOC) --grpc-gateway_out=logtostderr=true,grpc_api_configuration=opentelemetry/proto/collector/metrics/v1/metrics_service_http.yaml:./$(PROTO_GEN_GO_DIR) opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(PROTOC) --grpc-gateway_out=logtostderr=true,grpc_api_configuration=opentelemetry/proto/collector/logs/v1/logs_service_http.yaml:./$(PROTO_GEN_GO_DIR) opentelemetry/proto/collector/logs/v1/logs_service.proto
-	$(PROTOC) --grpc-gateway_out=logtostderr=true,grpc_api_configuration=opentelemetry/proto/collector/profiles/v1experimental/profiles_service_http.yaml:./$(PROTO_GEN_GO_DIR) opentelemetry/proto/collector/profiles/v1experimental/profiles_service.proto
+	$(PROTOC) --grpc-gateway_out=logtostderr=true,grpc_api_configuration=opentelemetry/proto/collector/profiles/v1development/profiles_service_http.yaml:./$(PROTO_GEN_GO_DIR) opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
 
 # Generate gRPC/Protobuf implementation for Java.
 .PHONY: gen-java
@@ -105,7 +105,7 @@ gen-js:
 	$(PROTOC) --js_out=import_style=commonjs:./$(PROTO_GEN_JS_DIR) --grpc-web_out=import_style=commonjs,mode=grpcweb:./$(PROTO_GEN_JS_DIR) opentelemetry/proto/collector/trace/v1/trace_service.proto
 	$(PROTOC) --js_out=import_style=commonjs:./$(PROTO_GEN_JS_DIR) --grpc-web_out=import_style=commonjs,mode=grpcweb:./$(PROTO_GEN_JS_DIR) opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(PROTOC) --js_out=import_style=commonjs:./$(PROTO_GEN_JS_DIR) --grpc-web_out=import_style=commonjs,mode=grpcweb:./$(PROTO_GEN_JS_DIR) opentelemetry/proto/collector/logs/v1/logs_service.proto
-	$(PROTOC) --js_out=import_style=commonjs:./$(PROTO_GEN_JS_DIR) --grpc-web_out=import_style=commonjs,mode=grpcweb:./$(PROTO_GEN_JS_DIR) opentelemetry/proto/collector/profiles/v1experimental/profiles_service.proto
+	$(PROTOC) --js_out=import_style=commonjs:./$(PROTO_GEN_JS_DIR) --grpc-web_out=import_style=commonjs,mode=grpcweb:./$(PROTO_GEN_JS_DIR) opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
 
 # Generate gRPC/Protobuf implementation for Objective-C.
 .PHONY: gen-objc
@@ -116,7 +116,7 @@ gen-objc:
 	$(PROTOC) --objc_out=./$(PROTO_GEN_OBJC_DIR) --grpc-objc_out=./$(PROTO_GEN_OBJC_DIR) opentelemetry/proto/collector/trace/v1/trace_service.proto
 	$(PROTOC) --objc_out=./$(PROTO_GEN_OBJC_DIR) --grpc-objc_out=./$(PROTO_GEN_OBJC_DIR) opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(PROTOC) --objc_out=./$(PROTO_GEN_OBJC_DIR) --grpc-objc_out=./$(PROTO_GEN_OBJC_DIR) opentelemetry/proto/collector/logs/v1/logs_service.proto
-	$(PROTOC) --objc_out=./$(PROTO_GEN_OBJC_DIR) --grpc-objc_out=./$(PROTO_GEN_OBJC_DIR) opentelemetry/proto/collector/profiles/v1experimental/profiles_service.proto
+	$(PROTOC) --objc_out=./$(PROTO_GEN_OBJC_DIR) --grpc-objc_out=./$(PROTO_GEN_OBJC_DIR) opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
 
 # Generate gRPC/Protobuf for openapi v2 (swagger)
 .PHONY: gen-openapi
@@ -125,7 +125,7 @@ gen-openapi:
 	$(PROTOC) --openapiv2_out=logtostderr=true,grpc_api_configuration=opentelemetry/proto/collector/trace/v1/trace_service_http.yaml:$(PROTO_GEN_OPENAPI_DIR) opentelemetry/proto/collector/trace/v1/trace_service.proto
 	$(PROTOC) --openapiv2_out=logtostderr=true,grpc_api_configuration=opentelemetry/proto/collector/metrics/v1/metrics_service_http.yaml:$(PROTO_GEN_OPENAPI_DIR) opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(PROTOC) --openapiv2_out=logtostderr=true,grpc_api_configuration=opentelemetry/proto/collector/logs/v1/logs_service_http.yaml:$(PROTO_GEN_OPENAPI_DIR) opentelemetry/proto/collector/logs/v1/logs_service.proto
-	$(PROTOC) --openapiv2_out=logtostderr=true,grpc_api_configuration=opentelemetry/proto/collector/profiles/v1experimental/profiles_service_http.yaml:$(PROTO_GEN_OPENAPI_DIR) opentelemetry/proto/collector/profiles/v1experimental/profiles_service.proto
+	$(PROTOC) --openapiv2_out=logtostderr=true,grpc_api_configuration=opentelemetry/proto/collector/profiles/v1development/profiles_service_http.yaml:$(PROTO_GEN_OPENAPI_DIR) opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
 
 # Generate gRPC/Protobuf implementation for PhP.
 .PHONY: gen-php
@@ -136,7 +136,7 @@ gen-php:
 	$(PROTOC) --php_out=./$(PROTO_GEN_PHP_DIR) --grpc-php_out=./$(PROTO_GEN_PHP_DIR) opentelemetry/proto/collector/trace/v1/trace_service.proto
 	$(PROTOC) --php_out=./$(PROTO_GEN_PHP_DIR) --grpc-php_out=./$(PROTO_GEN_PHP_DIR) opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(PROTOC) --php_out=./$(PROTO_GEN_PHP_DIR) --grpc-php_out=./$(PROTO_GEN_PHP_DIR) opentelemetry/proto/collector/logs/v1/logs_service.proto
-	$(PROTOC) --php_out=./$(PROTO_GEN_PHP_DIR) --grpc-php_out=./$(PROTO_GEN_PHP_DIR) opentelemetry/proto/collector/profiles/v1experimental/profiles_service.proto
+	$(PROTOC) --php_out=./$(PROTO_GEN_PHP_DIR) --grpc-php_out=./$(PROTO_GEN_PHP_DIR) opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
 
 # Generate gRPC/Protobuf implementation for Python.
 .PHONY: gen-python
@@ -147,7 +147,7 @@ gen-python:
 	$(PROTOC) --python_out=./$(PROTO_GEN_PYTHON_DIR) --grpc-python_out=./$(PROTO_GEN_PYTHON_DIR) opentelemetry/proto/collector/trace/v1/trace_service.proto
 	$(PROTOC) --python_out=./$(PROTO_GEN_PYTHON_DIR) --grpc-python_out=./$(PROTO_GEN_PYTHON_DIR) opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(PROTOC) --python_out=./$(PROTO_GEN_PYTHON_DIR) --grpc-python_out=./$(PROTO_GEN_PYTHON_DIR) opentelemetry/proto/collector/logs/v1/logs_service.proto
-	$(PROTOC) --python_out=./$(PROTO_GEN_PYTHON_DIR) --grpc-python_out=./$(PROTO_GEN_PYTHON_DIR) opentelemetry/proto/collector/profiles/v1experimental/profiles_service.proto
+	$(PROTOC) --python_out=./$(PROTO_GEN_PYTHON_DIR) --grpc-python_out=./$(PROTO_GEN_PYTHON_DIR) opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
 
 # Generate gRPC/Protobuf implementation for Ruby.
 .PHONY: gen-ruby
@@ -158,9 +158,9 @@ gen-ruby:
 	$(PROTOC) --ruby_out=./$(PROTO_GEN_RUBY_DIR) --grpc-ruby_out=./$(PROTO_GEN_RUBY_DIR) opentelemetry/proto/collector/trace/v1/trace_service.proto
 	$(PROTOC) --ruby_out=./$(PROTO_GEN_RUBY_DIR) --grpc-ruby_out=./$(PROTO_GEN_RUBY_DIR) opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(PROTOC) --ruby_out=./$(PROTO_GEN_RUBY_DIR) --grpc-ruby_out=./$(PROTO_GEN_RUBY_DIR) opentelemetry/proto/collector/logs/v1/logs_service.proto
-	$(PROTOC) --ruby_out=./$(PROTO_GEN_RUBY_DIR) --grpc-ruby_out=./$(PROTO_GEN_RUBY_DIR) opentelemetry/proto/collector/profiles/v1experimental/profiles_service.proto
+	$(PROTOC) --ruby_out=./$(PROTO_GEN_RUBY_DIR) --grpc-ruby_out=./$(PROTO_GEN_RUBY_DIR) opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
 
-# The Profiling protocol is still experimental. So it is excluded from the breaking-change check.
+# The Profiling protocol is still development. So it is excluded from the breaking-change check.
 .PHONY: breaking-change
 breaking-change:
 	$(BUF) breaking --against $(BUF_AGAINST) --config '{"version":"v1","breaking":{"ignore":["opentelemetry/proto/profiles", "opentelemetry/proto/collector/profiles"]}}' $(BUF_FLAGS)

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ components as indicated by the Maturity table below.
 | metrics/\*<br>collector/metrics/* | Stable | [Stable](docs/specification.md#json-protobuf-encoding) |
 | trace/\*<br>collector/trace/* | Stable | [Stable](docs/specification.md#json-protobuf-encoding) |
 | logs/\*<br>collector/logs/* | Stable | [Stable](docs/specification.md#json-protobuf-encoding) |
-| profiles/\*<br>collector/profiles/* | Experimental | [Experimental](docs/specification.md#json-protobuf-encoding) |
+| profiles/\*<br>collector/profiles/* | Development | [Development](docs/specification.md#json-protobuf-encoding) |
 
-(See [maturity-matrix.yaml](https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f466a58bd2bb94edc72/maturity-matrix.yaml#L57)
+(See [Versioning and Stability](https://github.com/open-telemetry/opentelemetry-specification/blob/a08d1f92f62acd4aafe4dfaa04ae7bf28600d49e/specification/versioning-and-stability.md)
 for definition of maturity levels).
 
 ## Stability Definition
@@ -89,8 +89,8 @@ is generated from the .proto files by any particular code generator.
 ## Experiments
 
 In some cases we are trying to experiment with different features. In this case,
-we recommend using an "experimental" sub-directory instead of adding them to any
+we recommend using a "development" sub-directory instead of adding them to any
 protocol version. These protocols should not be used, except for
 development/testing purposes.
 
-Another review must be conducted for experimental protocols to join the main project.
+Another review must be conducted for in-development protocols to join the main project.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -96,7 +96,7 @@ telemetry data using unary requests using
 messages ([ExportLogsServiceRequest](../opentelemetry/proto/collector/logs/v1/logs_service.proto) for logs,
 [ExportMetricsServiceRequest](../opentelemetry/proto/collector/metrics/v1/metrics_service.proto) for metrics,
 [ExportTraceServiceRequest](../opentelemetry/proto/collector/trace/v1/trace_service.proto) for traces,
-[ExportProfilesServiceRequest](../opentelemetry/proto/collector/profiles/v1experimental/profiles_service.proto) for profiles).
+[ExportProfilesServiceRequest](../opentelemetry/proto/collector/profiles/v1development/profiles_service.proto) for profiles).
 The client continuously sends a sequence of requests to the server and expects
 to receive a response to each request:
 

--- a/opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
+++ b/opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
@@ -14,15 +14,15 @@
 
 syntax = "proto3";
 
-package opentelemetry.proto.collector.profiles.v1experimental;
+package opentelemetry.proto.collector.profiles.v1development;
 
-import "opentelemetry/proto/profiles/v1experimental/profiles.proto";
+import "opentelemetry/proto/profiles/v1development/profiles.proto";
 
-option csharp_namespace = "OpenTelemetry.Proto.Collector.Profiles.V1Experimental";
+option csharp_namespace = "OpenTelemetry.Proto.Collector.Profiles.V1Development";
 option java_multiple_files = true;
-option java_package = "io.opentelemetry.proto.collector.profiles.v1experimental";
+option java_package = "io.opentelemetry.proto.collector.profiles.v1development";
 option java_outer_classname = "ProfilesServiceProto";
-option go_package = "go.opentelemetry.io/proto/otlp/collector/profiles/v1experimental";
+option go_package = "go.opentelemetry.io/proto/otlp/collector/profiles/v1development";
 
 // Service that can be used to push profiles between one Application instrumented with
 // OpenTelemetry and a collector, or between a collector and a central collector.
@@ -38,7 +38,7 @@ message ExportProfilesServiceRequest {
   // element. Intermediary nodes (such as OpenTelemetry Collector) that receive
   // data from multiple origins typically batch the data before forwarding further and
   // in that case this array will contain multiple elements.
-  repeated opentelemetry.proto.profiles.v1experimental.ResourceProfiles resource_profiles = 1;
+  repeated opentelemetry.proto.profiles.v1development.ResourceProfiles resource_profiles = 1;
 }
 
 message ExportProfilesServiceResponse {

--- a/opentelemetry/proto/collector/profiles/v1development/profiles_service_http.yaml
+++ b/opentelemetry/proto/collector/profiles/v1development/profiles_service_http.yaml
@@ -4,6 +4,6 @@ type: google.api.Service
 config_version: 3
 http:
  rules:
- - selector: opentelemetry.proto.collector.profiles.v1experimental.ProfilesService.Export
-   post: /v1experimental/profiles
+ - selector: opentelemetry.proto.collector.profiles.v1development.ProfilesService.Export
+   post: /v1development/profiles
    body: "*"

--- a/opentelemetry/proto/profiles/v1development/pprofextended.proto
+++ b/opentelemetry/proto/profiles/v1development/pprofextended.proto
@@ -54,14 +54,14 @@
 
 syntax = "proto3";
 
-package opentelemetry.proto.profiles.v1experimental;
+package opentelemetry.proto.profiles.v1development;
 
 import "opentelemetry/proto/common/v1/common.proto";
 
-option csharp_namespace = "OpenTelemetry.Proto.Profiles.V1Experimental";
+option csharp_namespace = "OpenTelemetry.Proto.Profiles.V1Development";
 option java_multiple_files = true;
-option java_package = "io.opentelemetry.proto.profiles.v1experimental";
-option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1experimental";
+option java_package = "io.opentelemetry.proto.profiles.v1development";
+option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1development";
 
 // Represents a complete profile, including sample types, samples,
 // mappings to binaries, locations, functions, string table, and additional metadata.

--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -14,17 +14,17 @@
 
 syntax = "proto3";
 
-package opentelemetry.proto.profiles.v1experimental;
+package opentelemetry.proto.profiles.v1development;
 
 import "opentelemetry/proto/common/v1/common.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
-import "opentelemetry/proto/profiles/v1experimental/pprofextended.proto";
+import "opentelemetry/proto/profiles/v1development/pprofextended.proto";
 
-option csharp_namespace = "OpenTelemetry.Proto.Profiles.V1Experimental";
+option csharp_namespace = "OpenTelemetry.Proto.Profiles.V1Development";
 option java_multiple_files = true;
-option java_package = "io.opentelemetry.proto.profiles.v1experimental";
+option java_package = "io.opentelemetry.proto.profiles.v1development";
 option java_outer_classname = "ProfilesProto";
-option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1experimental";
+option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1development";
 
 //                Relationships Diagram
 //
@@ -187,5 +187,5 @@ message ProfileContainer {
   bytes original_payload = 7;
 
   // This is a reference to a pprof profile. Required, even when original_payload is present.
-  opentelemetry.proto.profiles.v1experimental.Profile profile = 8;
+  opentelemetry.proto.profiles.v1development.Profile profile = 8;
 }


### PR DESCRIPTION
As discussed in https://github.com/open-telemetry/opentelemetry-proto/pull/582#discussion_r1751850589, this renames the `v1experimental` version for profiles to `v1development`.

I've also taken this opportunity to update the versioning and stability link.