### PR TITLE
Add EntityRef and use it in Resource.

### DIFF
--- a/opentelemetry/proto/common/v1/common.proto
+++ b/opentelemetry/proto/common/v1/common.proto
@@ -90,7 +90,7 @@ message EntityRef {
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   //
   // This schema_url applies to the data in this message and to the Resource attributes
-  // referenced by id_attr_keys and descr_attr_keys.
+  // referenced by id_keys and description_keys.
   // TODO: discuss if we are happy with this somewhat complicated definition of what
   // the schema_url applies to.
   //

--- a/opentelemetry/proto/common/v1/common.proto
+++ b/opentelemetry/proto/common/v1/common.proto
@@ -81,7 +81,7 @@ message InstrumentationScope {
 }
 
 // A reference to an Entity.
-// Entity represents an object of interest associated with produced telemetry: e.g spans, metrics or logs.
+// Entity represents an object of interest associated with produced telemetry: e.g spans, metrics, profiles, or logs.
 //
 // Status: [Development]
 message EntityRef {

--- a/opentelemetry/proto/common/v1/common.proto
+++ b/opentelemetry/proto/common/v1/common.proto
@@ -79,3 +79,37 @@ message InstrumentationScope {
   repeated KeyValue attributes = 3;
   uint32 dropped_attributes_count = 4;
 }
+
+// A reference to an Entity.
+// Entity represents an object of interest associated with produced telemetry: e.g spans, metrics or logs.
+//
+// Status: [Development]
+message EntityRef {
+  // The Schema URL, if known. This is the identifier of the Schema that the entity data
+  // is recorded in. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+  //
+  // This schema_url applies to the data in this message and to the Resource attributes
+  // referenced by id_attr_keys and descr_attr_keys.
+  // TODO: discuss if we are happy with this somewhat complicated definition of what
+  // the schema_url applies to.
+  //
+  // This field obsoletes the schema_url field in ResourceMetrics/ResourceSpans/ResourceLogs.
+  string schema_url = 1;
+
+  // Defines the type of the entity. MUST not change during the lifetime of the entity.
+  // For example: "service" or "host". This field is required and MUST not be empty
+  // for valid entities.
+  string type = 2;
+
+  // Attribute Keys that identify the entity.
+  // MUST not change during the lifetime of the entity. The Id must contain at least one attribute.
+  // These keys MUST exist in the containing {message}.attributes.
+  repeated string id_keys = 3;
+
+  // Descriptive (non-identifying) attribute keys of the entity.
+  // MAY change over the lifetime of the entity. MAY be empty.
+  // These attribute keys are not part of entity's identity.
+  // These keys MUST exist in the containing {message}.attributes.
+  repeated string description_keys = 4;
+}

--- a/opentelemetry/proto/resource/v1/resource.proto
+++ b/opentelemetry/proto/resource/v1/resource.proto
@@ -37,7 +37,7 @@ message Resource {
 
   // Set of entities that participate in this Resource.
   //
-  // Note: keys in the references MUST existing in attributes of this message.
+  // Note: keys in the references MUST exist in attributes of this message.
   //
   // Status: [Development]
   repeated opentelemetry.proto.common.v1.EntityRef entity_refs = 3;

--- a/opentelemetry/proto/resource/v1/resource.proto
+++ b/opentelemetry/proto/resource/v1/resource.proto
@@ -34,4 +34,11 @@ message Resource {
   // dropped_attributes_count is the number of dropped attributes. If the value is 0, then
   // no attributes were dropped.
   uint32 dropped_attributes_count = 2;
+
+  // Set of entities that participate in this Resource.
+  //
+  // Note: keys in the references MUST existing in attributes of this message.
+  //
+  // Status: [Development]
+  repeated opentelemetry.proto.common.v1.EntityRef entity_refs = 3;
 }


### PR DESCRIPTION
As per [OTEP 264](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/entities/0264-resource-and-entities.md) - This is the proposal for representing "Entity" in OTLP.

- Adds a new `EntityRef` message where an Entity is an object of interest in observability.
  - Entity has a type (e.g. `host`, `k8s.pod`, `service`).
  - Entity has a set of identifying attributes (these contribute to signal identity)
  - Entity has a set of descriptive attirbutes (these are used to aide signal retreival/querying).
  - Entity can be defined and versioned (e.g. semantic conventions via schema_url).
- Adds a new `entity_refs` field to `Resource` that allows distinguishing which key-value pairs in `Resource` come from which reported `Entity`.

Please read the OTEP for details and rationale behind this protocol design.  High level this meant to be:

- Sufficient to represent entities
- Non-breaking for all OpenTelemetry users.


Prototypes using this protocol

- java: https://github.com/open-telemetry/opentelemetry-java/pull/6855
- collector: https://github.com/open-telemetry/opentelemetry-collector/pull/11958
- go: https://github.com/open-telemetry/opentelemetry-go/pull/5918/