### PR TITLE
Add extra link check to release.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 _Instruction for Maintainers only._
 
-- Run [opentelemetry.io workflow](https://github.com/open-telemetry/opentelemetry.io/actions/workflows/build-dev.yml)
+- Run the [opentelemetry.io dev-build workflow](https://github.com/open-telemetry/opentelemetry.io/actions/workflows/build-dev.yml)
   against `opentelemetry-proto` submodule as a smoke-test for docs. Fix broken links, if any.
 
 - Prepare the release by updating [CHANGELOG.md](CHANGELOG.md), see for example

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,6 +2,9 @@
 
 _Instruction for Maintainers only._
 
+- Run [opentelemetry.io workflow](https://github.com/open-telemetry/opentelemetry.io/actions/workflows/build-dev.yml)
+  against `opentelemetry-proto` submodule as a smoke-test for docs. Fix broken links, if any.
+
 - Prepare the release by updating [CHANGELOG.md](CHANGELOG.md), see for example
 [this PR](https://github.com/open-telemetry/opentelemetry-proto/pull/537).
 Merge the PR. From this point on no new PRs can be merged until the release is complete.


### PR DESCRIPTION
See https://github.com/open-telemetry/semantic-conventions/issues/1009 and https://github.com/open-telemetry/opentelemetry-proto/pull/611#issuecomment-2542654361 for the context.

TL;DR: [markdown-link-check](https://github.com/tcort/markdown-link-check/) does not check cross-file anchor links.
Today broken links are discovered only when a new proto release is published on otel.io, where these links needs to be manually overridden and fixed.

The general tooling for this is tracked in https://github.com/open-telemetry/semantic-conventions/issues/1009, in the meantime, we should leverage otel.io workflow that can run against proto `main` branch and detect broken anchors. 

It finds a few broken anchors in almost every semconv and spec release, so 1) it's useful 2) it adds just a few minutes to the release process and not too bad.

This PR adds this as a manual step until we have a full automation.


