### PR TITLE
Add note about schema url and schema version

### DIFF
--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -56,7 +56,8 @@ message ResourceLogs {
   repeated ScopeLogs scope_logs = 2;
 
   // The Schema URL, if known. This is the identifier of the Schema that the resource data
-  // is recorded in. To learn more about Schema URL see
+  // is recorded in. Notably, the last part of the URL path is the version number of the
+  // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to the data in the "resource" field. It does not apply
   // to the data in the "scope_logs" field which have their own schema_url field.
@@ -74,7 +75,8 @@ message ScopeLogs {
   repeated LogRecord log_records = 2;
 
   // The Schema URL, if known. This is the identifier of the Schema that the log data
-  // is recorded in. To learn more about Schema URL see
+  // is recorded in. Notably, the last part of the URL path is the version number of the
+  // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to all logs in the "logs" field.
   string schema_url = 3;

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -74,7 +74,8 @@ message ResourceMetrics {
   repeated ScopeMetrics scope_metrics = 2;
 
   // The Schema URL, if known. This is the identifier of the Schema that the resource data
-  // is recorded in. To learn more about Schema URL see
+  // is recorded in. Notably, the last part of the URL path is the version number of the
+  // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to the data in the "resource" field. It does not apply
   // to the data in the "scope_metrics" field which have their own schema_url field.
@@ -92,7 +93,8 @@ message ScopeMetrics {
   repeated Metric metrics = 2;
 
   // The Schema URL, if known. This is the identifier of the Schema that the metric data
-  // is recorded in. To learn more about Schema URL see
+  // is recorded in. Notably, the last part of the URL path is the version number of the
+  // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to all metrics in the "metrics" field.
   string schema_url = 3;

--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -122,7 +122,8 @@ message ResourceProfiles {
   repeated ScopeProfiles scope_profiles = 2;
 
   // The Schema URL, if known. This is the identifier of the Schema that the resource data
-  // is recorded in. To learn more about Schema URL see
+  // is recorded in. Notably, the last part of the URL path is the version number of the
+  // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to the data in the "resource" field. It does not apply
   // to the data in the "scope_profiles" field which have their own schema_url field.
@@ -140,7 +141,8 @@ message ScopeProfiles {
   repeated Profile profiles = 2;
 
   // The Schema URL, if known. This is the identifier of the Schema that the profile data
-  // is recorded in. To learn more about Schema URL see
+  // is recorded in. Notably, the last part of the URL path is the version number of the
+  // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to all profiles in the "profiles" field.
   string schema_url = 3;

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -56,7 +56,8 @@ message ResourceSpans {
   repeated ScopeSpans scope_spans = 2;
 
   // The Schema URL, if known. This is the identifier of the Schema that the resource data
-  // is recorded in. To learn more about Schema URL see
+  // is recorded in. Notably, the last part of the URL path is the version number of the
+  // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to the data in the "resource" field. It does not apply
   // to the data in the "scope_spans" field which have their own schema_url field.
@@ -74,7 +75,8 @@ message ScopeSpans {
   repeated Span spans = 2;
 
   // The Schema URL, if known. This is the identifier of the Schema that the span data
-  // is recorded in. To learn more about Schema URL see
+  // is recorded in. Notably, the last part of the URL path is the version number of the
+  // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to all spans and span events in the "spans" field.
   string schema_url = 3;


### PR DESCRIPTION
It wasn't obvious to me that `schema_url` requires that the last part of the URL path is the schema version number.

From the [spec](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/schemas#schema-url):

> The last part of the URL path is the version number of the schema.

This PR extends the comment for each schema_url to make this crucial piece of information clear. Note there are still other relevant bits of information about schema_url that reads need to follow the link to `https://opentelemetry.io/docs/specs/otel/schemas/#schema-url` in order to understand. E.g. that the version follows the format `MAJOR.MINOR.PATCH` and more.