### PR TITLE
Clarify aggregation temporality for Summary metric type

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -268,6 +268,9 @@ message ExponentialHistogram {
 // data type. These data points cannot always be merged in a meaningful way.
 // While they can be useful in some applications, histogram data points are
 // recommended for new applications.
+// Summary metrics do not have an aggregation temporality field. This is
+// because the count and sum fields of a SummaryDataPoint are assumed to be
+// cumulative values.
 message Summary {
   repeated SummaryDataPoint data_points = 1;
 }
@@ -606,7 +609,8 @@ message ExponentialHistogramDataPoint {
 }
 
 // SummaryDataPoint is a single data point in a timeseries that describes the
-// time-varying values of a Summary metric.
+// time-varying values of a Summary metric. The count and sum fields represent
+// cumulative values.
 message SummaryDataPoint {
   reserved 1;
 


### PR DESCRIPTION
I recently came across a scenario where an OTLP consumer assumed the count and sum fields of a Summary metric represented delta values. Needless to say, this is a false assumption.

The specific use case that led me to this discovery was from a user using the collector's Prometheus receiver scraping a target that emitted summary metrics. Of course the start time of the metric emitted by the collector was constant signaling these were cumulative values.

If my assumption is correct that Summary metrics will always represent cumulative values (with the exception of the quantiles) I think it makes sense to clarify this in the description.