### PR TITLE
Exclude profiles service from breaking changes too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ gen-ruby:
 # The Profiling protocol is still experimental. So it is excluded from the breaking-change check.
 .PHONY: breaking-change
 breaking-change:
-	$(BUF) breaking --against $(BUF_AGAINST) --config '{"version":"v1","breaking":{"ignore":["opentelemetry/proto/profiles"]}}' $(BUF_FLAGS)
+	$(BUF) breaking --against $(BUF_AGAINST) --config '{"version":"v1","breaking":{"ignore":["opentelemetry/proto/profiles", "opentelemetry/proto/collector/profiles"]}}' $(BUF_FLAGS)
 
 
 ALL_DOCS := $(shell find . -type f -name '*.md' -not -path './.github/*' -not -path './node_modules/*' | sort)


### PR DESCRIPTION
#576 excluded the profiles definition from breaking changes.
But the entire profiles protocol is in development and can have breaking changes, including the gRPC service.