### PR TITLE
Add specs for empty telemetry envelopes.

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -665,10 +665,6 @@ payloads that contain zero spans, zero metric points or zero log records),
 receivers MAY ignore empty envelopes, and implementations that receive and send
 (forward) OTLP payloads MAY drop empty envelopes.
 
-There are certain use cases for communicating the existece of a Resource
-without any contained telemetry data, such as service discovery or mapping, but
-going forward those use cases are best addressed by using Entities instead.
-
 ## Known Limitations
 
 ### Request Acknowledgements

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -651,6 +651,24 @@ This ensures that all destination servers receive the data regardless of their
 speed of reception (within the available limits imposed by the size of the
 client-side queue).
 
+### Empty Telemetry Envelopes
+
+Under certain circumstances, it is possible to have a telemetry envelope with
+no contents. Some examples would be a ResourceMetrics with no ScopeMetrics
+inside it, a ResourceMetrics with no Metrics inside it, or the equivalents for
+Logs or Spans. One way this might happen would be for filtering rules to remove
+all the contained data points, though there are others.
+
+In practice, such empty envelopes are often discarded by existing
+implementations. Given that, senders SHOULD NOT create empty envelopes (OTLP
+payloads that contain zero spans, zero metric points or zero log records),
+receivers MAY ignore empty envelopes, and implementations that receive and send
+(forward) OTLP payloads MAY drop empty envelopes.
+
+There are certain use cases for communicating the existece of a Resource
+without any contained telemetry data, such as service discovery or mapping, but
+going forward those use cases are best addressed by using Entities instead.
+
 ## Known Limitations
 
 ### Request Acknowledgements


### PR DESCRIPTION
Based on the discussion [here](https://github.com/open-telemetry/opentelemetry-proto/issues/598), this PR adds some guidelines for handling empty telemetry envelopes. (Specifically, that they should generally be avoided and may be dropped.)

This is my first PR to the OTel spec, so please let me know if there's a better place to put this or I missed any steps of the process!