### PR TITLE
Clarify when bucket_counts array may be empty

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -461,7 +461,9 @@ message HistogramDataPoint {
   // The sum of the bucket_counts must equal the value in the count field.
   //
   // The number of elements in bucket_counts array must be by one greater than
-  // the number of elements in explicit_bounds array.
+  // the number of elements in explicit_bounds array. The exception to this rule
+  // is when the length of bucket_counts is 0, then the length of explicit_bounds
+  // must also be 0.
   repeated fixed64 bucket_counts = 6;
 
   // explicit_bounds specifies buckets with explicitly defined bounds for values.
@@ -477,6 +479,9 @@ message HistogramDataPoint {
   // Histogram buckets are inclusive of their upper boundary, except the last
   // bucket where the boundary is at infinity. This format is intentionally
   // compatible with the OpenMetrics histogram definition.
+  //
+  // If bucket_counts length is 0 then explicit_bounds length must also be 0,
+  // otherwise the data point is invalid.
   repeated double explicit_bounds = 7;
 
   // (Optional) List of exemplars collected from


### PR DESCRIPTION
The current definition says:

"The number of elements in bucket_counts array must be by one
 greater than the number of elements in explicit_bounds array."

However, it also says "bucket_counts is an optional field", which 
means its length can be 0, which then in turn means the length of 
explicit_bounds must be -1, which is impossible.

We clarify that it is a valid situation to have both bucket_counts and explicit_bounds arrays empty.