### PR TITLE
Add profiling-approvers as CODEOWNERS for profiles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,4 +16,5 @@
 *   @open-telemetry/spec-sponsors
 
 # Profiles owners (global + profiles)
-opentelemetry/proto/profiles  @open-telemetry/spec-sponsors @open-telemetry/profiling-maintainers
+opentelemetry/proto/profiles  @open-telemetry/spec-sponsors @open-telemetry/profiling-maintainers @open-telemetry/profiling-approvers
+opentelemetry/proto/collector/profiles  @open-telemetry/spec-sponsors @open-telemetry/profiling-maintainers @open-telemetry/profiling-approvers


### PR DESCRIPTION
Also add opentelemetry/proto/collector/profiles directory to CODEOWNERS.