### PR TITLE
Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ Additional Notes:
 
 We follow a structured workflow to ensure smooth collaboration:
 ### Commit Message Format
+
 - Use descriptive commit messages (e.g., `fix(proto): resolve issue with trace spec`)
 - Follow [Conventional Commits](https://www.conventionalcommits.org/) where possible.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,6 @@ Before getting started, ensure you have the following installed:
 Additional Notes:
 - Ensure your environment supports the required dependencies for building and testing .proto files.
 - Windows users may need [Git Bash](https://gitforwindows.org/) for better compatibility.
-
-
 ## Workflow
 
 We follow a structured workflow to ensure smooth collaboration:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,6 @@ Additional Notes:
 ## Workflow
 
 We follow a structured workflow to ensure smooth collaboration:
-
-
 ### Commit Message Format
 - Use descriptive commit messages (e.g., `fix(proto): resolve issue with trace spec`)
 - Follow [Conventional Commits](https://www.conventionalcommits.org/) where possible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ make compatibility-test
 ## Contributing Rules
 
 - Follow OpenTelemetry’s [Contribution Guidelines](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md).
-- Ensure that .proto files adhere to OpenTelemetry’s stability guarantees.
+- Ensure that `.proto` files adhere to OpenTelemetry's stability guarantees.
 - Ensure new changes maintain compatibility with existing OpenTelemetry client libraries.
 - Include clear and concise documentation updates if needed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Welcome to the OpenTelemetry Protocol (OTLP) Specification repository! 🎉
 
-Thank you for your interest in contributing to this project. This repository contains the OTLP protocol specification and the corresponding Language Independent Interface Types (.proto files). Your contributions help improve the interoperability of OpenTelemetry client libraries across various languages.
+Thank you for your interest in contributing to this project. This repository contains the OTLP specification and the corresponding Language Independent Interface Types (`.proto` files). Your contributions help improve the interoperability of OpenTelemetry clients across various programming languages.
 
 If you have any questions, feel free to ask in the community channels. We’re happy to help! 😊
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,11 @@ Before getting started, ensure you have the following installed:
 Additional Notes:
 - Ensure your environment supports the required dependencies for building and testing .proto files.
 - Windows users may need [Git Bash](https://gitforwindows.org/) for better compatibility.
+
 ## Workflow
 
 We follow a structured workflow to ensure smooth collaboration:
+
 ### Commit Message Format
 
 - Use descriptive commit messages (e.g., `fix(proto): resolve issue with trace spec`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,6 @@ make compatibility-test
 
 - Follow OpenTelemetry’s [Contribution Guidelines](https://opentelemetry.io/docs/contributing/style-guide/).
 - Ensure that `.proto` files adhere to OpenTelemetry's stability guarantees.
-- Ensure new changes maintain compatibility with existing OpenTelemetry client libraries.
 - Include clear and concise documentation updates if needed.
 
 Check for issues labeled [`good first issue`](https://github.com/open-telemetry/opentelemetry-proto/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to start contributing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,9 @@ Before getting started, ensure you have the following installed:
 
 * **Docker** – [Install Docker](https://docs.docker.com/engine/install/)
 * **Make** (for running development tasks)
-* **Protobuf Compiler (protoc)** – [Install protoc](https://grpc.io/docs/protoc-installation/)
 
 Additional Notes:
 
-* Ensure your environment supports the required dependencies for building and testing .proto files.
 * Windows users may need [Git Bash](https://gitforwindows.org/) for better compatibility.
 
 ## Workflow
@@ -33,8 +31,7 @@ We follow a structured workflow to ensure smooth collaboration:
 ### Pull Request Guidelines
 
 - Fork the repository and create a new branch.
-- Follow the coding guidelines before submitting your PR.
-- Ensure tests pass locally before pushing.
+- Ensure `make all` pass locally before pushing.
 - Link relevant issues in the PR description.
 
 ---
@@ -52,19 +49,6 @@ cd opentelemetry-proto
 make gen-all
 ```
 
-To validate your changes:
-
-```bash
-make check
-```
-
-To update dependencies:
-
-```bash
-make update
-```
-
-
 ## Testing
 
 To test your changes, run:
@@ -79,16 +63,10 @@ To verify the protobuf definitions:
 make proto-lint
 ```
 
-To check compatibility with different OpenTelemetry client libraries:
-
-```bash
-make compatibility-test
-```
-
 
 ## Contributing Rules
 
-- Follow OpenTelemetry’s [Contribution Guidelines](https://opentelemetry.io/docs/contributing/style-guide/).
+- Follow OpenTelemetry’s [Contribution Guidelines](https://github.com/open-telemetry/community/blob/main/guides/contributor/README.md).
 - Ensure that `.proto` files adhere to OpenTelemetry's stability guarantees.
 - Include clear and concise documentation updates if needed.
 
@@ -103,11 +81,9 @@ Need help? Join our community:
 - **Issues**: If you encounter a bug, [open an issue](https://github.com/open-telemetry/opentelemetry-proto/issues)
 
 
-## Troubleshooting Guide
+## Troubleshooting
 
-### Common Issues & Fixes
-
-#### 1. Protobuf Compiler Issues
+#### Protobuf Compiler Issues
 
 **Error:** `protoc: command not found`
 
@@ -117,7 +93,7 @@ sudo apt install protobuf-compiler  # Linux
 brew install protobuf  # macOS
 ```
 
-#### 2. Build Failures
+#### Build Failures
 
 **Error:** `Failed to generate gRPC client libraries`
 
@@ -126,7 +102,7 @@ brew install protobuf  # macOS
 make clean && make gen-all
 ```
 
-#### 3. Linting Errors
+#### Linting Errors
 
 **Error:** `proto-lint: some files do not conform to style guidelines`
 
@@ -134,8 +110,6 @@ make clean && make gen-all
 ```bash
 make proto-lint-fix
 ```
-
----
 
 ## Additional Information
 
@@ -146,7 +120,6 @@ This repository follows OpenTelemetry’s stability guarantees:
 * Stable components will not introduce breaking changes
 * Development components may be removed or changed without prior notice.
 
-Refer to the [Versioning and Stability](https://github.com/open-telemetry/opentelemetry-proto/blob/main/README.md#versioning-and-stability) documentation for more details.
 
 ### Generating gRPC Client Libraries
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ make compatibility-test
 
 ## Contributing Rules
 
-- Follow OpenTelemetry’s [Contribution Guidelines](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md).
+- Follow OpenTelemetry’s [Contribution Guidelines](https://opentelemetry.io/docs/contributing/style-guide/).
 - Ensure that `.proto` files adhere to OpenTelemetry's stability guarantees.
 - Ensure new changes maintain compatibility with existing OpenTelemetry client libraries.
 - Include clear and concise documentation updates if needed.
@@ -97,7 +97,6 @@ Check for issues labeled [`good first issue`](https://github.com/open-telemetry/
 Need help? Join our community:
 
 - **Slack**: [OpenTelemetry Slack](https://opentelemetry.io/community/)
-- **GitHub Discussions**: [OpenTelemetry Discussions](https://github.com/open-telemetry/opentelemetry-proto/discussions)
 - **Issues**: If you encounter a bug, [open an issue](https://github.com/open-telemetry/opentelemetry-proto/issues)
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,13 +12,14 @@ If you have any questions, feel free to ask in the community channels. We're hap
 
 Before getting started, ensure you have the following installed:
 
-- **Docker** – [Install Docker](https://docs.docker.com/engine/install/)
-- **Make** (for running development tasks)
-- **Protobuf Compiler (protoc)** – [Install protoc](https://grpc.io/docs/protoc-installation/)
+* **Docker** – [Install Docker](https://docs.docker.com/engine/install/)
+* **Make** (for running development tasks)
+* **Protobuf Compiler (protoc)** – [Install protoc](https://grpc.io/docs/protoc-installation/)
 
 Additional Notes:
-- Ensure your environment supports the required dependencies for building and testing .proto files.
-- Windows users may need [Git Bash](https://gitforwindows.org/) for better compatibility.
+
+* Ensure your environment supports the required dependencies for building and testing .proto files.
+* Windows users may need [Git Bash](https://gitforwindows.org/) for better compatibility.
 
 ## Workflow
 
@@ -26,8 +27,8 @@ We follow a structured workflow to ensure smooth collaboration:
 
 ### Commit Message Format
 
-- Use descriptive commit messages (e.g., `fix(proto): resolve issue with trace spec`)
-- Follow [Conventional Commits](https://www.conventionalcommits.org/) where possible.
+* Use descriptive commit messages (e.g., `fix(proto): resolve issue with trace spec`)
+* Follow [Conventional Commits](https://www.conventionalcommits.org/) where possible.
 
 ### Pull Request Guidelines
 
@@ -52,16 +53,17 @@ make gen-all
 ```
 
 To validate your changes:
+
 ```bash
 make check
 ```
 
 To update dependencies:
+
 ```bash
 make update
 ```
 
----
 
 ## Testing
 
@@ -72,16 +74,17 @@ make test
 ```
 
 To verify the protobuf definitions:
+
 ```bash
 make proto-lint
 ```
 
 To check compatibility with different OpenTelemetry client libraries:
+
 ```bash
 make compatibility-test
 ```
 
----
 
 ## Contributing Rules
 
@@ -91,7 +94,6 @@ make compatibility-test
 
 Check for issues labeled [`good first issue`](https://github.com/open-telemetry/opentelemetry-proto/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to start contributing.
 
----
 
 ## Further Help
 
@@ -100,13 +102,13 @@ Need help? Join our community:
 - **Slack**: [OpenTelemetry Slack](https://opentelemetry.io/community/)
 - **Issues**: If you encounter a bug, [open an issue](https://github.com/open-telemetry/opentelemetry-proto/issues)
 
----
 
 ## Troubleshooting Guide
 
 ### Common Issues & Fixes
 
 #### 1. Protobuf Compiler Issues
+
 **Error:** `protoc: command not found`
 
 **Fix:** Install the protobuf compiler:
@@ -116,6 +118,7 @@ brew install protobuf  # macOS
 ```
 
 #### 2. Build Failures
+
 **Error:** `Failed to generate gRPC client libraries`
 
 **Fix:** Ensure Docker is running and retry:
@@ -124,6 +127,7 @@ make clean && make gen-all
 ```
 
 #### 3. Linting Errors
+
 **Error:** `proto-lint: some files do not conform to style guidelines`
 
 **Fix:** Run:
@@ -138,8 +142,9 @@ make proto-lint-fix
 ### Stability Guidelines
 
 This repository follows OpenTelemetry’s stability guarantees:
-- Stable components will not introduce breaking changes.
-- Development components may be removed or changed without prior notice.
+
+* Stable components will not introduce breaking changes
+* Development components may be removed or changed without prior notice.
 
 Refer to the [Versioning and Stability](https://github.com/open-telemetry/opentelemetry-proto/blob/main/README.md#versioning-and-stability) documentation for more details.
 
@@ -152,14 +157,15 @@ make gen-<language>
 ```
 
 Currently supported languages:
-- cpp
-- csharp
-- go
-- java
-- objc
-- openapi (swagger)
-- php
-- python
-- ruby
+
+* cpp
+* csharp
+* go
+* java
+* objc
+* openapi (swagger)
+* php
+* python
+* ruby
 
 Thank you for contributing! 🚀

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,6 @@ To verify the protobuf definitions:
 make proto-lint
 ```
 
-
 ## Contributing Rules
 
 - Follow OpenTelemetry’s [Contribution Guidelines](https://github.com/open-telemetry/community/blob/main/guides/contributor/README.md).
@@ -72,14 +71,12 @@ make proto-lint
 
 Check for issues labeled [`good first issue`](https://github.com/open-telemetry/opentelemetry-proto/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to start contributing.
 
-
 ## Further Help
 
 Need help? Join our community:
 
 - **Slack**: [OpenTelemetry Slack](https://opentelemetry.io/community/)
 - **Issues**: If you encounter a bug, [open an issue](https://github.com/open-telemetry/opentelemetry-proto/issues)
-
 
 ## Troubleshooting
 
@@ -88,6 +85,7 @@ Need help? Join our community:
 **Error:** `protoc: command not found`
 
 **Fix:** Install the protobuf compiler:
+
 ```bash
 sudo apt install protobuf-compiler  # Linux
 brew install protobuf  # macOS
@@ -98,6 +96,7 @@ brew install protobuf  # macOS
 **Error:** `Failed to generate gRPC client libraries`
 
 **Fix:** Ensure Docker is running and retry:
+
 ```bash
 make clean && make gen-all
 ```
@@ -107,6 +106,7 @@ make clean && make gen-all
 **Error:** `proto-lint: some files do not conform to style guidelines`
 
 **Fix:** Run:
+
 ```bash
 make proto-lint-fix
 ```
@@ -119,7 +119,6 @@ This repository follows OpenTelemetry’s stability guarantees:
 
 * Stable components will not introduce breaking changes
 * Development components may be removed or changed without prior notice.
-
 
 ### Generating gRPC Client Libraries
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Welcome to the OpenTelemetry Protocol (OTLP) Specification repository! 🎉
 
 Thank you for your interest in contributing to this project. This repository contains the OTLP specification and the corresponding Language Independent Interface Types (`.proto` files). Your contributions help improve the interoperability of OpenTelemetry clients across various programming languages.
 
-If you have any questions, feel free to ask in the community channels. We’re happy to help! 😊
+If you have any questions, feel free to ask in the community channels. We're happy to help! 😊
 
 ## Prerequisites
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,182 @@
+# Contributing to OpenTelemetry Protocol (OTLP) Specification
+
+## Introduction
+
+Welcome to the OpenTelemetry Protocol (OTLP) Specification repository! 🎉
+
+Thank you for your interest in contributing to this project. This repository contains the OTLP protocol specification and the corresponding Language Independent Interface Types (.proto files). Your contributions help improve the interoperability of OpenTelemetry client libraries across various languages.
+
+If you have any questions, feel free to ask in the community channels. We’re happy to help! 😊
+
+## Prerequisites
+
+Before getting started, ensure you have the following installed:
+
+- **Docker** – [Install Docker](https://docs.docker.com/engine/install/)
+- **Make** (for running development tasks)
+- **Protobuf Compiler (protoc)** – [Install protoc](https://grpc.io/docs/protoc-installation/)
+
+Additional Notes:
+- Ensure your environment supports the required dependencies for building and testing .proto files.
+- Windows users may need [Git Bash](https://gitforwindows.org/) for better compatibility.
+
+
+## Workflow
+
+We follow a structured workflow to ensure smooth collaboration:
+
+### Branch Naming Convention
+- **Feature branches**: `feature/<short-description>`
+- **Bugfix branches**: `fix/<short-description>`
+- **Documentation updates**: `docs/<short-description>`
+
+### Commit Message Format
+- Use descriptive commit messages (e.g., `fix(proto): resolve issue with trace spec`)
+- Follow [Conventional Commits](https://www.conventionalcommits.org/) where possible.
+
+### Pull Request Guidelines
+- Fork the repository and create a new branch.
+- Follow the coding guidelines before submitting your PR.
+- Ensure tests pass locally before pushing.
+- Link relevant issues in the PR description.
+
+---
+
+## Local Setup & Development
+
+To set up your local development environment:
+
+```bash
+# Clone the repository
+git clone https://github.com/open-telemetry/opentelemetry-proto.git
+cd opentelemetry-proto
+
+# Generate all implementations
+make gen-all
+```
+
+To validate your changes:
+```bash
+make check
+```
+
+To update dependencies:
+```bash
+make update
+```
+
+---
+
+## Testing
+
+To test your changes, run:
+
+```bash
+make test
+```
+
+To verify the protobuf definitions:
+```bash
+make proto-lint
+```
+
+To check compatibility with different OpenTelemetry client libraries:
+```bash
+make compatibility-test
+```
+
+---
+
+## Contributing Rules
+
+- Follow OpenTelemetry’s [Contribution Guidelines](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md).
+- Ensure that .proto files adhere to OpenTelemetry’s stability guarantees.
+- Ensure new changes maintain compatibility with existing OpenTelemetry client libraries.
+- Include clear and concise documentation updates if needed.
+
+Check for issues labeled [`good first issue`](https://github.com/open-telemetry/opentelemetry-proto/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to start contributing.
+
+---
+
+## Further Help
+
+Need help? Join our community:
+
+- **Slack**: [OpenTelemetry Slack](https://opentelemetry.io/community/)
+- **GitHub Discussions**: [OpenTelemetry Discussions](https://github.com/open-telemetry/opentelemetry-proto/discussions)
+- **Issues**: If you encounter a bug, [open an issue](https://github.com/open-telemetry/opentelemetry-proto/issues)
+
+---
+
+## Troubleshooting Guide
+
+### Common Issues & Fixes
+
+#### 1. Protobuf Compiler Issues
+**Error:** `protoc: command not found`
+
+**Fix:** Install the protobuf compiler:
+```bash
+sudo apt install protobuf-compiler  # Linux
+brew install protobuf  # macOS
+```
+
+#### 2. Build Failures
+**Error:** `Failed to generate gRPC client libraries`
+
+**Fix:** Ensure Docker is running and retry:
+```bash
+make clean && make gen-all
+```
+
+#### 3. Linting Errors
+**Error:** `proto-lint: some files do not conform to style guidelines`
+
+**Fix:** Run:
+```bash
+make proto-lint-fix
+```
+
+---
+
+## Additional Information
+
+### Stability Guidelines
+
+This repository follows OpenTelemetry’s stability guarantees:
+- Stable components will not introduce breaking changes.
+- Development components may be removed or changed without prior notice.
+
+Refer to the [Versioning and Stability](https://github.com/open-telemetry/opentelemetry-proto/blob/main/README.md#versioning-and-stability) documentation for more details.
+
+### Generating gRPC Client Libraries
+
+To generate raw gRPC client libraries for supported languages, run:
+
+```bash
+make gen-<language>
+```
+
+Currently supported languages:
+- cpp
+- csharp
+- go
+- java
+- objc
+- openapi (swagger)
+- php
+- python
+- ruby
+
+Thank you for contributing! 🚀
+
+
+
 # Contributing
 
 Read OpenTelemetry project [contributing
 guide](https://github.com/open-telemetry/community/blob/main/guides/contributor/README.md)
 for general information about the project.
-
-## Prerequisites
-
-- `Docker`
 
 ## Making changes to the .proto files
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ We follow a structured workflow to ensure smooth collaboration:
 - Follow [Conventional Commits](https://www.conventionalcommits.org/) where possible.
 
 ### Pull Request Guidelines
+
 - Fork the repository and create a new branch.
 - Follow the coding guidelines before submitting your PR.
 - Ensure tests pass locally before pushing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,6 @@ Additional Notes:
 
 We follow a structured workflow to ensure smooth collaboration:
 
-### Branch Naming Convention
-- **Feature branches**: `feature/<short-description>`
-- **Bugfix branches**: `fix/<short-description>`
-- **Documentation updates**: `docs/<short-description>`
 
 ### Commit Message Format
 - Use descriptive commit messages (e.g., `fix(proto): resolve issue with trace spec`)
@@ -169,16 +165,3 @@ Currently supported languages:
 - ruby
 
 Thank you for contributing! 🚀
-
-
-
-# Contributing
-
-Read OpenTelemetry project [contributing
-guide](https://github.com/open-telemetry/community/blob/main/guides/contributor/README.md)
-for general information about the project.
-
-## Making changes to the .proto files
-
-After making any changes to .proto files make sure to generate all
-implementation by running `make gen-all`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Welcome to the OpenTelemetry Protocol (OTLP) Specification repository! 🎉
 
-Thank you for your interest in contributing to this project. This repository contains the OTLP specification and the corresponding Language Independent Interface Types (`.proto` files). Your contributions help improve the interoperability of OpenTelemetry clients across various programming languages.
+Your contributions help improve the interoperability of OpenTelemetry clients across various programming languages.
 
 If you have any questions, feel free to ask in the community channels. We're happy to help! 😊
 
@@ -83,7 +83,7 @@ Need help? Join our community:
 
 ## Troubleshooting
 
-#### Protobuf Compiler Issues
+### Protobuf Compiler Issues
 
 **Error:** `protoc: command not found`
 
@@ -93,7 +93,7 @@ sudo apt install protobuf-compiler  # Linux
 brew install protobuf  # macOS
 ```
 
-#### Build Failures
+### Build Failures
 
 **Error:** `Failed to generate gRPC client libraries`
 
@@ -102,7 +102,7 @@ brew install protobuf  # macOS
 make clean && make gen-all
 ```
 
-#### Linting Errors
+### Linting Errors
 
 **Error:** `proto-lint: some files do not conform to style guidelines`
 


### PR DESCRIPTION
part of https://github.com/open-telemetry/sig-contributor-experience/issues/31

This pull request standardizes the setup guide for the opentelemetry-proto repository using the proposed template

### Next Steps:

Feedback and suggestions are highly welcomed!

This update aims to make it easier for contributors to get started with the project and follow best practices while contributing while following a consistent pattern for a setup guide across the Otel ecosystem.

Please review and let me know if you have any suggestions or feedback.