### PR TITLE
[editorial] Update metrics.proto comment to use https

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -194,7 +194,7 @@ message Metric {
   string description = 2;
 
   // unit in which the metric value is reported. Follows the format
-  // described by http://unitsofmeasure.org/ucum.html.
+  // described by https://unitsofmeasure.org/ucum.html.
   string unit = 3;
 
   // Data determines the aggregation type (if any) of the metric, what is the


### PR DESCRIPTION
- I don't know if comments can be updated, but if so, this PR proposes to use the canonical link to https://unitsofmeasure.org/ucum instead of the `http` version (which redirects).
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/6409

/cc @open-telemetry/spec-sponsors 