### PR TITLE
Generate Mermaid diagrams for proto files

### DIFF
--- a/docs/generated/common.proto.md
+++ b/docs/generated/common.proto.md
@@ -1,0 +1,180 @@
+# Package: opentelemetry.proto.common.v1
+
+<div class="comment"><span>Copyright 2019, OpenTelemetry Authors Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</span><br/></div>
+
+## Imports
+
+| Import | Description |
+|--------|-------------|
+
+
+
+## Options
+
+| Name                 | Value                                    | Description |
+|----------------------|------------------------------------------|-------------|
+| csharp_namespace     | OpenTelemetry.Proto.Common.V1            |             |
+| java_multiple_files  | true                                     |             |
+| java_package         | io.opentelemetry.proto.common.v1         |             |
+| java_outer_classname | CommonProto                              |             |
+| go_package           | go.opentelemetry.io/proto/otlp/common/v1 |             |
+
+
+
+
+### AnyValue Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% AnyValue is used to represent any type of attribute value. AnyValue may contain a primitive value such as a string or integer or it may contain an arbitrary nested object containing arrays, key-value lists and primitives.
+
+class AnyValue {
+  + string string_value
+  + bool bool_value
+  + int64 int_value
+  + double double_value
+  + ArrayValue array_value
+  + KeyValueList kvlist_value
+  + bytes bytes_value
+}
+AnyValue --> `ArrayValue`
+AnyValue --> `KeyValueList`
+
+```
+### ArrayValue Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% ArrayValue is a list of AnyValue messages. We need ArrayValue as a message since oneof in AnyValue does not allow repeated fields.
+
+class ArrayValue {
+  + List~AnyValue~ values
+}
+ArrayValue --> `AnyValue`
+
+```
+### KeyValueList Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% KeyValueList is a list of KeyValue messages. We need KeyValueList as a message since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches are semantically equivalent.
+
+class KeyValueList {
+  + List~KeyValue~ values
+}
+KeyValueList --> `KeyValue`
+
+```
+### KeyValue Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% KeyValue is a key-value pair that is used to store Span attributes, Link attributes, etc.
+
+class KeyValue {
+  + string key
+  + AnyValue value
+}
+KeyValue --> `AnyValue`
+
+```
+### InstrumentationScope Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% InstrumentationScope is a message representing the instrumentation scope information such as the fully qualified name and version.
+
+class InstrumentationScope {
+  + string name
+  + string version
+  + List~KeyValue~ attributes
+  + uint32 dropped_attributes_count
+}
+InstrumentationScope --> `KeyValue`
+
+```
+
+## Message: AnyValue
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.common.v1.AnyValue</div>
+
+<div class="comment"><span>AnyValue is used to represent any type of attribute value. AnyValue may contain a primitive value such as a string or integer or it may contain an arbitrary nested object containing arrays, key-value lists and primitives.</span><br/></div>
+
+| Field        | Ordinal | Type         | Label | Description                                                                                                                                   |
+|--------------|---------|--------------|-------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| string_value | 1       | string       |       | The value is one of the listed fields. It is valid for all values to be unspecified in which case this AnyValue is considered to be "empty".  |
+| bool_value   | 2       | bool         |       |                                                                                                                                               |
+| int_value    | 3       | int64        |       |                                                                                                                                               |
+| double_value | 4       | double       |       |                                                                                                                                               |
+| array_value  | 5       | ArrayValue   |       |                                                                                                                                               |
+| kvlist_value | 6       | KeyValueList |       |                                                                                                                                               |
+| bytes_value  | 7       | bytes        |       |                                                                                                                                               |
+
+
+
+
+## Message: ArrayValue
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.common.v1.ArrayValue</div>
+
+<div class="comment"><span>ArrayValue is a list of AnyValue messages. We need ArrayValue as a message since oneof in AnyValue does not allow repeated fields.</span><br/></div>
+
+| Field  | Ordinal | Type     | Label    | Description                                                    |
+|--------|---------|----------|----------|----------------------------------------------------------------|
+| values | 1       | AnyValue | Repeated | Array of values. The array may be empty (contain 0 elements).  |
+
+
+
+
+## Message: KeyValueList
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.common.v1.KeyValueList</div>
+
+<div class="comment"><span>KeyValueList is a list of KeyValue messages. We need KeyValueList as a message since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches are semantically equivalent.</span><br/></div>
+
+| Field  | Ordinal | Type     | Label    | Description                                                                                                                                                                                     |
+|--------|---------|----------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| values | 1       | KeyValue | Repeated | A collection of key/value pairs of key-value pairs. The list may be empty (may contain 0 elements). The keys MUST be unique (it is not allowed to have more than one value with the same key).  |
+
+
+
+
+## Message: KeyValue
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.common.v1.KeyValue</div>
+
+<div class="comment"><span>KeyValue is a key-value pair that is used to store Span attributes, Link attributes, etc.</span><br/></div>
+
+| Field | Ordinal | Type     | Label | Description |
+|-------|---------|----------|-------|-------------|
+| key   | 1       | string   |       |             |
+| value | 2       | AnyValue |       |             |
+
+
+
+
+## Message: InstrumentationScope
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.common.v1.InstrumentationScope</div>
+
+<div class="comment"><span>InstrumentationScope is a message representing the instrumentation scope information such as the fully qualified name and version.</span><br/></div>
+
+| Field                    | Ordinal | Type     | Label    | Description                                                                                                                                                      |
+|--------------------------|---------|----------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name                     | 1       | string   |          | An empty instrumentation scope name means the name is unknown.                                                                                                   |
+| version                  | 2       | string   |          |                                                                                                                                                                  |
+| attributes               | 3       | KeyValue | Repeated | Additional attributes that describe the scope. [Optional]. Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key).  |
+| dropped_attributes_count | 4       | uint32   |          |                                                                                                                                                                  |
+
+
+
+
+
+
+<!-- Created by: Proto Diagram Tool -->
+<!-- https://github.com/GoogleCloudPlatform/proto-gen-md-diagrams -->

--- a/docs/generated/logs.proto.md
+++ b/docs/generated/logs.proto.md
@@ -1,0 +1,261 @@
+# Package: opentelemetry.proto.logs.v1
+
+<div class="comment"><span>Copyright 2020, OpenTelemetry Authors Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</span><br/></div>
+
+## Imports
+
+| Import                                         | Description |
+|------------------------------------------------|-------------|
+| opentelemetry/proto/common/v1/common.proto     |             |
+| opentelemetry/proto/resource/v1/resource.proto |             |
+
+
+
+## Options
+
+| Name                 | Value                                  | Description |
+|----------------------|----------------------------------------|-------------|
+| csharp_namespace     | OpenTelemetry.Proto.Logs.V1            |             |
+| java_multiple_files  | true                                   |             |
+| java_package         | io.opentelemetry.proto.logs.v1         |             |
+| java_outer_classname | LogsProto                              |             |
+| go_package           | go.opentelemetry.io/proto/otlp/logs/v1 |             |
+
+
+
+## Enum: SeverityNumber
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.logs.v1.SeverityNumber</div>
+
+<div class="comment"><span>Possible values for LogRecord.SeverityNumber.</span><br/></div>
+
+| Name                        | Ordinal | Description                                                      |
+|-----------------------------|---------|------------------------------------------------------------------|
+| SEVERITY_NUMBER_UNSPECIFIED | 0       | UNSPECIFIED is the default SeverityNumber, it MUST NOT be used.  |
+| SEVERITY_NUMBER_TRACE       | 1       |                                                                  |
+| SEVERITY_NUMBER_TRACE2      | 2       |                                                                  |
+| SEVERITY_NUMBER_TRACE3      | 3       |                                                                  |
+| SEVERITY_NUMBER_TRACE4      | 4       |                                                                  |
+| SEVERITY_NUMBER_DEBUG       | 5       |                                                                  |
+| SEVERITY_NUMBER_DEBUG2      | 6       |                                                                  |
+| SEVERITY_NUMBER_DEBUG3      | 7       |                                                                  |
+| SEVERITY_NUMBER_DEBUG4      | 8       |                                                                  |
+| SEVERITY_NUMBER_INFO        | 9       |                                                                  |
+| SEVERITY_NUMBER_INFO2       | 10      |                                                                  |
+| SEVERITY_NUMBER_INFO3       | 11      |                                                                  |
+| SEVERITY_NUMBER_INFO4       | 12      |                                                                  |
+| SEVERITY_NUMBER_WARN        | 13      |                                                                  |
+| SEVERITY_NUMBER_WARN2       | 14      |                                                                  |
+| SEVERITY_NUMBER_WARN3       | 15      |                                                                  |
+| SEVERITY_NUMBER_WARN4       | 16      |                                                                  |
+| SEVERITY_NUMBER_ERROR       | 17      |                                                                  |
+| SEVERITY_NUMBER_ERROR2      | 18      |                                                                  |
+| SEVERITY_NUMBER_ERROR3      | 19      |                                                                  |
+| SEVERITY_NUMBER_ERROR4      | 20      |                                                                  |
+| SEVERITY_NUMBER_FATAL       | 21      |                                                                  |
+| SEVERITY_NUMBER_FATAL2      | 22      |                                                                  |
+| SEVERITY_NUMBER_FATAL3      | 23      |                                                                  |
+| SEVERITY_NUMBER_FATAL4      | 24      |                                                                  |
+
+
+## Enum: LogRecordFlags
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.logs.v1.LogRecordFlags</div>
+
+<div class="comment"><span>LogRecordFlags represents constants used to interpret the LogRecord.flags field, which is protobuf 'fixed32' type and is to be used as bit-fields. Each non-zero value defined in this enum is a bit-mask. To extract the bit-field, for example, use an expression like: (logRecord.flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK)</span><br/></div>
+
+| Name                              | Ordinal | Description                                                                                                                           |
+|-----------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------|
+| LOG_RECORD_FLAGS_DO_NOT_USE       | 0       | The zero value for the enum. Should not be used for comparisons. Instead use bitwise "and" with the appropriate mask as shown above.  |
+| LOG_RECORD_FLAGS_TRACE_FLAGS_MASK | 0       | Bits 0-7 are used for trace flags.                                                                                                    |
+
+
+
+### SeverityNumber Diagram
+
+```mermaid
+classDiagram
+direction LR
+%% Possible values for LogRecord.SeverityNumber.
+
+class SeverityNumber{
+  <<enumeration>>
+  SEVERITY_NUMBER_UNSPECIFIED
+  SEVERITY_NUMBER_TRACE
+  SEVERITY_NUMBER_TRACE2
+  SEVERITY_NUMBER_TRACE3
+  SEVERITY_NUMBER_TRACE4
+  SEVERITY_NUMBER_DEBUG
+  SEVERITY_NUMBER_DEBUG2
+  SEVERITY_NUMBER_DEBUG3
+  SEVERITY_NUMBER_DEBUG4
+  SEVERITY_NUMBER_INFO
+  SEVERITY_NUMBER_INFO2
+  SEVERITY_NUMBER_INFO3
+  SEVERITY_NUMBER_INFO4
+  SEVERITY_NUMBER_WARN
+  SEVERITY_NUMBER_WARN2
+  SEVERITY_NUMBER_WARN3
+  SEVERITY_NUMBER_WARN4
+  SEVERITY_NUMBER_ERROR
+  SEVERITY_NUMBER_ERROR2
+  SEVERITY_NUMBER_ERROR3
+  SEVERITY_NUMBER_ERROR4
+  SEVERITY_NUMBER_FATAL
+  SEVERITY_NUMBER_FATAL2
+  SEVERITY_NUMBER_FATAL3
+  SEVERITY_NUMBER_FATAL4
+}
+```
+### LogRecordFlags Diagram
+
+```mermaid
+classDiagram
+direction LR
+%% LogRecordFlags represents constants used to interpret the LogRecord.flags field, which is protobuf 'fixed32' type and is to be used as bit-fields. Each non-zero value defined in this enum is a bit-mask. To extract the bit-field, for example, use an expression like: (logRecord.flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK)
+
+class LogRecordFlags{
+  <<enumeration>>
+  LOG_RECORD_FLAGS_DO_NOT_USE
+  LOG_RECORD_FLAGS_TRACE_FLAGS_MASK
+}
+```
+### LogsData Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% LogsData represents the logs data that can be stored in a persistent storage, OR can be embedded by other protocols that transfer OTLP logs data but do not implement the OTLP protocol. The main difference between this message and collector protocol is that in this message there will not be any "control" or "metadata" specific to OTLP protocol. When new fields are added into this message, the OTLP request MUST be updated as well.
+
+class LogsData {
+  + List~ResourceLogs~ resource_logs
+}
+LogsData --> `ResourceLogs`
+
+```
+### ResourceLogs Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% A collection of ScopeLogs from a Resource.
+
+class ResourceLogs {
+  + opentelemetry.proto.resource.v1.Resource resource
+  + List~ScopeLogs~ scope_logs
+  + string schema_url
+}
+ResourceLogs --> `opentelemetry.proto.resource.v1.Resource`
+ResourceLogs --> `ScopeLogs`
+
+```
+### ScopeLogs Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% A collection of Logs produced by a Scope.
+
+class ScopeLogs {
+  + opentelemetry.proto.common.v1.InstrumentationScope scope
+  + List~LogRecord~ log_records
+  + string schema_url
+}
+ScopeLogs --> `opentelemetry.proto.common.v1.InstrumentationScope`
+ScopeLogs --> `LogRecord`
+
+```
+### LogRecord Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% A log record according to OpenTelemetry Log Data Model: https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md
+
+class LogRecord {
+  + fixed64 time_unix_nano
+  + SeverityNumber severity_number
+  + string severity_text
+  + opentelemetry.proto.common.v1.AnyValue body
+  + List~opentelemetry.proto.common.v1.KeyValue~ attributes
+  + uint32 dropped_attributes_count
+  + fixed32 flags
+  + bytes trace_id
+  + bytes span_id
+  + fixed64 observed_time_unix_nano
+  + string event_name
+}
+LogRecord --> `SeverityNumber`
+LogRecord --> `opentelemetry.proto.common.v1.AnyValue`
+LogRecord --> `opentelemetry.proto.common.v1.KeyValue`
+
+```
+
+## Message: LogsData
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.logs.v1.LogsData</div>
+
+<div class="comment"><span>LogsData represents the logs data that can be stored in a persistent storage, OR can be embedded by other protocols that transfer OTLP logs data but do not implement the OTLP protocol. The main difference between this message and collector protocol is that in this message there will not be any "control" or "metadata" specific to OTLP protocol. When new fields are added into this message, the OTLP request MUST be updated as well.</span><br/></div>
+
+| Field         | Ordinal | Type         | Label    | Description                                                                                                                                                                                                                                                                                |
+|---------------|---------|--------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| resource_logs | 1       | ResourceLogs | Repeated | An array of ResourceLogs. For data coming from a single resource this array will typically contain one element. Intermediary nodes that receive data from multiple origins typically batch the data before forwarding further and in that case this array will contain multiple elements.  |
+
+
+
+
+## Message: ResourceLogs
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.logs.v1.ResourceLogs</div>
+
+<div class="comment"><span>A collection of ScopeLogs from a Resource.</span><br/></div>
+
+| Field      | Ordinal | Type                                     | Label    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+|------------|---------|------------------------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| resource   | 1       | opentelemetry.proto.resource.v1.Resource |          | The resource for the logs in this message. If this field is not set then resource info is unknown.                                                                                                                                                                                                                                                                                                                                                                                     |
+| scope_logs | 2       | ScopeLogs                                | Repeated | A list of ScopeLogs that originate from a resource.                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| schema_url | 3       | string                                   |          | The Schema URL, if known. This is the identifier of the Schema that the resource data is recorded in. Notably, the last part of the URL path is the version number of the schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see https://opentelemetry.io/docs/specs/otel/schemas/#schema-url This schema_url applies to the data in the "resource" field. It does not apply to the data in the "scope_logs" field which have their own schema_url field.  |
+
+
+
+
+## Message: ScopeLogs
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.logs.v1.ScopeLogs</div>
+
+<div class="comment"><span>A collection of Logs produced by a Scope.</span><br/></div>
+
+| Field       | Ordinal | Type                                               | Label    | Description                                                                                                                                                                                                                                                                                                                                                                    |
+|-------------|---------|----------------------------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| scope       | 1       | opentelemetry.proto.common.v1.InstrumentationScope |          | The instrumentation scope information for the logs in this message. Semantically when InstrumentationScope isn't set, it is equivalent with an empty instrumentation scope name (unknown).                                                                                                                                                                                     |
+| log_records | 2       | LogRecord                                          | Repeated | A list of log records.                                                                                                                                                                                                                                                                                                                                                         |
+| schema_url  | 3       | string                                             |          | The Schema URL, if known. This is the identifier of the Schema that the log data is recorded in. Notably, the last part of the URL path is the version number of the schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see https://opentelemetry.io/docs/specs/otel/schemas/#schema-url This schema_url applies to all logs in the "logs" field.  |
+
+
+
+
+## Message: LogRecord
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.logs.v1.LogRecord</div>
+
+<div class="comment"><span>A log record according to OpenTelemetry Log Data Model: https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md</span><br/></div>
+
+| Field                    | Ordinal | Type                                   | Label    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+|--------------------------|---------|----------------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| time_unix_nano           | 1       | fixed64                                |          | time_unix_nano is the time when the event occurred. Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970. Value of 0 indicates unknown or missing timestamp.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| severity_number          | 2       | SeverityNumber                         |          | Numerical value of the severity, normalized to values described in Log Data Model. [Optional].                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| severity_text            | 3       | string                                 |          | The severity text (also known as log level). The original string representation as it is known at the source. [Optional].                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| body                     | 5       | opentelemetry.proto.common.v1.AnyValue |          | A value containing the body of the log record. Can be for example a human-readable string message (including multi-line) describing the event in a free form or it can be a structured data composed of arrays and maps of other values. [Optional].                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| attributes               | 6       | opentelemetry.proto.common.v1.KeyValue | Repeated | Additional attributes that describe the specific event occurrence. [Optional]. Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| dropped_attributes_count | 7       | uint32                                 |          |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| flags                    | 8       | fixed32                                |          | Flags, a bit field. 8 least significant bits are the trace flags as defined in W3C Trace Context specification. 24 most significant bits are reserved and must be set to 0. Readers must not assume that 24 most significant bits will be zero and must correctly mask the bits when reading 8-bit trace flag (use flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK). [Optional].                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| trace_id                 | 9       | bytes                                  |          | A unique identifier for a trace. All logs from the same trace share the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR of length other than 16 bytes is considered invalid (empty string in OTLP/JSON is zero-length and thus is also invalid). This field is optional. The receivers SHOULD assume that the log record is not associated with a trace if any of the following is true: - the field is not present, - the field contains an invalid value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| span_id                  | 10      | bytes                                  |          | A unique identifier for a span within a trace, assigned when the span is created. The ID is an 8-byte array. An ID with all zeroes OR of length other than 8 bytes is considered invalid (empty string in OTLP/JSON is zero-length and thus is also invalid). This field is optional. If the sender specifies a valid span_id then it SHOULD also specify a valid trace_id. The receivers SHOULD assume that the log record is not associated with a span if any of the following is true: - the field is not present, - the field contains an invalid value.                                                                                                                                                                                                                                                                                                                                                                                    |
+| observed_time_unix_nano  | 11      | fixed64                                |          | Time when the event was observed by the collection system. For events that originate in OpenTelemetry (e.g. using OpenTelemetry Logging SDK) this timestamp is typically set at the generation time and is equal to Timestamp. For events originating externally and collected by OpenTelemetry (e.g. using Collector) this is the time when OpenTelemetry's code observed the event measured by the clock of the OpenTelemetry code. This field MUST be set once the event is observed by OpenTelemetry. For converting OpenTelemetry log data to formats that support only one timestamp or when receiving OpenTelemetry log data by recipients that support only one timestamp internally the following logic is recommended: - Use time_unix_nano if it is present, otherwise use observed_time_unix_nano. Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970. Value of 0 indicates unknown or missing timestamp.  |
+| event_name               | 12      | string                                 |          | A unique identifier of event category/type. All events with the same event_name are expected to conform to the same schema for both their attributes and their body. Recommended to be fully qualified and short (no longer than 256 characters). Presence of event_name on the log record identifies this record as an event. [Optional]. Status: [Development]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+
+
+
+
+
+
+<!-- Created by: Proto Diagram Tool -->
+<!-- https://github.com/GoogleCloudPlatform/proto-gen-md-diagrams -->

--- a/docs/generated/logs_service.proto.md
+++ b/docs/generated/logs_service.proto.md
@@ -1,0 +1,133 @@
+# Package: opentelemetry.proto.collector.logs.v1
+
+<div class="comment"><span>Copyright 2020, OpenTelemetry Authors Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</span><br/></div>
+
+## Imports
+
+| Import                                 | Description |
+|----------------------------------------|-------------|
+| opentelemetry/proto/logs/v1/logs.proto |             |
+
+
+
+## Options
+
+| Name                 | Value                                            | Description |
+|----------------------|--------------------------------------------------|-------------|
+| csharp_namespace     | OpenTelemetry.Proto.Collector.Logs.V1            |             |
+| java_multiple_files  | true                                             |             |
+| java_package         | io.opentelemetry.proto.collector.logs.v1         |             |
+| java_outer_classname | LogsServiceProto                                 |             |
+| go_package           | go.opentelemetry.io/proto/otlp/collector/logs/v1 |             |
+
+
+
+## Service: LogsService
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.logs.v1</div>
+
+<div class="comment"><span>Service that can be used to push logs between one Application instrumented with OpenTelemetry and an collector, or between an collector and a central collector (in this case logs are sent/received to/from multiple Applications).</span><br/></div>
+
+### LogsService Diagram
+
+```mermaid
+classDiagram
+direction LR
+class LogsService {
+  <<service>>
+  +Export(ExportLogsServiceRequest) ExportLogsServiceResponse
+}
+LogsService --> `ExportLogsServiceRequest`
+LogsService --> `ExportLogsServiceResponse`
+
+```
+
+| Method | Parameter (In)           | Parameter (Out)           | Description                                                                                                |
+|--------|--------------------------|---------------------------|------------------------------------------------------------------------------------------------------------|
+| Export | ExportLogsServiceRequest | ExportLogsServiceResponse | For performance reasons, it is recommended to keep this RPC alive for the entire life of the application.  |
+
+
+
+### ExportLogsServiceRequest Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% 
+
+class ExportLogsServiceRequest {
+  + List~opentelemetry.proto.logs.v1.ResourceLogs~ resource_logs
+}
+ExportLogsServiceRequest --> `opentelemetry.proto.logs.v1.ResourceLogs`
+
+```
+### ExportLogsServiceResponse Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% 
+
+class ExportLogsServiceResponse {
+  + ExportLogsPartialSuccess partial_success
+}
+ExportLogsServiceResponse --> `ExportLogsPartialSuccess`
+
+```
+### ExportLogsPartialSuccess Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% 
+
+class ExportLogsPartialSuccess {
+  + int64 rejected_log_records
+  + string error_message
+}
+
+```
+
+## Message: ExportLogsServiceRequest
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest</div>
+
+<div class="comment"><span></span><br/></div>
+
+| Field         | Ordinal | Type                                     | Label    | Description                                                                                                                                                                                                                                                                                                                  |
+|---------------|---------|------------------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| resource_logs | 1       | opentelemetry.proto.logs.v1.ResourceLogs | Repeated | An array of ResourceLogs. For data coming from a single resource this array will typically contain one element. Intermediary nodes (such as OpenTelemetry Collector) that receive data from multiple origins typically batch the data before forwarding further and in that case this array will contain multiple elements.  |
+
+
+
+
+## Message: ExportLogsServiceResponse
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse</div>
+
+<div class="comment"><span></span><br/></div>
+
+| Field           | Ordinal | Type                     | Label | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+|-----------------|---------|--------------------------|-------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| partial_success | 1       | ExportLogsPartialSuccess |       | The details of a partially successful export request. If the request is only partially accepted (i.e. when the server accepts only parts of the data and rejects the rest) the server MUST initialize the `partial_success` field and MUST set the `rejected_<signal>` with the number of items it rejected. Servers MAY also make use of the `partial_success` field to convey warnings/suggestions to senders even when the request was fully accepted. In such cases, the `rejected_<signal>` MUST have a value of `0` and the `error_message` MUST be non-empty. A `partial_success` message with an empty value (rejected_<signal> = 0 and `error_message` = "") is equivalent to it not being set/present. Senders SHOULD interpret it the same way as in the full success case.  |
+
+
+
+
+## Message: ExportLogsPartialSuccess
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.logs.v1.ExportLogsPartialSuccess</div>
+
+<div class="comment"><span></span><br/></div>
+
+| Field                | Ordinal | Type   | Label | Description                                                                                                                                                                                                                                                                                                                                                                                                |
+|----------------------|---------|--------|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rejected_log_records | 1       | int64  |       | The number of rejected log records. A `rejected_<signal>` field holding a `0` value indicates that the request was fully accepted.                                                                                                                                                                                                                                                                         |
+| error_message        | 2       | string |       | A developer-facing human-readable message in English. It should be used either to explain why the server rejected parts of the data during a partial success or to convey warnings/suggestions during a full success. The message should offer guidance on how users can address such issues. error_message is an optional field. An error_message with an empty value is equivalent to it not being set.  |
+
+
+
+
+
+
+<!-- Created by: Proto Diagram Tool -->
+<!-- https://github.com/GoogleCloudPlatform/proto-gen-md-diagrams -->

--- a/docs/generated/metrics.proto.md
+++ b/docs/generated/metrics.proto.md
@@ -1,0 +1,631 @@
+# Package: opentelemetry.proto.metrics.v1
+
+<div class="comment"><span>Copyright 2019, OpenTelemetry Authors Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</span><br/></div>
+
+## Imports
+
+| Import                                         | Description |
+|------------------------------------------------|-------------|
+| opentelemetry/proto/common/v1/common.proto     |             |
+| opentelemetry/proto/resource/v1/resource.proto |             |
+
+
+
+## Options
+
+| Name                 | Value                                     | Description |
+|----------------------|-------------------------------------------|-------------|
+| csharp_namespace     | OpenTelemetry.Proto.Metrics.V1            |             |
+| java_multiple_files  | true                                      |             |
+| java_package         | io.opentelemetry.proto.metrics.v1         |             |
+| java_outer_classname | MetricsProto                              |             |
+| go_package           | go.opentelemetry.io/proto/otlp/metrics/v1 |             |
+
+
+
+## Enum: AggregationTemporality
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.AggregationTemporality</div>
+
+<div class="comment"><span>AggregationTemporality defines how a metric aggregator reports aggregated values. It describes how those values relate to the time interval over which they are aggregated.</span><br/></div>
+
+| Name                                | Ordinal | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+|-------------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| AGGREGATION_TEMPORALITY_UNSPECIFIED | 0       | UNSPECIFIED is the default AggregationTemporality, it MUST not be used.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| AGGREGATION_TEMPORALITY_DELTA       | 1       | DELTA is an AggregationTemporality for a metric aggregator which reports changes since last report time. Successive metrics contain aggregation of values from continuous and non-overlapping intervals. The values for a DELTA metric are based only on the time interval associated with one measurement cycle. There is no dependency on previous measurements like is the case for CUMULATIVE metrics. For example, consider a system measuring the number of requests that it receives and reports the sum of these requests every second as a DELTA metric: 1. The system starts receiving at time=t_0. 2. A request is received, the system measures 1 request. 3. A request is received, the system measures 1 request. 4. A request is received, the system measures 1 request. 5. The 1 second collection cycle ends. A metric is exported for the number of requests received over the interval of time t_0 to t_0+1 with a value of 3. 6. A request is received, the system measures 1 request. 7. A request is received, the system measures 1 request. 8. The 1 second collection cycle ends. A metric is exported for the number of requests received over the interval of time t_0+1 to t_0+2 with a value of 2.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| AGGREGATION_TEMPORALITY_CUMULATIVE  | 2       | CUMULATIVE is an AggregationTemporality for a metric aggregator which reports changes since a fixed start time. This means that current values of a CUMULATIVE metric depend on all previous measurements since the start time. Because of this, the sender is required to retain this state in some form. If this state is lost or invalidated, the CUMULATIVE metric values MUST be reset and a new fixed start time following the last reported measurement time sent MUST be used. For example, consider a system measuring the number of requests that it receives and reports the sum of these requests every second as a CUMULATIVE metric: 1. The system starts receiving at time=t_0. 2. A request is received, the system measures 1 request. 3. A request is received, the system measures 1 request. 4. A request is received, the system measures 1 request. 5. The 1 second collection cycle ends. A metric is exported for the number of requests received over the interval of time t_0 to t_0+1 with a value of 3. 6. A request is received, the system measures 1 request. 7. A request is received, the system measures 1 request. 8. The 1 second collection cycle ends. A metric is exported for the number of requests received over the interval of time t_0 to t_0+2 with a value of 5. 9. The system experiences a fault and loses state. 10. The system recovers and resumes receiving at time=t_1. 11. A request is received, the system measures 1 request. 12. The 1 second collection cycle ends. A metric is exported for the number of requests received over the interval of time t_1 to t_0+1 with a value of 1. Note: Even though, when reporting changes since last report time, using CUMULATIVE is valid, it is not recommended. This may cause problems for systems that do not use start_time to determine when the aggregation value was reset (e.g. Prometheus).  |
+
+
+## Enum: DataPointFlags
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.DataPointFlags</div>
+
+<div class="comment"><span>DataPointFlags is defined as a protobuf 'uint32' type and is to be used as a bit-field representing 32 distinct boolean flags. Each flag defined in this enum is a bit-mask. To test the presence of a single flag in the flags of a data point, for example, use an expression like: (point.flags & DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK) == DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK</span><br/></div>
+
+| Name                                    | Ordinal | Description                                                                                                                                                                              |
+|-----------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| DATA_POINT_FLAGS_DO_NOT_USE             | 0       | The zero value for the enum. Should not be used for comparisons. Instead use bitwise "and" with the appropriate mask as shown above.                                                     |
+| DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK | 1       | This DataPoint is valid but has no recorded value. This value SHOULD be used to reflect explicitly missing data in a series, as for an equivalent to the Prometheus "staleness marker".  |
+
+
+
+### AggregationTemporality Diagram
+
+```mermaid
+classDiagram
+direction LR
+%% AggregationTemporality defines how a metric aggregator reports aggregated values. It describes how those values relate to the time interval over which they are aggregated.
+
+class AggregationTemporality{
+  <<enumeration>>
+  AGGREGATION_TEMPORALITY_UNSPECIFIED
+  AGGREGATION_TEMPORALITY_DELTA
+  AGGREGATION_TEMPORALITY_CUMULATIVE
+}
+```
+### DataPointFlags Diagram
+
+```mermaid
+classDiagram
+direction LR
+%% DataPointFlags is defined as a protobuf 'uint32' type and is to be used as a bit-field representing 32 distinct boolean flags. Each flag defined in this enum is a bit-mask. To test the presence of a single flag in the flags of a data point, for example, use an expression like: (point.flags & DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK) == DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK
+
+class DataPointFlags{
+  <<enumeration>>
+  DATA_POINT_FLAGS_DO_NOT_USE
+  DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK
+}
+```
+### MetricsData Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% MetricsData represents the metrics data that can be stored in a persistent storage, OR can be embedded by other protocols that transfer OTLP metrics data but do not implement the OTLP protocol. MetricsData └─── ResourceMetrics ├── Resource ├── SchemaURL └── ScopeMetrics ├── Scope ├── SchemaURL └── Metric ├── Name ├── Description ├── Unit └── data ├── Gauge ├── Sum ├── Histogram ├── ExponentialHistogram └── Summary The main difference between this message and collector protocol is that in this message there will not be any "control" or "metadata" specific to OTLP protocol. When new fields are added into this message, the OTLP request MUST be updated as well.
+
+class MetricsData {
+  + List~ResourceMetrics~ resource_metrics
+}
+MetricsData --> `ResourceMetrics`
+
+```
+### ResourceMetrics Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% A collection of ScopeMetrics from a Resource.
+
+class ResourceMetrics {
+  + opentelemetry.proto.resource.v1.Resource resource
+  + List~ScopeMetrics~ scope_metrics
+  + string schema_url
+}
+ResourceMetrics --> `opentelemetry.proto.resource.v1.Resource`
+ResourceMetrics --> `ScopeMetrics`
+
+```
+### ScopeMetrics Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% A collection of Metrics produced by an Scope.
+
+class ScopeMetrics {
+  + opentelemetry.proto.common.v1.InstrumentationScope scope
+  + List~Metric~ metrics
+  + string schema_url
+}
+ScopeMetrics --> `opentelemetry.proto.common.v1.InstrumentationScope`
+ScopeMetrics --> `Metric`
+
+```
+### Metric Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Defines a Metric which has one or more timeseries. The following is a brief summary of the Metric data model. For more details, see: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md The data model and relation between entities is shown in the diagram below. Here, "DataPoint" is the term used to refer to any one of the specific data point value types, and "points" is the term used to refer to any one of the lists of points contained in the Metric. - Metric is composed of a metadata and data. - Metadata part contains a name, description, unit. - Data is one of the possible types (Sum, Gauge, Histogram, Summary). - DataPoint contains timestamps, attributes, and one of the possible value type fields. Metric +------------+ |name | |description | |unit | +------------------------------------+ |data |---> |Gauge, Sum, Histogram, Summary, ... | +------------+ +------------------------------------+ Data [One of Gauge, Sum, Histogram, Summary, ...] +-----------+ |... | // Metadata about the Data. |points |--+ +-----------+ | | +---------------------------+ | |DataPoint 1 | v |+------+------+ +------+ | +-----+ ||label |label |...|label | | | 1 |-->||value1|value2|...|valueN| | +-----+ |+------+------+ +------+ | | . | |+-----+ | | . | ||value| | | . | |+-----+ | | . | +---------------------------+ | . | . | . | . | . | . | . | +---------------------------+ | . | |DataPoint M | +-----+ |+------+------+ +------+ | | M |-->||label |label |...|label | | +-----+ ||value1|value2|...|valueN| | |+------+------+ +------+ | |+-----+ | ||value| | |+-----+ | +---------------------------+ Each distinct type of DataPoint represents the output of a specific aggregation function, the result of applying the DataPoint's associated function of to one or more measurements. All DataPoint types have three common fields: - Attributes includes key-value pairs associated with the data point - TimeUnixNano is required, set to the end time of the aggregation - StartTimeUnixNano is optional, but strongly encouraged for DataPoints having an AggregationTemporality field, as discussed below. Both TimeUnixNano and StartTimeUnixNano values are expressed as UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970. # TimeUnixNano This field is required, having consistent interpretation across DataPoint types. TimeUnixNano is the moment corresponding to when the data point's aggregate value was captured. Data points with the 0 value for TimeUnixNano SHOULD be rejected by consumers. # StartTimeUnixNano StartTimeUnixNano in general allows detecting when a sequence of observations is unbroken. This field indicates to consumers the start time for points with cumulative and delta AggregationTemporality, and it should be included whenever possible to support correct rate calculation. Although it may be omitted when the start time is truly unknown, setting StartTimeUnixNano is strongly encouraged.
+
+class Metric {
+  + string name
+  + string description
+  + string unit
+  + Gauge gauge
+  + Sum sum
+  + Histogram histogram
+  + ExponentialHistogram exponential_histogram
+  + Summary summary
+}
+Metric --> `Gauge`
+Metric --> `Sum`
+Metric --> `Histogram`
+Metric --> `ExponentialHistogram`
+Metric --> `Summary`
+
+```
+### Gauge Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Additional metadata attributes that describe the metric. [Optional]. Attributes are non-identifying. Consumers SHOULD NOT need to be aware of these attributes. These attributes MAY be used to encode information allowing for lossless roundtrip translation to / from another data model. Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key). Gauge represents the type of a scalar metric that always exports the "current value" for every data point. It should be used for an "unknown" aggregation. A Gauge does not support different aggregation temporalities. Given the aggregation is unknown, points cannot be combined using the same aggregation, regardless of aggregation temporalities. Therefore, AggregationTemporality is not included. Consequently, this also means "StartTimeUnixNano" is ignored for all data points.
+
+class Gauge {
+  + List~NumberDataPoint~ data_points
+}
+Gauge --> `NumberDataPoint`
+
+```
+### Sum Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Sum represents the type of a scalar metric that is calculated as a sum of all reported measurements over a time interval.
+
+class Sum {
+  + List~NumberDataPoint~ data_points
+  + AggregationTemporality aggregation_temporality
+  + bool is_monotonic
+}
+Sum --> `NumberDataPoint`
+Sum --> `AggregationTemporality`
+
+```
+### Histogram Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Histogram represents the type of a metric that is calculated by aggregating as a Histogram of all reported measurements over a time interval.
+
+class Histogram {
+  + List~HistogramDataPoint~ data_points
+  + AggregationTemporality aggregation_temporality
+}
+Histogram --> `HistogramDataPoint`
+Histogram --> `AggregationTemporality`
+
+```
+### ExponentialHistogram Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% ExponentialHistogram represents the type of a metric that is calculated by aggregating as a ExponentialHistogram of all reported double measurements over a time interval.
+
+class ExponentialHistogram {
+  + List~ExponentialHistogramDataPoint~ data_points
+  + AggregationTemporality aggregation_temporality
+}
+ExponentialHistogram --> `ExponentialHistogramDataPoint`
+ExponentialHistogram --> `AggregationTemporality`
+
+```
+### Summary Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Summary metric data are used to convey quantile summaries, a Prometheus (see: https://prometheus.io/docs/concepts/metric_types/#summary) and OpenMetrics (see: https://github.com/prometheus/OpenMetrics/blob/4dbf6075567ab43296eed941037c12951faafb92/protos/prometheus.proto#L45) data type. These data points cannot always be merged in a meaningful way. While they can be useful in some applications, histogram data points are recommended for new applications. Summary metrics do not have an aggregation temporality field. This is because the count and sum fields of a SummaryDataPoint are assumed to be cumulative values.
+
+class Summary {
+  + List~SummaryDataPoint~ data_points
+}
+Summary --> `SummaryDataPoint`
+
+```
+### NumberDataPoint Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% NumberDataPoint is a single data point in a timeseries that describes the time-varying scalar value of a metric.
+
+class NumberDataPoint {
+  + fixed64 start_time_unix_nano
+  + fixed64 time_unix_nano
+  + double as_double
+  + sfixed64 as_int
+  + List~opentelemetry.proto.common.v1.KeyValue~ attributes
+}
+NumberDataPoint --> `opentelemetry.proto.common.v1.KeyValue`
+
+```
+### HistogramDataPoint Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% (Optional) List of exemplars collected from measurements that were used to form the data point Flags that apply to this specific data point. See DataPointFlags for the available flags and their meaning. HistogramDataPoint is a single data point in a timeseries that describes the time-varying values of a Histogram. A Histogram contains summary statistics for a population of values, it may optionally contain the distribution of those values across a set of buckets. If the histogram contains the distribution of values, then both "explicit_bounds" and "bucket counts" fields must be defined. If the histogram does not contain the distribution of values, then both "explicit_bounds" and "bucket_counts" must be omitted and only "count" and "sum" are known.
+
+class HistogramDataPoint {
+  + fixed64 start_time_unix_nano
+  + fixed64 time_unix_nano
+  + fixed64 count
+  + Optional~double~ sum
+  + List~fixed64~ bucket_counts
+  + List~double~ explicit_bounds
+  + List~Exemplar~ exemplars
+  + List~opentelemetry.proto.common.v1.KeyValue~ attributes
+  + uint32 flags
+  + Optional~double~ min
+  + Optional~double~ max
+}
+HistogramDataPoint --> `Exemplar`
+HistogramDataPoint --> `opentelemetry.proto.common.v1.KeyValue`
+
+```
+### ExponentialHistogramDataPoint Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% ExponentialHistogramDataPoint is a single data point in a timeseries that describes the time-varying values of a ExponentialHistogram of double values. A ExponentialHistogram contains summary statistics for a population of values, it may optionally contain the distribution of those values across a set of buckets.
+
+class ExponentialHistogramDataPoint {
+  + List~opentelemetry.proto.common.v1.KeyValue~ attributes
+  + fixed64 start_time_unix_nano
+  + fixed64 time_unix_nano
+  + fixed64 count
+  + Optional~double~ sum
+  + sint32 scale
+  + fixed64 zero_count
+  + Buckets positive
+  + Buckets negative
+  + uint32 flags
+  + List~Exemplar~ exemplars
+  + Optional~double~ min
+  + Optional~double~ max
+  + double zero_threshold
+}
+ExponentialHistogramDataPoint --> `opentelemetry.proto.common.v1.KeyValue`
+ExponentialHistogramDataPoint --> `Buckets`
+ExponentialHistogramDataPoint --> `Buckets`
+ExponentialHistogramDataPoint --> `Exemplar`
+ExponentialHistogramDataPoint --o `Buckets`
+
+%% Buckets are a set of bucket counts, encoded in a contiguous array of counts.
+
+class Buckets {
+  + sint32 offset
+  + List~uint64~ bucket_counts
+}
+
+```
+### SummaryDataPoint Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% SummaryDataPoint is a single data point in a timeseries that describes the time-varying values of a Summary metric. The count and sum fields represent cumulative values.
+
+class SummaryDataPoint {
+  + fixed64 start_time_unix_nano
+  + fixed64 time_unix_nano
+  + fixed64 count
+  + double sum
+  + List~ValueAtQuantile~ quantile_values
+  + List~opentelemetry.proto.common.v1.KeyValue~ attributes
+  + uint32 flags
+}
+SummaryDataPoint --> `ValueAtQuantile`
+SummaryDataPoint --> `opentelemetry.proto.common.v1.KeyValue`
+SummaryDataPoint --o `ValueAtQuantile`
+
+%% Represents the value at a given quantile of a distribution. To record Min and Max values following conventions are used: - The 1.0 quantile is equivalent to the maximum value observed. - The 0.0 quantile is equivalent to the minimum value observed. See the following issue for more context: https://github.com/open-telemetry/opentelemetry-proto/issues/125
+
+class ValueAtQuantile {
+  + double quantile
+  + double value
+}
+
+```
+### Exemplar Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% A representation of an exemplar, which is a sample input measurement. Exemplars also hold information about the environment when the measurement was recorded, for example the span and trace ID of the active span when the exemplar was recorded.
+
+class Exemplar {
+  + fixed64 time_unix_nano
+  + double as_double
+  + sfixed64 as_int
+  + List~opentelemetry.proto.common.v1.KeyValue~ filtered_attributes
+}
+Exemplar --> `opentelemetry.proto.common.v1.KeyValue`
+
+```
+
+## Message: MetricsData
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.MetricsData</div>
+
+<div class="comment"><span>MetricsData represents the metrics data that can be stored in a persistent storage, OR can be embedded by other protocols that transfer OTLP metrics data but do not implement the OTLP protocol. MetricsData └─── ResourceMetrics ├── Resource ├── SchemaURL └── ScopeMetrics ├── Scope ├── SchemaURL └── Metric ├── Name ├── Description ├── Unit └── data ├── Gauge ├── Sum ├── Histogram ├── ExponentialHistogram └── Summary The main difference between this message and collector protocol is that in this message there will not be any "control" or "metadata" specific to OTLP protocol. When new fields are added into this message, the OTLP request MUST be updated as well.</span><br/></div>
+
+| Field            | Ordinal | Type            | Label    | Description                                                                                                                                                                                                                                                                                   |
+|------------------|---------|-----------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| resource_metrics | 1       | ResourceMetrics | Repeated | An array of ResourceMetrics. For data coming from a single resource this array will typically contain one element. Intermediary nodes that receive data from multiple origins typically batch the data before forwarding further and in that case this array will contain multiple elements.  |
+
+
+
+
+## Message: ResourceMetrics
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.ResourceMetrics</div>
+
+<div class="comment"><span>A collection of ScopeMetrics from a Resource.</span><br/></div>
+
+| Field         | Ordinal | Type                                     | Label    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+|---------------|---------|------------------------------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| resource      | 1       | opentelemetry.proto.resource.v1.Resource |          | The resource for the metrics in this message. If this field is not set then no resource info is known.                                                                                                                                                                                                                                                                                                                                                                                    |
+| scope_metrics | 2       | ScopeMetrics                             | Repeated | A list of metrics that originate from a resource.                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| schema_url    | 3       | string                                   |          | The Schema URL, if known. This is the identifier of the Schema that the resource data is recorded in. Notably, the last part of the URL path is the version number of the schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see https://opentelemetry.io/docs/specs/otel/schemas/#schema-url This schema_url applies to the data in the "resource" field. It does not apply to the data in the "scope_metrics" field which have their own schema_url field.  |
+
+
+
+
+## Message: ScopeMetrics
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.ScopeMetrics</div>
+
+<div class="comment"><span>A collection of Metrics produced by an Scope.</span><br/></div>
+
+| Field      | Ordinal | Type                                               | Label    | Description                                                                                                                                                                                                                                                                                                                                                                             |
+|------------|---------|----------------------------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| scope      | 1       | opentelemetry.proto.common.v1.InstrumentationScope |          | The instrumentation scope information for the metrics in this message. Semantically when InstrumentationScope isn't set, it is equivalent with an empty instrumentation scope name (unknown).                                                                                                                                                                                           |
+| metrics    | 2       | Metric                                             | Repeated | A list of metrics that originate from an instrumentation library.                                                                                                                                                                                                                                                                                                                       |
+| schema_url | 3       | string                                             |          | The Schema URL, if known. This is the identifier of the Schema that the metric data is recorded in. Notably, the last part of the URL path is the version number of the schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see https://opentelemetry.io/docs/specs/otel/schemas/#schema-url This schema_url applies to all metrics in the "metrics" field.  |
+
+
+
+
+## Message: Metric
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.Metric</div>
+
+<div class="comment"><span>Defines a Metric which has one or more timeseries. The following is a brief summary of the Metric data model. For more details, see: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md The data model and relation between entities is shown in the diagram below. Here, "DataPoint" is the term used to refer to any one of the specific data point value types, and "points" is the term used to refer to any one of the lists of points contained in the Metric. - Metric is composed of a metadata and data. - Metadata part contains a name, description, unit. - Data is one of the possible types (Sum, Gauge, Histogram, Summary). - DataPoint contains timestamps, attributes, and one of the possible value type fields. Metric +------------+ |name | |description | |unit | +------------------------------------+ |data |---> |Gauge, Sum, Histogram, Summary, ... | +------------+ +------------------------------------+ Data [One of Gauge, Sum, Histogram, Summary, ...] +-----------+ |... | // Metadata about the Data. |points |--+ +-----------+ | | +---------------------------+ | |DataPoint 1 | v |+------+------+ +------+ | +-----+ ||label |label |...|label | | | 1 |-->||value1|value2|...|valueN| | +-----+ |+------+------+ +------+ | | . | |+-----+ | | . | ||value| | | . | |+-----+ | | . | +---------------------------+ | . | . | . | . | . | . | . | +---------------------------+ | . | |DataPoint M | +-----+ |+------+------+ +------+ | | M |-->||label |label |...|label | | +-----+ ||value1|value2|...|valueN| | |+------+------+ +------+ | |+-----+ | ||value| | |+-----+ | +---------------------------+ Each distinct type of DataPoint represents the output of a specific aggregation function, the result of applying the DataPoint's associated function of to one or more measurements. All DataPoint types have three common fields: - Attributes includes key-value pairs associated with the data point - TimeUnixNano is required, set to the end time of the aggregation - StartTimeUnixNano is optional, but strongly encouraged for DataPoints having an AggregationTemporality field, as discussed below. Both TimeUnixNano and StartTimeUnixNano values are expressed as UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970. # TimeUnixNano This field is required, having consistent interpretation across DataPoint types. TimeUnixNano is the moment corresponding to when the data point's aggregate value was captured. Data points with the 0 value for TimeUnixNano SHOULD be rejected by consumers. # StartTimeUnixNano StartTimeUnixNano in general allows detecting when a sequence of observations is unbroken. This field indicates to consumers the start time for points with cumulative and delta AggregationTemporality, and it should be included whenever possible to support correct rate calculation. Although it may be omitted when the start time is truly unknown, setting StartTimeUnixNano is strongly encouraged.</span><br/></div>
+
+| Field                 | Ordinal | Type                 | Label | Description                                                                                                                                                                                         |
+|-----------------------|---------|----------------------|-------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name                  | 1       | string               |       | name of the metric.                                                                                                                                                                                 |
+| description           | 2       | string               |       | description of the metric, which can be used in documentation.                                                                                                                                      |
+| unit                  | 3       | string               |       | unit in which the metric value is reported. Follows the format described by https://unitsofmeasure.org/ucum.html.                                                                                   |
+| gauge                 | 5       | Gauge                |       | Data determines the aggregation type (if any) of the metric, what is the reported value type for the data points, as well as the relatationship to the time interval over which they are reported.  |
+| sum                   | 7       | Sum                  |       |                                                                                                                                                                                                     |
+| histogram             | 9       | Histogram            |       |                                                                                                                                                                                                     |
+| exponential_histogram | 10      | ExponentialHistogram |       |                                                                                                                                                                                                     |
+| summary               | 11      | Summary              |       |                                                                                                                                                                                                     |
+
+
+
+
+## Message: Gauge
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.Gauge</div>
+
+<div class="comment"><span>Additional metadata attributes that describe the metric. [Optional]. Attributes are non-identifying. Consumers SHOULD NOT need to be aware of these attributes. These attributes MAY be used to encode information allowing for lossless roundtrip translation to / from another data model. Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key). Gauge represents the type of a scalar metric that always exports the "current value" for every data point. It should be used for an "unknown" aggregation. A Gauge does not support different aggregation temporalities. Given the aggregation is unknown, points cannot be combined using the same aggregation, regardless of aggregation temporalities. Therefore, AggregationTemporality is not included. Consequently, this also means "StartTimeUnixNano" is ignored for all data points.</span><br/></div>
+
+| Field       | Ordinal | Type            | Label    | Description |
+|-------------|---------|-----------------|----------|-------------|
+| data_points | 1       | NumberDataPoint | Repeated |             |
+
+
+
+
+## Message: Sum
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.Sum</div>
+
+<div class="comment"><span>Sum represents the type of a scalar metric that is calculated as a sum of all reported measurements over a time interval.</span><br/></div>
+
+| Field                   | Ordinal | Type                   | Label    | Description                                                                                                                                        |
+|-------------------------|---------|------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| data_points             | 1       | NumberDataPoint        | Repeated |                                                                                                                                                    |
+| aggregation_temporality | 2       | AggregationTemporality |          | aggregation_temporality describes if the aggregator reports delta changes since last report time, or cumulative changes since a fixed start time.  |
+| is_monotonic            | 3       | bool                   |          | If "true" means that the sum is monotonic.                                                                                                         |
+
+
+
+
+## Message: Histogram
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.Histogram</div>
+
+<div class="comment"><span>Histogram represents the type of a metric that is calculated by aggregating as a Histogram of all reported measurements over a time interval.</span><br/></div>
+
+| Field                   | Ordinal | Type                   | Label    | Description                                                                                                                                        |
+|-------------------------|---------|------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| data_points             | 1       | HistogramDataPoint     | Repeated |                                                                                                                                                    |
+| aggregation_temporality | 2       | AggregationTemporality |          | aggregation_temporality describes if the aggregator reports delta changes since last report time, or cumulative changes since a fixed start time.  |
+
+
+
+
+## Message: ExponentialHistogram
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.ExponentialHistogram</div>
+
+<div class="comment"><span>ExponentialHistogram represents the type of a metric that is calculated by aggregating as a ExponentialHistogram of all reported double measurements over a time interval.</span><br/></div>
+
+| Field                   | Ordinal | Type                          | Label    | Description                                                                                                                                        |
+|-------------------------|---------|-------------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| data_points             | 1       | ExponentialHistogramDataPoint | Repeated |                                                                                                                                                    |
+| aggregation_temporality | 2       | AggregationTemporality        |          | aggregation_temporality describes if the aggregator reports delta changes since last report time, or cumulative changes since a fixed start time.  |
+
+
+
+
+## Message: Summary
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.Summary</div>
+
+<div class="comment"><span>Summary metric data are used to convey quantile summaries, a Prometheus (see: https://prometheus.io/docs/concepts/metric_types/#summary) and OpenMetrics (see: https://github.com/prometheus/OpenMetrics/blob/4dbf6075567ab43296eed941037c12951faafb92/protos/prometheus.proto#L45) data type. These data points cannot always be merged in a meaningful way. While they can be useful in some applications, histogram data points are recommended for new applications. Summary metrics do not have an aggregation temporality field. This is because the count and sum fields of a SummaryDataPoint are assumed to be cumulative values.</span><br/></div>
+
+| Field       | Ordinal | Type             | Label    | Description |
+|-------------|---------|------------------|----------|-------------|
+| data_points | 1       | SummaryDataPoint | Repeated |             |
+
+
+
+
+## Message: NumberDataPoint
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.NumberDataPoint</div>
+
+<div class="comment"><span>NumberDataPoint is a single data point in a timeseries that describes the time-varying scalar value of a metric.</span><br/></div>
+
+| Field                | Ordinal | Type                                   | Label    | Description                                                                                                                                                                                                                                           |
+|----------------------|---------|----------------------------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| start_time_unix_nano | 2       | fixed64                                |          | StartTimeUnixNano is optional but strongly encouraged, see the the detailed comments above Metric. Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.                                                                      |
+| time_unix_nano       | 3       | fixed64                                |          | TimeUnixNano is required, see the detailed comments above Metric. Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.                                                                                                       |
+| as_double            | 4       | double                                 |          | The value itself. A point is considered invalid when one of the recognized value fields is not present inside this oneof.                                                                                                                             |
+| as_int               | 6       | sfixed64                               |          |                                                                                                                                                                                                                                                       |
+| attributes           | 7       | opentelemetry.proto.common.v1.KeyValue | Repeated | The set of key/value pairs that uniquely identify the timeseries from where this point belongs. The list may be empty (may contain 0 elements). Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key).  |
+
+
+
+
+## Message: HistogramDataPoint
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.HistogramDataPoint</div>
+
+<div class="comment"><span>(Optional) List of exemplars collected from measurements that were used to form the data point Flags that apply to this specific data point. See DataPointFlags for the available flags and their meaning. HistogramDataPoint is a single data point in a timeseries that describes the time-varying values of a Histogram. A Histogram contains summary statistics for a population of values, it may optionally contain the distribution of those values across a set of buckets. If the histogram contains the distribution of values, then both "explicit_bounds" and "bucket counts" fields must be defined. If the histogram does not contain the distribution of values, then both "explicit_bounds" and "bucket_counts" must be omitted and only "count" and "sum" are known.</span><br/></div>
+
+| Field                | Ordinal | Type                                   | Label    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+|----------------------|---------|----------------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| start_time_unix_nano | 2       | fixed64                                |          | StartTimeUnixNano is optional but strongly encouraged, see the the detailed comments above Metric. Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| time_unix_nano       | 3       | fixed64                                |          | TimeUnixNano is required, see the detailed comments above Metric. Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| count                | 4       | fixed64                                |          | count is the number of values in the population. Must be non-negative. This value must be equal to the sum of the "count" fields in buckets if a histogram is provided.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| sum                  | 5       | double                                 | Optional | sum of the values in the population. If count is zero then this field must be zero. Note: Sum should only be filled out when measuring non-negative discrete events, and is assumed to be monotonic over the values of these events. Negative events *can* be recorded, but sum should not be filled out when doing so. This is specifically to enforce compatibility w/ OpenMetrics, see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram                                                                                                                                                                                                                   |
+| bucket_counts        | 6       | fixed64                                | Repeated | bucket_counts is an optional field contains the count values of histogram for each bucket. The sum of the bucket_counts must equal the value in the count field. The number of elements in bucket_counts array must be by one greater than the number of elements in explicit_bounds array. The exception to this rule is when the length of bucket_counts is 0, then the length of explicit_bounds must also be 0.                                                                                                                                                                                                                                                                                       |
+| explicit_bounds      | 7       | double                                 | Repeated | explicit_bounds specifies buckets with explicitly defined bounds for values. The boundaries for bucket at index i are: (-infinity, explicit_bounds[i]] for i == 0 (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < size(explicit_bounds) (explicit_bounds[i-1], +infinity) for i == size(explicit_bounds) The values in the explicit_bounds array must be strictly increasing. Histogram buckets are inclusive of their upper boundary, except the last bucket where the boundary is at infinity. This format is intentionally compatible with the OpenMetrics histogram definition. If bucket_counts length is 0 then explicit_bounds length must also be 0, otherwise the data point is invalid.  |
+| exemplars            | 8       | Exemplar                               | Repeated | (Optional) List of exemplars collected from measurements that were used to form the data point                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| attributes           | 9       | opentelemetry.proto.common.v1.KeyValue | Repeated | The set of key/value pairs that uniquely identify the timeseries from where this point belongs. The list may be empty (may contain 0 elements). Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key).                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| flags                | 10      | uint32                                 |          | Flags that apply to this specific data point. See DataPointFlags for the available flags and their meaning.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| min                  | 11      | double                                 | Optional | min is the minimum value over (start_time, end_time].                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| max                  | 12      | double                                 | Optional | max is the maximum value over (start_time, end_time].                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+
+
+
+
+## Message: ExponentialHistogramDataPoint
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint</div>
+
+<div class="comment"><span>ExponentialHistogramDataPoint is a single data point in a timeseries that describes the time-varying values of a ExponentialHistogram of double values. A ExponentialHistogram contains summary statistics for a population of values, it may optionally contain the distribution of those values across a set of buckets.</span><br/></div>
+
+| Field                | Ordinal | Type                                   | Label    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+|----------------------|---------|----------------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| attributes           | 1       | opentelemetry.proto.common.v1.KeyValue | Repeated | The set of key/value pairs that uniquely identify the timeseries from where this point belongs. The list may be empty (may contain 0 elements). Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key).                                                                                                                                                                                                                                                                                                                                             |
+| start_time_unix_nano | 2       | fixed64                                |          | StartTimeUnixNano is optional but strongly encouraged, see the the detailed comments above Metric. Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| time_unix_nano       | 3       | fixed64                                |          | TimeUnixNano is required, see the detailed comments above Metric. Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| count                | 4       | fixed64                                |          | count is the number of values in the population. Must be non-negative. This value must be equal to the sum of the "bucket_counts" values in the positive and negative Buckets plus the "zero_count" field.                                                                                                                                                                                                                                                                                                                                                                                       |
+| sum                  | 5       | double                                 | Optional | sum of the values in the population. If count is zero then this field must be zero. Note: Sum should only be filled out when measuring non-negative discrete events, and is assumed to be monotonic over the values of these events. Negative events *can* be recorded, but sum should not be filled out when doing so. This is specifically to enforce compatibility w/ OpenMetrics, see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram                                                                                                          |
+| scale                | 6       | sint32                                 |          | scale describes the resolution of the histogram. Boundaries are located at powers of the base, where: base = (2^(2^-scale)) The histogram bucket identified by `index`, a signed integer, contains values that are greater than (base^index) and less than or equal to (base^(index+1)). The positive and negative ranges of the histogram are expressed separately. Negative values are mapped by their absolute value into the negative range using the same scale as the positive range. scale is not restricted by the protocol, as the permissible values depend on the range of the data.  |
+| zero_count           | 7       | fixed64                                |          | zero_count is the count of values that are either exactly zero or within the region considered zero by the instrumentation at the tolerated degree of precision. This bucket stores values that cannot be expressed using the standard exponential formula as well as values that have been rounded to zero. Implementations MAY consider the zero bucket to have probability mass equal to (zero_count / count).                                                                                                                                                                                |
+| positive             | 8       | Buckets                                |          | positive carries the positive range of exponential bucket counts.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| negative             | 9       | Buckets                                |          | negative carries the negative range of exponential bucket counts.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| flags                | 10      | uint32                                 |          | Flags that apply to this specific data point. See DataPointFlags for the available flags and their meaning.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| exemplars            | 11      | Exemplar                               | Repeated | (Optional) List of exemplars collected from measurements that were used to form the data point                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| min                  | 12      | double                                 | Optional | min is the minimum value over (start_time, end_time].                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| max                  | 13      | double                                 | Optional | max is the maximum value over (start_time, end_time].                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| zero_threshold       | 14      | double                                 |          | ZeroThreshold may be optionally set to convey the width of the zero region. Where the zero region is defined as the closed interval [-ZeroThreshold, ZeroThreshold]. When ZeroThreshold is 0, zero count bucket stores values that cannot be expressed using the standard exponential formula as well as values that have been rounded to zero.                                                                                                                                                                                                                                                  |
+
+
+
+### Buckets Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Buckets are a set of bucket counts, encoded in a contiguous array of counts.
+
+class Buckets {
+  + sint32 offset
+  + List~uint64~ bucket_counts
+}
+
+```
+
+## Message: Buckets
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint.Buckets</div>
+
+<div class="comment"><span>Buckets are a set of bucket counts, encoded in a contiguous array of counts.</span><br/></div>
+
+| Field         | Ordinal | Type   | Label    | Description                                                                                                                                                                                                                                                                                                                                                                                                                      |
+|---------------|---------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| offset        | 1       | sint32 |          | Offset is the bucket index of the first entry in the bucket_counts array. Note: This uses a varint encoding as a simple form of compression.                                                                                                                                                                                                                                                                                     |
+| bucket_counts | 2       | uint64 | Repeated | bucket_counts is an array of count values, where bucket_counts[i] carries the count of the bucket at index (offset+i). bucket_counts[i] is the count of values greater than base^(offset+i) and less than or equal to base^(offset+i+1). Note: By contrast, the explicit HistogramDataPoint uses fixed64. This field is expected to have many buckets, especially zeros, so uint64 has been selected to ensure varint encoding.  |
+
+
+
+
+## Message: SummaryDataPoint
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.SummaryDataPoint</div>
+
+<div class="comment"><span>SummaryDataPoint is a single data point in a timeseries that describes the time-varying values of a Summary metric. The count and sum fields represent cumulative values.</span><br/></div>
+
+| Field                | Ordinal | Type                                   | Label    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+|----------------------|---------|----------------------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| start_time_unix_nano | 2       | fixed64                                |          | StartTimeUnixNano is optional but strongly encouraged, see the the detailed comments above Metric. Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.                                                                                                                                                                                                                                                                                                       |
+| time_unix_nano       | 3       | fixed64                                |          | TimeUnixNano is required, see the detailed comments above Metric. Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.                                                                                                                                                                                                                                                                                                                                        |
+| count                | 4       | fixed64                                |          | count is the number of values in the population. Must be non-negative.                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| sum                  | 5       | double                                 |          | sum of the values in the population. If count is zero then this field must be zero. Note: Sum should only be filled out when measuring non-negative discrete events, and is assumed to be monotonic over the values of these events. Negative events *can* be recorded, but sum should not be filled out when doing so. This is specifically to enforce compatibility w/ OpenMetrics, see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#summary  |
+| quantile_values      | 6       | ValueAtQuantile                        | Repeated | (Optional) list of values at different quantiles of the distribution calculated from the current snapshot. The quantiles must be strictly increasing.                                                                                                                                                                                                                                                                                                                                  |
+| attributes           | 7       | opentelemetry.proto.common.v1.KeyValue | Repeated | The set of key/value pairs that uniquely identify the timeseries from where this point belongs. The list may be empty (may contain 0 elements). Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key).                                                                                                                                                                                                                                   |
+| flags                | 8       | uint32                                 |          | Flags that apply to this specific data point. See DataPointFlags for the available flags and their meaning.                                                                                                                                                                                                                                                                                                                                                                            |
+
+
+
+### ValueAtQuantile Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Represents the value at a given quantile of a distribution. To record Min and Max values following conventions are used: - The 1.0 quantile is equivalent to the maximum value observed. - The 0.0 quantile is equivalent to the minimum value observed. See the following issue for more context: https://github.com/open-telemetry/opentelemetry-proto/issues/125
+
+class ValueAtQuantile {
+  + double quantile
+  + double value
+}
+
+```
+
+## Message: ValueAtQuantile
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.SummaryDataPoint.ValueAtQuantile</div>
+
+<div class="comment"><span>Represents the value at a given quantile of a distribution. To record Min and Max values following conventions are used: - The 1.0 quantile is equivalent to the maximum value observed. - The 0.0 quantile is equivalent to the minimum value observed. See the following issue for more context: https://github.com/open-telemetry/opentelemetry-proto/issues/125</span><br/></div>
+
+| Field    | Ordinal | Type   | Label | Description                                                                               |
+|----------|---------|--------|-------|-------------------------------------------------------------------------------------------|
+| quantile | 1       | double |       | The quantile of a distribution. Must be in the interval [0.0, 1.0].                       |
+| value    | 2       | double |       | The value at the given quantile of a distribution. Quantile values must NOT be negative.  |
+
+
+
+
+## Message: Exemplar
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.metrics.v1.Exemplar</div>
+
+<div class="comment"><span>A representation of an exemplar, which is a sample input measurement. Exemplars also hold information about the environment when the measurement was recorded, for example the span and trace ID of the active span when the exemplar was recorded.</span><br/></div>
+
+| Field               | Ordinal | Type                                   | Label    | Description                                                                                                                                                                                             |
+|---------------------|---------|----------------------------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| time_unix_nano      | 2       | fixed64                                |          | time_unix_nano is the exact time when this exemplar was recorded Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.                                                          |
+| as_double           | 3       | double                                 |          | The value of the measurement that was recorded. An exemplar is considered invalid when one of the recognized value fields is not present inside this oneof.                                             |
+| as_int              | 6       | sfixed64                               |          |                                                                                                                                                                                                         |
+| filtered_attributes | 7       | opentelemetry.proto.common.v1.KeyValue | Repeated | The set of key/value pairs that were filtered out by the aggregator, but recorded alongside the original measurement. Only key/value pairs that were filtered out by the aggregator should be included  |
+
+
+
+
+
+
+<!-- Created by: Proto Diagram Tool -->
+<!-- https://github.com/GoogleCloudPlatform/proto-gen-md-diagrams -->

--- a/docs/generated/metrics_service.proto.md
+++ b/docs/generated/metrics_service.proto.md
@@ -1,0 +1,133 @@
+# Package: opentelemetry.proto.collector.metrics.v1
+
+<div class="comment"><span>Copyright 2019, OpenTelemetry Authors Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</span><br/></div>
+
+## Imports
+
+| Import                                       | Description |
+|----------------------------------------------|-------------|
+| opentelemetry/proto/metrics/v1/metrics.proto |             |
+
+
+
+## Options
+
+| Name                 | Value                                               | Description |
+|----------------------|-----------------------------------------------------|-------------|
+| csharp_namespace     | OpenTelemetry.Proto.Collector.Metrics.V1            |             |
+| java_multiple_files  | true                                                |             |
+| java_package         | io.opentelemetry.proto.collector.metrics.v1         |             |
+| java_outer_classname | MetricsServiceProto                                 |             |
+| go_package           | go.opentelemetry.io/proto/otlp/collector/metrics/v1 |             |
+
+
+
+## Service: MetricsService
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.metrics.v1</div>
+
+<div class="comment"><span>Service that can be used to push metrics between one Application instrumented with OpenTelemetry and a collector, or between a collector and a central collector.</span><br/></div>
+
+### MetricsService Diagram
+
+```mermaid
+classDiagram
+direction LR
+class MetricsService {
+  <<service>>
+  +Export(ExportMetricsServiceRequest) ExportMetricsServiceResponse
+}
+MetricsService --> `ExportMetricsServiceRequest`
+MetricsService --> `ExportMetricsServiceResponse`
+
+```
+
+| Method | Parameter (In)              | Parameter (Out)              | Description                                                                                                |
+|--------|-----------------------------|------------------------------|------------------------------------------------------------------------------------------------------------|
+| Export | ExportMetricsServiceRequest | ExportMetricsServiceResponse | For performance reasons, it is recommended to keep this RPC alive for the entire life of the application.  |
+
+
+
+### ExportMetricsServiceRequest Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% 
+
+class ExportMetricsServiceRequest {
+  + List~opentelemetry.proto.metrics.v1.ResourceMetrics~ resource_metrics
+}
+ExportMetricsServiceRequest --> `opentelemetry.proto.metrics.v1.ResourceMetrics`
+
+```
+### ExportMetricsServiceResponse Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% 
+
+class ExportMetricsServiceResponse {
+  + ExportMetricsPartialSuccess partial_success
+}
+ExportMetricsServiceResponse --> `ExportMetricsPartialSuccess`
+
+```
+### ExportMetricsPartialSuccess Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% 
+
+class ExportMetricsPartialSuccess {
+  + int64 rejected_data_points
+  + string error_message
+}
+
+```
+
+## Message: ExportMetricsServiceRequest
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest</div>
+
+<div class="comment"><span></span><br/></div>
+
+| Field            | Ordinal | Type                                           | Label    | Description                                                                                                                                                                                                                                                                                                                     |
+|------------------|---------|------------------------------------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| resource_metrics | 1       | opentelemetry.proto.metrics.v1.ResourceMetrics | Repeated | An array of ResourceMetrics. For data coming from a single resource this array will typically contain one element. Intermediary nodes (such as OpenTelemetry Collector) that receive data from multiple origins typically batch the data before forwarding further and in that case this array will contain multiple elements.  |
+
+
+
+
+## Message: ExportMetricsServiceResponse
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse</div>
+
+<div class="comment"><span></span><br/></div>
+
+| Field           | Ordinal | Type                        | Label | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+|-----------------|---------|-----------------------------|-------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| partial_success | 1       | ExportMetricsPartialSuccess |       | The details of a partially successful export request. If the request is only partially accepted (i.e. when the server accepts only parts of the data and rejects the rest) the server MUST initialize the `partial_success` field and MUST set the `rejected_<signal>` with the number of items it rejected. Servers MAY also make use of the `partial_success` field to convey warnings/suggestions to senders even when the request was fully accepted. In such cases, the `rejected_<signal>` MUST have a value of `0` and the `error_message` MUST be non-empty. A `partial_success` message with an empty value (rejected_<signal> = 0 and `error_message` = "") is equivalent to it not being set/present. Senders SHOULD interpret it the same way as in the full success case.  |
+
+
+
+
+## Message: ExportMetricsPartialSuccess
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.metrics.v1.ExportMetricsPartialSuccess</div>
+
+<div class="comment"><span></span><br/></div>
+
+| Field                | Ordinal | Type   | Label | Description                                                                                                                                                                                                                                                                                                                                                                                                |
+|----------------------|---------|--------|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rejected_data_points | 1       | int64  |       | The number of rejected data points. A `rejected_<signal>` field holding a `0` value indicates that the request was fully accepted.                                                                                                                                                                                                                                                                         |
+| error_message        | 2       | string |       | A developer-facing human-readable message in English. It should be used either to explain why the server rejected parts of the data during a partial success or to convey warnings/suggestions during a full success. The message should offer guidance on how users can address such issues. error_message is an optional field. An error_message with an empty value is equivalent to it not being set.  |
+
+
+
+
+
+
+<!-- Created by: Proto Diagram Tool -->
+<!-- https://github.com/GoogleCloudPlatform/proto-gen-md-diagrams -->

--- a/docs/generated/profiles.proto.md
+++ b/docs/generated/profiles.proto.md
@@ -1,0 +1,471 @@
+# Package: opentelemetry.proto.profiles.v1development
+
+<div class="comment"><span>Copyright 2023, OpenTelemetry Authors Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. This file includes work covered by the following copyright and permission notices: Copyright 2016 Google Inc. All Rights Reserved. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</span><br/></div>
+
+## Imports
+
+| Import                                         | Description |
+|------------------------------------------------|-------------|
+| opentelemetry/proto/common/v1/common.proto     |             |
+| opentelemetry/proto/resource/v1/resource.proto |             |
+
+
+
+## Options
+
+| Name                 | Value                                                 | Description |
+|----------------------|-------------------------------------------------------|-------------|
+| csharp_namespace     | OpenTelemetry.Proto.Profiles.V1Development            |             |
+| java_multiple_files  | true                                                  |             |
+| java_package         | io.opentelemetry.proto.profiles.v1development         |             |
+| java_outer_classname | ProfilesProto                                         |             |
+| go_package           | go.opentelemetry.io/proto/otlp/profiles/v1development |             |
+
+
+
+## Enum: AggregationTemporality
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.profiles.v1development.AggregationTemporality</div>
+
+<div class="comment"><span>Specifies the method of aggregating metric values, either DELTA (change since last report) or CUMULATIVE (total since a fixed start time).</span><br/></div>
+
+| Name                                | Ordinal | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+|-------------------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| AGGREGATION_TEMPORALITY_UNSPECIFIED | 0       | UNSPECIFIED is the default AggregationTemporality, it MUST not be used.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| AGGREGATION_TEMPORALITY_DELTA       | 1       | * DELTA is an AggregationTemporality for a profiler which reports  changes since last report time. Successive metrics contain aggregation of  values from continuous and non-overlapping intervals.   The values for a DELTA metric are based only on the time interval  associated with one measurement cycle. There is no dependency on  previous measurements like is the case for CUMULATIVE metrics.   For example, consider a system measuring the number of requests that  it receives and reports the sum of these requests every second as a  DELTA metric:   1. The system starts receiving at time=t_0.  2. A request is received, the system measures 1 request.  3. A request is received, the system measures 1 request.  4. A request is received, the system measures 1 request.  5. The 1 second collection cycle ends. A metric is exported for the  number of requests received over the interval of time t_0 to  t_0+1 with a value of 3.  6. A request is received, the system measures 1 request.  7. A request is received, the system measures 1 request.  8. The 1 second collection cycle ends. A metric is exported for the  number of requests received over the interval of time t_0+1 to  t_0+2 with a value of 2.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| AGGREGATION_TEMPORALITY_CUMULATIVE  | 2       | * CUMULATIVE is an AggregationTemporality for a profiler which  reports changes since a fixed start time. This means that current values  of a CUMULATIVE metric depend on all previous measurements since the  start time. Because of this, the sender is required to retain this state  in some form. If this state is lost or invalidated, the CUMULATIVE metric  values MUST be reset and a new fixed start time following the last  reported measurement time sent MUST be used.   For example, consider a system measuring the number of requests that  it receives and reports the sum of these requests every second as a  CUMULATIVE metric:   1. The system starts receiving at time=t_0.  2. A request is received, the system measures 1 request.  3. A request is received, the system measures 1 request.  4. A request is received, the system measures 1 request.  5. The 1 second collection cycle ends. A metric is exported for the  number of requests received over the interval of time t_0 to  t_0+1 with a value of 3.  6. A request is received, the system measures 1 request.  7. A request is received, the system measures 1 request.  8. The 1 second collection cycle ends. A metric is exported for the  number of requests received over the interval of time t_0 to  t_0+2 with a value of 5.  9. The system experiences a fault and loses state.  10. The system recovers and resumes receiving at time=t_1.  11. A request is received, the system measures 1 request.  12. The 1 second collection cycle ends. A metric is exported for the  number of requests received over the interval of time t_1 to  t_1+1 with a value of 1.   Note: Even though, when reporting changes since last report time, using  CUMULATIVE is valid, it is not recommended.  |
+
+
+
+### AggregationTemporality Diagram
+
+```mermaid
+classDiagram
+direction LR
+%% Specifies the method of aggregating metric values, either DELTA (change since last report) or CUMULATIVE (total since a fixed start time).
+
+class AggregationTemporality{
+  <<enumeration>>
+  AGGREGATION_TEMPORALITY_UNSPECIFIED
+  AGGREGATION_TEMPORALITY_DELTA
+  AGGREGATION_TEMPORALITY_CUMULATIVE
+}
+```
+### ProfilesData Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Relationships Diagram ┌──────────────────┐ LEGEND │ ProfilesData │ └──────────────────┘ ─────▶ embedded │ │ 1-n ─────▷ referenced by index ▼ ┌──────────────────┐ │ ResourceProfiles │ └──────────────────┘ │ │ 1-n ▼ ┌──────────────────┐ │ ScopeProfiles │ └──────────────────┘ │ │ 1-1 ▼ ┌──────────────────┐ │ Profile │ └──────────────────┘ │ n-1 │ 1-n ┌───────────────────────────────────────┐ ▼ │ ▽ ┌──────────────────┐ 1-n ┌──────────────┐ ┌──────────┐ │ Sample │ ──────▷ │ KeyValue │ │ Link │ └──────────────────┘ └──────────────┘ └──────────┘ │ 1-n △ △ │ 1-n ┌─────────────────┘ │ 1-n ▽ │ │ ┌──────────────────┐ n-1 ┌──────────────┐ │ Location │ ──────▷ │ Mapping │ └──────────────────┘ └──────────────┘ │ │ 1-n ▼ ┌──────────────────┐ │ Line │ └──────────────────┘ │ │ 1-1 ▽ ┌──────────────────┐ │ Function │ └──────────────────┘ ProfilesData represents the profiles data that can be stored in persistent storage, OR can be embedded by other protocols that transfer OTLP profiles data but do not implement the OTLP protocol. The main difference between this message and collector protocol is that in this message there will not be any "control" or "metadata" specific to OTLP protocol. When new fields are added into this message, the OTLP request MUST be updated as well.
+
+class ProfilesData {
+  + List~ResourceProfiles~ resource_profiles
+}
+ProfilesData --> `ResourceProfiles`
+
+```
+### ResourceProfiles Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% A collection of ScopeProfiles from a Resource.
+
+class ResourceProfiles {
+  + opentelemetry.proto.resource.v1.Resource resource
+  + List~ScopeProfiles~ scope_profiles
+  + string schema_url
+}
+ResourceProfiles --> `opentelemetry.proto.resource.v1.Resource`
+ResourceProfiles --> `ScopeProfiles`
+
+```
+### ScopeProfiles Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% A collection of Profiles produced by an InstrumentationScope.
+
+class ScopeProfiles {
+  + opentelemetry.proto.common.v1.InstrumentationScope scope
+  + List~Profile~ profiles
+  + string schema_url
+}
+ScopeProfiles --> `opentelemetry.proto.common.v1.InstrumentationScope`
+ScopeProfiles --> `Profile`
+
+```
+### Profile Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Profile is a common stacktrace profile format. Measurements represented with this format should follow the following conventions: - Consumers should treat unset optional fields as if they had been set with their default value. - When possible, measurements should be stored in "unsampled" form that is most useful to humans. There should be enough information present to determine the original sampled values. - On-disk, the serialized proto must be gzip-compressed. - The profile is represented as a set of samples, where each sample references a sequence of locations, and where each location belongs to a mapping. - There is a N->1 relationship from sample.location_id entries to locations. For every sample.location_id entry there must be a unique Location with that index. - There is an optional N->1 relationship from locations to mappings. For every nonzero Location.mapping_id there must be a unique Mapping with that index. Represents a complete profile, including sample types, samples, mappings to binaries, locations, functions, string table, and additional metadata. It modifies and annotates pprof Profile with OpenTelemetry specific fields. Note that whilst fields in this message retain the name and field id from pprof in most cases for ease of understanding data migration, it is not intended that pprof:Profile and OpenTelemetry:Profile encoding be wire compatible.
+
+class Profile {
+  + List~ValueType~ sample_type
+  + List~Sample~ sample
+  + List~Mapping~ mapping_table
+  + List~Location~ location_table
+  + List~int32~ location_indices
+  + List~Function~ function_table
+  + List~opentelemetry.proto.common.v1.KeyValue~ attribute_table
+  + List~AttributeUnit~ attribute_units
+  + List~Link~ link_table
+  + List~string~ string_table
+  + int64 time_nanos
+  + int64 duration_nanos
+  + ValueType period_type
+  + int64 period
+  + List~int32~ comment_strindices
+  + int32 default_sample_type_index
+  + bytes profile_id
+  + uint32 dropped_attributes_count
+  + string original_payload_format
+  + bytes original_payload
+}
+Profile --> `ValueType`
+Profile --> `Sample`
+Profile --> `Mapping`
+Profile --> `Location`
+Profile --> `Function`
+Profile --> `opentelemetry.proto.common.v1.KeyValue`
+Profile --> `AttributeUnit`
+Profile --> `Link`
+Profile --> `ValueType`
+
+```
+### AttributeUnit Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Represents a mapping between Attribute Keys and Units.
+
+class AttributeUnit {
+  + int32 attribute_key_strindex
+  + int32 unit_strindex
+}
+
+```
+### Link Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% A pointer from a profile Sample to a trace Span. Connects a profile sample to a trace span, identified by unique trace and span IDs.
+
+class Link {
+  + bytes trace_id
+  + bytes span_id
+}
+
+```
+### ValueType Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% ValueType describes the type and units of a value, with an optional aggregation temporality.
+
+class ValueType {
+  + int32 type_strindex
+  + int32 unit_strindex
+  + AggregationTemporality aggregation_temporality
+}
+ValueType --> `AggregationTemporality`
+
+```
+### Sample Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Each Sample records values encountered in some program context. The program context is typically a stack trace, perhaps augmented with auxiliary information like the thread-id, some indicator of a higher level request being handled etc.
+
+class Sample {
+  + int32 locations_start_index
+  + int32 locations_length
+  + List~int64~ value
+  + List~int32~ attribute_indices
+  + Optional~int32~ link_index
+  + List~uint64~ timestamps_unix_nano
+}
+
+```
+### Mapping Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Describes the mapping of a binary in memory, including its address range, file offset, and metadata like build ID
+
+class Mapping {
+  + uint64 memory_start
+  + uint64 memory_limit
+  + uint64 file_offset
+  + int32 filename_strindex
+  + List~int32~ attribute_indices
+  + bool has_functions
+  + bool has_filenames
+  + bool has_line_numbers
+  + bool has_inline_frames
+}
+
+```
+### Location Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Describes function and line table debug information.
+
+class Location {
+  + Optional~int32~ mapping_index
+  + uint64 address
+  + List~Line~ line
+  + bool is_folded
+  + List~int32~ attribute_indices
+}
+Location --> `Line`
+
+```
+### Line Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Details a specific line in a source code, linked to a function.
+
+class Line {
+  + int32 function_index
+  + int64 line
+  + int64 column
+}
+
+```
+### Function Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Describes a function, including its human-readable name, system name, source file, and starting line number in the source.
+
+class Function {
+  + int32 name_strindex
+  + int32 system_name_strindex
+  + int32 filename_strindex
+  + int64 start_line
+}
+
+```
+
+## Message: ProfilesData
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.profiles.v1development.ProfilesData</div>
+
+<div class="comment"><span>Relationships Diagram ┌──────────────────┐ LEGEND │ ProfilesData │ └──────────────────┘ ─────▶ embedded │ │ 1-n ─────▷ referenced by index ▼ ┌──────────────────┐ │ ResourceProfiles │ └──────────────────┘ │ │ 1-n ▼ ┌──────────────────┐ │ ScopeProfiles │ └──────────────────┘ │ │ 1-1 ▼ ┌──────────────────┐ │ Profile │ └──────────────────┘ │ n-1 │ 1-n ┌───────────────────────────────────────┐ ▼ │ ▽ ┌──────────────────┐ 1-n ┌──────────────┐ ┌──────────┐ │ Sample │ ──────▷ │ KeyValue │ │ Link │ └──────────────────┘ └──────────────┘ └──────────┘ │ 1-n △ △ │ 1-n ┌─────────────────┘ │ 1-n ▽ │ │ ┌──────────────────┐ n-1 ┌──────────────┐ │ Location │ ──────▷ │ Mapping │ └──────────────────┘ └──────────────┘ │ │ 1-n ▼ ┌──────────────────┐ │ Line │ └──────────────────┘ │ │ 1-1 ▽ ┌──────────────────┐ │ Function │ └──────────────────┘ ProfilesData represents the profiles data that can be stored in persistent storage, OR can be embedded by other protocols that transfer OTLP profiles data but do not implement the OTLP protocol. The main difference between this message and collector protocol is that in this message there will not be any "control" or "metadata" specific to OTLP protocol. When new fields are added into this message, the OTLP request MUST be updated as well.</span><br/></div>
+
+| Field             | Ordinal | Type             | Label    | Description                                                                                                                                                                                                                                                                                    |
+|-------------------|---------|------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| resource_profiles | 1       | ResourceProfiles | Repeated | An array of ResourceProfiles. For data coming from a single resource this array will typically contain one element. Intermediary nodes that receive data from multiple origins typically batch the data before forwarding further and in that case this array will contain multiple elements.  |
+
+
+
+
+## Message: ResourceProfiles
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.profiles.v1development.ResourceProfiles</div>
+
+<div class="comment"><span>A collection of ScopeProfiles from a Resource.</span><br/></div>
+
+| Field          | Ordinal | Type                                     | Label    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+|----------------|---------|------------------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| resource       | 1       | opentelemetry.proto.resource.v1.Resource |          | The resource for the profiles in this message. If this field is not set then no resource info is known.                                                                                                                                                                                                                                                                                                                                                                                    |
+| scope_profiles | 2       | ScopeProfiles                            | Repeated | A list of ScopeProfiles that originate from a resource.                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| schema_url     | 3       | string                                   |          | The Schema URL, if known. This is the identifier of the Schema that the resource data is recorded in. Notably, the last part of the URL path is the version number of the schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see https://opentelemetry.io/docs/specs/otel/schemas/#schema-url This schema_url applies to the data in the "resource" field. It does not apply to the data in the "scope_profiles" field which have their own schema_url field.  |
+
+
+
+
+## Message: ScopeProfiles
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.profiles.v1development.ScopeProfiles</div>
+
+<div class="comment"><span>A collection of Profiles produced by an InstrumentationScope.</span><br/></div>
+
+| Field      | Ordinal | Type                                               | Label    | Description                                                                                                                                                                                                                                                                                                                                                                                |
+|------------|---------|----------------------------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| scope      | 1       | opentelemetry.proto.common.v1.InstrumentationScope |          | The instrumentation scope information for the profiles in this message. Semantically when InstrumentationScope isn't set, it is equivalent with an empty instrumentation scope name (unknown).                                                                                                                                                                                             |
+| profiles   | 2       | Profile                                            | Repeated | A list of Profiles that originate from an instrumentation scope.                                                                                                                                                                                                                                                                                                                           |
+| schema_url | 3       | string                                             |          | The Schema URL, if known. This is the identifier of the Schema that the profile data is recorded in. Notably, the last part of the URL path is the version number of the schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see https://opentelemetry.io/docs/specs/otel/schemas/#schema-url This schema_url applies to all profiles in the "profiles" field.  |
+
+
+
+
+## Message: Profile
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.profiles.v1development.Profile</div>
+
+<div class="comment"><span>Profile is a common stacktrace profile format. Measurements represented with this format should follow the following conventions: - Consumers should treat unset optional fields as if they had been set with their default value. - When possible, measurements should be stored in "unsampled" form that is most useful to humans. There should be enough information present to determine the original sampled values. - On-disk, the serialized proto must be gzip-compressed. - The profile is represented as a set of samples, where each sample references a sequence of locations, and where each location belongs to a mapping. - There is a N->1 relationship from sample.location_id entries to locations. For every sample.location_id entry there must be a unique Location with that index. - There is an optional N->1 relationship from locations to mappings. For every nonzero Location.mapping_id there must be a unique Mapping with that index. Represents a complete profile, including sample types, samples, mappings to binaries, locations, functions, string table, and additional metadata. It modifies and annotates pprof Profile with OpenTelemetry specific fields. Note that whilst fields in this message retain the name and field id from pprof in most cases for ease of understanding data migration, it is not intended that pprof:Profile and OpenTelemetry:Profile encoding be wire compatible.</span><br/></div>
+
+| Field                     | Ordinal | Type                                   | Label    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+|---------------------------|---------|----------------------------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| sample_type               | 1       | ValueType                              | Repeated | A description of the samples associated with each Sample.value. For a cpu profile this might be: [["cpu","nanoseconds"]] or [["wall","seconds"]] or [["syscall","count"]] For a heap profile, this might be: [["allocations","count"], ["space","bytes"]], If one of the values represents the number of events represented by the sample, by convention it should be at index 0 and use sample_type.unit == "count".                                                                                                                                                                                               |
+| sample                    | 2       | Sample                                 | Repeated | The set of samples recorded in this profile.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| mapping_table             | 3       | Mapping                                | Repeated | Mapping from address ranges to the image/binary/library mapped into that address range. mapping[0] will be the main binary. If multiple binaries contribute to the Profile and no main binary can be identified, mapping[0] has no special meaning.                                                                                                                                                                                                                                                                                                                                                                 |
+| location_table            | 4       | Location                               | Repeated | Locations referenced by samples via location_indices.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| location_indices          | 5       | int32                                  | Repeated | Array of locations referenced by samples.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| function_table            | 6       | Function                               | Repeated | Functions referenced by locations.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| attribute_table           | 7       | opentelemetry.proto.common.v1.KeyValue | Repeated | Lookup table for attributes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| attribute_units           | 8       | AttributeUnit                          | Repeated | Represents a mapping between Attribute Keys and Units.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| link_table                | 9       | Link                                   | Repeated | Lookup table for links.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| string_table              | 10      | string                                 | Repeated | A common table for strings referenced by various messages. string_table[0] must always be "".                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| time_nanos                | 11      | int64                                  |          | The following fields 9-14 are informational, do not affect interpretation of results. Time of collection (UTC) represented as nanoseconds past the epoch.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| duration_nanos            | 12      | int64                                  |          | Duration of the profile, if a duration makes sense.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| period_type               | 13      | ValueType                              |          | The kind of events between sampled occurrences. e.g [ "cpu","cycles" ] or [ "heap","bytes" ]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| period                    | 14      | int64                                  |          | The number of events between sampled occurrences.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| comment_strindices        | 15      | int32                                  | Repeated | Free-form text associated with the profile. The text is displayed as is to the user by the tools that read profiles (e.g. by pprof). This field should not be used to store any machine-readable information, it is only for human-friendly content. The profile must stay functional if this field is cleaned. Indices into string table.                                                                                                                                                                                                                                                                          |
+| default_sample_type_index | 16      | int32                                  |          | Index into the sample_type array to the default sample type.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| profile_id                | 17      | bytes                                  |          | A globally unique identifier for a profile. The ID is a 16-byte array. An ID with all zeroes is considered invalid. This field is required.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| dropped_attributes_count  | 19      | uint32                                 |          | dropped_attributes_count is the number of attributes that were discarded. Attributes can be discarded because their keys are too long or because there are too many attributes. If this value is 0, then no attributes were dropped.                                                                                                                                                                                                                                                                                                                                                                                |
+| original_payload_format   | 20      | string                                 |          | Specifies format of the original payload. Common values are defined in semantic conventions. [required if original_payload is present]                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| original_payload          | 21      | bytes                                  |          | Original payload can be stored in this field. This can be useful for users who want to get the original payload. Formats such as JFR are highly extensible and can contain more information than what is defined in this spec. Inclusion of original payload should be configurable by the user. Default behavior should be to not include the original payload. If the original payload is in pprof format, it SHOULD not be included in this field. The field is optional, however if it is present then equivalent converted data should be populated in other fields of this message as far as is practicable.  |
+
+
+
+
+## Message: AttributeUnit
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.profiles.v1development.AttributeUnit</div>
+
+<div class="comment"><span>Represents a mapping between Attribute Keys and Units.</span><br/></div>
+
+| Field                  | Ordinal | Type  | Label | Description               |
+|------------------------|---------|-------|-------|---------------------------|
+| attribute_key_strindex | 1       | int32 |       | Index into string table.  |
+| unit_strindex          | 2       | int32 |       | Index into string table.  |
+
+
+
+
+## Message: Link
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.profiles.v1development.Link</div>
+
+<div class="comment"><span>A pointer from a profile Sample to a trace Span. Connects a profile sample to a trace span, identified by unique trace and span IDs.</span><br/></div>
+
+| Field    | Ordinal | Type  | Label | Description                                                                                  |
+|----------|---------|-------|-------|----------------------------------------------------------------------------------------------|
+| trace_id | 1       | bytes |       | A unique identifier of a trace that this linked span is part of. The ID is a 16-byte array.  |
+| span_id  | 2       | bytes |       | A unique identifier for the linked span. The ID is an 8-byte array.                          |
+
+
+
+
+## Message: ValueType
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.profiles.v1development.ValueType</div>
+
+<div class="comment"><span>ValueType describes the type and units of a value, with an optional aggregation temporality.</span><br/></div>
+
+| Field                   | Ordinal | Type                   | Label | Description               |
+|-------------------------|---------|------------------------|-------|---------------------------|
+| type_strindex           | 1       | int32                  |       | Index into string table.  |
+| unit_strindex           | 2       | int32                  |       | Index into string table.  |
+| aggregation_temporality | 3       | AggregationTemporality |       |                           |
+
+
+
+
+## Message: Sample
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.profiles.v1development.Sample</div>
+
+<div class="comment"><span>Each Sample records values encountered in some program context. The program context is typically a stack trace, perhaps augmented with auxiliary information like the thread-id, some indicator of a higher level request being handled etc.</span><br/></div>
+
+| Field                 | Ordinal | Type   | Label    | Description                                                                                                                                                                                                                                                                                                                                        |
+|-----------------------|---------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| locations_start_index | 1       | int32  |          | locations_start_index along with locations_length refers to to a slice of locations in Profile.location_indices.                                                                                                                                                                                                                                   |
+| locations_length      | 2       | int32  |          | locations_length along with locations_start_index refers to a slice of locations in Profile.location_indices. Supersedes location_index.                                                                                                                                                                                                           |
+| value                 | 3       | int64  | Repeated | The type and unit of each value is defined by the corresponding entry in Profile.sample_type. All samples must have the same number of values, the same as the length of Profile.sample_type. When aggregating multiple samples into a single sample, the result has a list of values that is the element-wise sum of the lists of the originals.  |
+| attribute_indices     | 4       | int32  | Repeated | References to attributes in Profile.attribute_table. [optional]                                                                                                                                                                                                                                                                                    |
+| link_index            | 5       | int32  | Optional | Reference to link in Profile.link_table. [optional]                                                                                                                                                                                                                                                                                                |
+| timestamps_unix_nano  | 6       | uint64 | Repeated | Timestamps associated with Sample represented in nanoseconds. These timestamps are expected to fall within the Profile's time range. [optional]                                                                                                                                                                                                    |
+
+
+
+
+## Message: Mapping
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.profiles.v1development.Mapping</div>
+
+<div class="comment"><span>Describes the mapping of a binary in memory, including its address range, file offset, and metadata like build ID</span><br/></div>
+
+| Field             | Ordinal | Type   | Label    | Description                                                                                                                                                                    |
+|-------------------|---------|--------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| memory_start      | 1       | uint64 |          | Address at which the binary (or DLL) is loaded into memory.                                                                                                                    |
+| memory_limit      | 2       | uint64 |          | The limit of the address range occupied by this mapping.                                                                                                                       |
+| file_offset       | 3       | uint64 |          | Offset in the binary that corresponds to the first mapped address.                                                                                                             |
+| filename_strindex | 4       | int32  |          | The object this entry is loaded from. This can be a filename on disk for the main binary and shared libraries, or virtual abstractions like "[vdso]". Index into string table  |
+| attribute_indices | 5       | int32  | Repeated | References to attributes in Profile.attribute_table. [optional]                                                                                                                |
+| has_functions     | 6       | bool   |          | The following fields indicate the resolution of symbolic info.                                                                                                                 |
+| has_filenames     | 7       | bool   |          |                                                                                                                                                                                |
+| has_line_numbers  | 8       | bool   |          |                                                                                                                                                                                |
+| has_inline_frames | 9       | bool   |          |                                                                                                                                                                                |
+
+
+
+
+## Message: Location
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.profiles.v1development.Location</div>
+
+<div class="comment"><span>Describes function and line table debug information.</span><br/></div>
+
+| Field             | Ordinal | Type   | Label    | Description                                                                                                                                                                                                                                                                                                |
+|-------------------|---------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| mapping_index     | 1       | int32  | Optional | Reference to mapping in Profile.mapping_table. It can be unset if the mapping is unknown or not applicable for this profile type.                                                                                                                                                                          |
+| address           | 2       | uint64 |          | The instruction address for this location, if available. It should be within [Mapping.memory_start...Mapping.memory_limit] for the corresponding mapping. A non-leaf address may be in the middle of a call instruction. It is up to display tools to find the beginning of the instruction if necessary.  |
+| line              | 3       | Line   | Repeated | Multiple line indicates this location has inlined functions, where the last entry represents the caller into which the preceding entries were inlined. E.g., if memcpy() is inlined into printf: line[0].function_name == "memcpy" line[1].function_name == "printf"                                       |
+| is_folded         | 4       | bool   |          | Provides an indication that multiple symbols map to this location's address, for example due to identical code folding by the linker. In that case the line information above represents one of the multiple symbols. This field must be recomputed when the symbolization state of the profile changes.   |
+| attribute_indices | 5       | int32  | Repeated | References to attributes in Profile.attribute_table. [optional]                                                                                                                                                                                                                                            |
+
+
+
+
+## Message: Line
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.profiles.v1development.Line</div>
+
+<div class="comment"><span>Details a specific line in a source code, linked to a function.</span><br/></div>
+
+| Field          | Ordinal | Type  | Label | Description                                       |
+|----------------|---------|-------|-------|---------------------------------------------------|
+| function_index | 1       | int32 |       | Reference to function in Profile.function_table.  |
+| line           | 2       | int64 |       | Line number in source code.                       |
+| column         | 3       | int64 |       | Column number in source code.                     |
+
+
+
+
+## Message: Function
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.profiles.v1development.Function</div>
+
+<div class="comment"><span>Describes a function, including its human-readable name, system name, source file, and starting line number in the source.</span><br/></div>
+
+| Field                | Ordinal | Type  | Label | Description                                                                                                             |
+|----------------------|---------|-------|-------|-------------------------------------------------------------------------------------------------------------------------|
+| name_strindex        | 1       | int32 |       | Name of the function, in human-readable form if available. Index into string table                                      |
+| system_name_strindex | 2       | int32 |       | Name of the function, as identified by the system. For instance, it can be a C++ mangled name. Index into string table  |
+| filename_strindex    | 3       | int32 |       | Source file containing the function. Index into string table                                                            |
+| start_line           | 4       | int64 |       | Line number in source file.                                                                                             |
+
+
+
+
+
+
+<!-- Created by: Proto Diagram Tool -->
+<!-- https://github.com/GoogleCloudPlatform/proto-gen-md-diagrams -->

--- a/docs/generated/profiles_service.proto.md
+++ b/docs/generated/profiles_service.proto.md
@@ -1,0 +1,133 @@
+# Package: opentelemetry.proto.collector.profiles.v1development
+
+<div class="comment"><span>Copyright 2023, OpenTelemetry Authors Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</span><br/></div>
+
+## Imports
+
+| Import                                                    | Description |
+|-----------------------------------------------------------|-------------|
+| opentelemetry/proto/profiles/v1development/profiles.proto |             |
+
+
+
+## Options
+
+| Name                 | Value                                                           | Description |
+|----------------------|-----------------------------------------------------------------|-------------|
+| csharp_namespace     | OpenTelemetry.Proto.Collector.Profiles.V1Development            |             |
+| java_multiple_files  | true                                                            |             |
+| java_package         | io.opentelemetry.proto.collector.profiles.v1development         |             |
+| java_outer_classname | ProfilesServiceProto                                            |             |
+| go_package           | go.opentelemetry.io/proto/otlp/collector/profiles/v1development |             |
+
+
+
+## Service: ProfilesService
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.profiles.v1development</div>
+
+<div class="comment"><span>Service that can be used to push profiles between one Application instrumented with OpenTelemetry and a collector, or between a collector and a central collector.</span><br/></div>
+
+### ProfilesService Diagram
+
+```mermaid
+classDiagram
+direction LR
+class ProfilesService {
+  <<service>>
+  +Export(ExportProfilesServiceRequest) ExportProfilesServiceResponse
+}
+ProfilesService --> `ExportProfilesServiceRequest`
+ProfilesService --> `ExportProfilesServiceResponse`
+
+```
+
+| Method | Parameter (In)               | Parameter (Out)               | Description                                                                                                |
+|--------|------------------------------|-------------------------------|------------------------------------------------------------------------------------------------------------|
+| Export | ExportProfilesServiceRequest | ExportProfilesServiceResponse | For performance reasons, it is recommended to keep this RPC alive for the entire life of the application.  |
+
+
+
+### ExportProfilesServiceRequest Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% 
+
+class ExportProfilesServiceRequest {
+  + List~opentelemetry.proto.profiles.v1development.ResourceProfiles~ resource_profiles
+}
+ExportProfilesServiceRequest --> `opentelemetry.proto.profiles.v1development.ResourceProfiles`
+
+```
+### ExportProfilesServiceResponse Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% 
+
+class ExportProfilesServiceResponse {
+  + ExportProfilesPartialSuccess partial_success
+}
+ExportProfilesServiceResponse --> `ExportProfilesPartialSuccess`
+
+```
+### ExportProfilesPartialSuccess Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% 
+
+class ExportProfilesPartialSuccess {
+  + int64 rejected_profiles
+  + string error_message
+}
+
+```
+
+## Message: ExportProfilesServiceRequest
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.profiles.v1development.ExportProfilesServiceRequest</div>
+
+<div class="comment"><span></span><br/></div>
+
+| Field             | Ordinal | Type                                                        | Label    | Description                                                                                                                                                                                                                                                                                                                      |
+|-------------------|---------|-------------------------------------------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| resource_profiles | 1       | opentelemetry.proto.profiles.v1development.ResourceProfiles | Repeated | An array of ResourceProfiles. For data coming from a single resource this array will typically contain one element. Intermediary nodes (such as OpenTelemetry Collector) that receive data from multiple origins typically batch the data before forwarding further and in that case this array will contain multiple elements.  |
+
+
+
+
+## Message: ExportProfilesServiceResponse
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.profiles.v1development.ExportProfilesServiceResponse</div>
+
+<div class="comment"><span></span><br/></div>
+
+| Field           | Ordinal | Type                         | Label | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+|-----------------|---------|------------------------------|-------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| partial_success | 1       | ExportProfilesPartialSuccess |       | The details of a partially successful export request. If the request is only partially accepted (i.e. when the server accepts only parts of the data and rejects the rest) the server MUST initialize the `partial_success` field and MUST set the `rejected_<signal>` with the number of items it rejected. Servers MAY also make use of the `partial_success` field to convey warnings/suggestions to senders even when the request was fully accepted. In such cases, the `rejected_<signal>` MUST have a value of `0` and the `error_message` MUST be non-empty. A `partial_success` message with an empty value (rejected_<signal> = 0 and `error_message` = "") is equivalent to it not being set/present. Senders SHOULD interpret it the same way as in the full success case.  |
+
+
+
+
+## Message: ExportProfilesPartialSuccess
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.profiles.v1development.ExportProfilesPartialSuccess</div>
+
+<div class="comment"><span></span><br/></div>
+
+| Field             | Ordinal | Type   | Label | Description                                                                                                                                                                                                                                                                                                                                                                                                |
+|-------------------|---------|--------|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rejected_profiles | 1       | int64  |       | The number of rejected profiles. A `rejected_<signal>` field holding a `0` value indicates that the request was fully accepted.                                                                                                                                                                                                                                                                            |
+| error_message     | 2       | string |       | A developer-facing human-readable message in English. It should be used either to explain why the server rejected parts of the data during a partial success or to convey warnings/suggestions during a full success. The message should offer guidance on how users can address such issues. error_message is an optional field. An error_message with an empty value is equivalent to it not being set.  |
+
+
+
+
+
+
+<!-- Created by: Proto Diagram Tool -->
+<!-- https://github.com/GoogleCloudPlatform/proto-gen-md-diagrams -->

--- a/docs/generated/resource.proto.md
+++ b/docs/generated/resource.proto.md
@@ -1,0 +1,58 @@
+# Package: opentelemetry.proto.resource.v1
+
+<div class="comment"><span>Copyright 2019, OpenTelemetry Authors Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</span><br/></div>
+
+## Imports
+
+| Import                                     | Description |
+|--------------------------------------------|-------------|
+| opentelemetry/proto/common/v1/common.proto |             |
+
+
+
+## Options
+
+| Name                 | Value                                      | Description |
+|----------------------|--------------------------------------------|-------------|
+| csharp_namespace     | OpenTelemetry.Proto.Resource.V1            |             |
+| java_multiple_files  | true                                       |             |
+| java_package         | io.opentelemetry.proto.resource.v1         |             |
+| java_outer_classname | ResourceProto                              |             |
+| go_package           | go.opentelemetry.io/proto/otlp/resource/v1 |             |
+
+
+
+
+### Resource Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Resource information.
+
+class Resource {
+  + List~opentelemetry.proto.common.v1.KeyValue~ attributes
+  + uint32 dropped_attributes_count
+}
+Resource --> `opentelemetry.proto.common.v1.KeyValue`
+
+```
+
+## Message: Resource
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.resource.v1.Resource</div>
+
+<div class="comment"><span>Resource information.</span><br/></div>
+
+| Field                    | Ordinal | Type                                   | Label    | Description                                                                                                                                         |
+|--------------------------|---------|----------------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| attributes               | 1       | opentelemetry.proto.common.v1.KeyValue | Repeated | Set of attributes that describe the resource. Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key).  |
+| dropped_attributes_count | 2       | uint32                                 |          | dropped_attributes_count is the number of dropped attributes. If the value is 0, then no attributes were dropped.                                   |
+
+
+
+
+
+
+<!-- Created by: Proto Diagram Tool -->
+<!-- https://github.com/GoogleCloudPlatform/proto-gen-md-diagrams -->

--- a/docs/generated/trace.proto.md
+++ b/docs/generated/trace.proto.md
@@ -1,0 +1,401 @@
+# Package: opentelemetry.proto.trace.v1
+
+<div class="comment"><span>Copyright 2019, OpenTelemetry Authors Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</span><br/></div>
+
+## Imports
+
+| Import                                         | Description |
+|------------------------------------------------|-------------|
+| opentelemetry/proto/common/v1/common.proto     |             |
+| opentelemetry/proto/resource/v1/resource.proto |             |
+
+
+
+## Options
+
+| Name                 | Value                                   | Description |
+|----------------------|-----------------------------------------|-------------|
+| csharp_namespace     | OpenTelemetry.Proto.Trace.V1            |             |
+| java_multiple_files  | true                                    |             |
+| java_package         | io.opentelemetry.proto.trace.v1         |             |
+| java_outer_classname | TraceProto                              |             |
+| go_package           | go.opentelemetry.io/proto/otlp/trace/v1 |             |
+
+
+
+## Enum: SpanFlags
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.trace.v1.SpanFlags</div>
+
+<div class="comment"><span>SpanFlags represents constants used to interpret the Span.flags field, which is protobuf 'fixed32' type and is to be used as bit-fields. Each non-zero value defined in this enum is a bit-mask. To extract the bit-field, for example, use an expression like: (span.flags & SPAN_FLAGS_TRACE_FLAGS_MASK) See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions. Note that Span flags were introduced in version 1.1 of the OpenTelemetry protocol. Older Span producers do not set this field, consequently consumers should not rely on the absence of a particular flag bit to indicate the presence of a particular feature.</span><br/></div>
+
+| Name                                  | Ordinal | Description                                                                                                                                                                                                     |
+|---------------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SPAN_FLAGS_DO_NOT_USE                 | 0       | The zero value for the enum. Should not be used for comparisons. Instead use bitwise "and" with the appropriate mask as shown above.                                                                            |
+| SPAN_FLAGS_TRACE_FLAGS_MASK           | 0       | Bits 0-7 are used for trace flags.                                                                                                                                                                              |
+| SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK | 0       | Bits 8 and 9 are used to indicate that the parent span or link span is remote. Bit 8 (`HAS_IS_REMOTE`) indicates whether the value is known. Bit 9 (`IS_REMOTE`) indicates whether the span or link is remote.  |
+| SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK     | 0       |                                                                                                                                                                                                                 |
+
+
+
+### SpanFlags Diagram
+
+```mermaid
+classDiagram
+direction LR
+%% SpanFlags represents constants used to interpret the Span.flags field, which is protobuf 'fixed32' type and is to be used as bit-fields. Each non-zero value defined in this enum is a bit-mask. To extract the bit-field, for example, use an expression like: (span.flags & SPAN_FLAGS_TRACE_FLAGS_MASK) See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions. Note that Span flags were introduced in version 1.1 of the OpenTelemetry protocol. Older Span producers do not set this field, consequently consumers should not rely on the absence of a particular flag bit to indicate the presence of a particular feature.
+
+class SpanFlags{
+  <<enumeration>>
+  SPAN_FLAGS_DO_NOT_USE
+  SPAN_FLAGS_TRACE_FLAGS_MASK
+  SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK
+  SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK
+}
+```
+### TracesData Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% TracesData represents the traces data that can be stored in a persistent storage, OR can be embedded by other protocols that transfer OTLP traces data but do not implement the OTLP protocol. The main difference between this message and collector protocol is that in this message there will not be any "control" or "metadata" specific to OTLP protocol. When new fields are added into this message, the OTLP request MUST be updated as well.
+
+class TracesData {
+  + List~ResourceSpans~ resource_spans
+}
+TracesData --> `ResourceSpans`
+
+```
+### ResourceSpans Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% A collection of ScopeSpans from a Resource.
+
+class ResourceSpans {
+  + opentelemetry.proto.resource.v1.Resource resource
+  + List~ScopeSpans~ scope_spans
+  + string schema_url
+}
+ResourceSpans --> `opentelemetry.proto.resource.v1.Resource`
+ResourceSpans --> `ScopeSpans`
+
+```
+### ScopeSpans Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% A collection of Spans produced by an InstrumentationScope.
+
+class ScopeSpans {
+  + opentelemetry.proto.common.v1.InstrumentationScope scope
+  + List~Span~ spans
+  + string schema_url
+}
+ScopeSpans --> `opentelemetry.proto.common.v1.InstrumentationScope`
+ScopeSpans --> `Span`
+
+```
+### Span Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% A Span represents a single operation performed by a single component of the system. The next available field id is 17.
+
+class Span {
+  + bytes trace_id
+  + bytes span_id
+  + string trace_state
+  + bytes parent_span_id
+  + string name
+  + SpanKind kind
+  + fixed64 start_time_unix_nano
+  + fixed64 end_time_unix_nano
+  + uint32 dropped_attributes_count
+  + List~Event~ events
+  + uint32 dropped_events_count
+  + List~Link~ links
+  + uint32 dropped_links_count
+  + Status status
+  + fixed32 flags
+}
+Span --> `SpanKind`
+Span --> `Event`
+Span --> `Link`
+Span --> `Status`
+Span --o `Event`
+
+%% Event is a time-stamped annotation of the span, consisting of user-supplied text description and key-value pairs.
+
+class Event {
+  + fixed64 time_unix_nano
+  + string name
+  + List~opentelemetry.proto.common.v1.KeyValue~ attributes
+  + uint32 dropped_attributes_count
+}
+Event --> `opentelemetry.proto.common.v1.KeyValue`
+Span --o `Link`
+
+%% A pointer from the current span to another span in the same trace or in a different trace. For example, this can be used in batching operations, where a single batch handler processes multiple requests from different traces or when the handler receives a request from a different project.
+
+class Link {
+  + bytes trace_id
+  + bytes span_id
+  + string trace_state
+  + List~opentelemetry.proto.common.v1.KeyValue~ attributes
+  + uint32 dropped_attributes_count
+  + fixed32 flags
+}
+Link --> `opentelemetry.proto.common.v1.KeyValue`
+Span --o `SpanKind`
+%% SpanKind is the type of span. Can be used to specify additional relationships between spans in addition to a parent/child relationship.
+
+class SpanKind{
+  <<enumeration>>
+  SPAN_KIND_UNSPECIFIED
+  SPAN_KIND_INTERNAL
+  SPAN_KIND_SERVER
+  SPAN_KIND_CLIENT
+  SPAN_KIND_PRODUCER
+  SPAN_KIND_CONSUMER
+}
+```
+### SpanKind Diagram
+
+```mermaid
+classDiagram
+direction LR
+%% SpanKind is the type of span. Can be used to specify additional relationships between spans in addition to a parent/child relationship.
+
+class SpanKind{
+  <<enumeration>>
+  SPAN_KIND_UNSPECIFIED
+  SPAN_KIND_INTERNAL
+  SPAN_KIND_SERVER
+  SPAN_KIND_CLIENT
+  SPAN_KIND_PRODUCER
+  SPAN_KIND_CONSUMER
+}
+```
+### Status Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% The Status type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs.
+
+class Status {
+  + string message
+  + StatusCode code
+}
+Status --> `StatusCode`
+Status --o `StatusCode`
+%% For the semantics of status codes see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
+
+class StatusCode{
+  <<enumeration>>
+  STATUS_CODE_UNSET
+  STATUS_CODE_OK
+  STATUS_CODE_ERROR
+}
+```
+### StatusCode Diagram
+
+```mermaid
+classDiagram
+direction LR
+%% For the semantics of status codes see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
+
+class StatusCode{
+  <<enumeration>>
+  STATUS_CODE_UNSET
+  STATUS_CODE_OK
+  STATUS_CODE_ERROR
+}
+```
+
+## Message: TracesData
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.trace.v1.TracesData</div>
+
+<div class="comment"><span>TracesData represents the traces data that can be stored in a persistent storage, OR can be embedded by other protocols that transfer OTLP traces data but do not implement the OTLP protocol. The main difference between this message and collector protocol is that in this message there will not be any "control" or "metadata" specific to OTLP protocol. When new fields are added into this message, the OTLP request MUST be updated as well.</span><br/></div>
+
+| Field          | Ordinal | Type          | Label    | Description                                                                                                                                                                                                                                                                                 |
+|----------------|---------|---------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| resource_spans | 1       | ResourceSpans | Repeated | An array of ResourceSpans. For data coming from a single resource this array will typically contain one element. Intermediary nodes that receive data from multiple origins typically batch the data before forwarding further and in that case this array will contain multiple elements.  |
+
+
+
+
+## Message: ResourceSpans
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.trace.v1.ResourceSpans</div>
+
+<div class="comment"><span>A collection of ScopeSpans from a Resource.</span><br/></div>
+
+| Field       | Ordinal | Type                                     | Label    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+|-------------|---------|------------------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| resource    | 1       | opentelemetry.proto.resource.v1.Resource |          | The resource for the spans in this message. If this field is not set then no resource info is known.                                                                                                                                                                                                                                                                                                                                                                                    |
+| scope_spans | 2       | ScopeSpans                               | Repeated | A list of ScopeSpans that originate from a resource.                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| schema_url  | 3       | string                                   |          | The Schema URL, if known. This is the identifier of the Schema that the resource data is recorded in. Notably, the last part of the URL path is the version number of the schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see https://opentelemetry.io/docs/specs/otel/schemas/#schema-url This schema_url applies to the data in the "resource" field. It does not apply to the data in the "scope_spans" field which have their own schema_url field.  |
+
+
+
+
+## Message: ScopeSpans
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.trace.v1.ScopeSpans</div>
+
+<div class="comment"><span>A collection of Spans produced by an InstrumentationScope.</span><br/></div>
+
+| Field      | Ordinal | Type                                               | Label    | Description                                                                                                                                                                                                                                                                                                                                                                                       |
+|------------|---------|----------------------------------------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| scope      | 1       | opentelemetry.proto.common.v1.InstrumentationScope |          | The instrumentation scope information for the spans in this message. Semantically when InstrumentationScope isn't set, it is equivalent with an empty instrumentation scope name (unknown).                                                                                                                                                                                                       |
+| spans      | 2       | Span                                               | Repeated | A list of Spans that originate from an instrumentation scope.                                                                                                                                                                                                                                                                                                                                     |
+| schema_url | 3       | string                                             |          | The Schema URL, if known. This is the identifier of the Schema that the span data is recorded in. Notably, the last part of the URL path is the version number of the schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see https://opentelemetry.io/docs/specs/otel/schemas/#schema-url This schema_url applies to all spans and span events in the "spans" field.  |
+
+
+
+
+## Message: Span
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.trace.v1.Span</div>
+
+<div class="comment"><span>A Span represents a single operation performed by a single component of the system. The next available field id is 17.</span><br/></div>
+
+| Field                    | Ordinal | Type     | Label    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|--------------------------|---------|----------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| trace_id                 | 1       | bytes    |          | A unique identifier for a trace. All spans from the same trace share the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR of length other than 16 bytes is considered invalid (empty string in OTLP/JSON is zero-length and thus is also invalid). This field is required.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| span_id                  | 2       | bytes    |          | A unique identifier for a span within a trace, assigned when the span is created. The ID is an 8-byte array. An ID with all zeroes OR of length other than 8 bytes is considered invalid (empty string in OTLP/JSON is zero-length and thus is also invalid). This field is required.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| trace_state              | 3       | string   |          | trace_state conveys information about request position in multiple distributed tracing graphs. It is a trace_state in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header See also https://github.com/w3c/distributed-tracing for more details about this field.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| parent_span_id           | 4       | bytes    |          | The `span_id` of this span's parent span. If this is a root span, then this field must be empty. The ID is an 8-byte array.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| name                     | 5       | string   |          | A description of the span's operation. For example, the name can be a qualified method name or a file name and a line number where the operation is called. A best practice is to use the same display name at the same call point in an application. This makes it easier to correlate spans in different traces. This field is semantically required to be set to non-empty string. Empty value is equivalent to an unknown span name. This field is required.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| kind                     | 6       | SpanKind |          | Distinguishes between spans generated in a particular context. For example, two spans with the same name may be distinguished using `CLIENT` (caller) and `SERVER` (callee) to identify queueing latency associated with the span.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| start_time_unix_nano     | 7       | fixed64  |          | start_time_unix_nano is the start time of the span. On the client side, this is the time kept by the local machine where the span execution starts. On the server side, this is the time when the server's application handler starts running. Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970. This field is semantically required and it is expected that end_time >= start_time.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| end_time_unix_nano       | 8       | fixed64  |          | end_time_unix_nano is the end time of the span. On the client side, this is the time kept by the local machine where the span execution ends. On the server side, this is the time when the server application handler stops running. Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970. This field is semantically required and it is expected that end_time >= start_time.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| dropped_attributes_count | 10      | uint32   |          | attributes is a collection of key/value pairs. Note, global attributes like server name can be set using the resource API. Examples of attributes: "/http/user_agent": "Mozilla/5.0 (Macintosh; dropped_attributes_count is the number of attributes that were discarded. Attributes can be discarded because their keys are too long or because there are too many attributes. If this value is 0, then no attributes were dropped.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| events                   | 11      | Event    | Repeated | events is a collection of Event items.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| dropped_events_count     | 12      | uint32   |          | dropped_events_count is the number of dropped events. If the value is 0, then no events were dropped.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| links                    | 13      | Link     | Repeated | links is a collection of Links, which are references from this span to a span in the same or different trace.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| dropped_links_count      | 14      | uint32   |          | dropped_links_count is the number of dropped links after the maximum size was enforced. If this value is 0, then no links were dropped.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| status                   | 15      | Status   |          | An optional final status for this span. Semantically when Status isn't set, it means span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| flags                    | 16      | fixed32  |          | Flags, a bit field. Bits 0-7 (8 least significant bits) are the trace flags as defined in W3C Trace Context specification. To read the 8-bit W3C trace flag, use `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`. See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions. Bits 8 and 9 represent the 3 states of whether a span's parent is remote. The states are (unknown, is not remote, is remote). To read whether the value is known, use `(flags & SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK) != 0`. To read whether the span is remote, use `(flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK) != 0`. When creating span messages, if the message is logically forwarded from another source with an equivalent flags fields (i.e., usually another OTLP span message), the field SHOULD be copied as-is. If creating from a source that does not have an equivalent flags field (such as a runtime representation of an OpenTelemetry span), the high 22 bits MUST be set to zero. Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero. [Optional].  |
+
+
+## Enum: SpanKind
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.trace.v1.Span.SpanKind</div>
+
+<div class="comment"><span>SpanKind is the type of span. Can be used to specify additional relationships between spans in addition to a parent/child relationship.</span><br/></div>
+
+| Name                  | Ordinal | Description                                                                                                                                                                                                                                                                                                                                         |
+|-----------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SPAN_KIND_UNSPECIFIED | 0       | Unspecified. Do NOT use as default. Implementations MAY assume SpanKind to be INTERNAL when receiving UNSPECIFIED.                                                                                                                                                                                                                                  |
+| SPAN_KIND_INTERNAL    | 1       | Indicates that the span represents an internal operation within an application, as opposed to an operation happening at the boundaries. Default value.                                                                                                                                                                                              |
+| SPAN_KIND_SERVER      | 2       | Indicates that the span covers server-side handling of an RPC or other remote network request.                                                                                                                                                                                                                                                      |
+| SPAN_KIND_CLIENT      | 3       | Indicates that the span describes a request to some remote service.                                                                                                                                                                                                                                                                                 |
+| SPAN_KIND_PRODUCER    | 4       | Indicates that the span describes a producer sending a message to a broker. Unlike CLIENT and SERVER, there is often no direct critical path latency relationship between producer and consumer spans. A PRODUCER span ends when the message was accepted by the broker while the logical processing of the message might span a much longer time.  |
+| SPAN_KIND_CONSUMER    | 5       | Indicates that the span describes consumer receiving a message from a broker. Like the PRODUCER kind, there is often no direct critical path latency relationship between producer and consumer spans.                                                                                                                                              |
+
+
+
+### Event Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% Event is a time-stamped annotation of the span, consisting of user-supplied text description and key-value pairs.
+
+class Event {
+  + fixed64 time_unix_nano
+  + string name
+  + List~opentelemetry.proto.common.v1.KeyValue~ attributes
+  + uint32 dropped_attributes_count
+}
+Event --> `opentelemetry.proto.common.v1.KeyValue`
+
+```
+### Link Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% A pointer from the current span to another span in the same trace or in a different trace. For example, this can be used in batching operations, where a single batch handler processes multiple requests from different traces or when the handler receives a request from a different project.
+
+class Link {
+  + bytes trace_id
+  + bytes span_id
+  + string trace_state
+  + List~opentelemetry.proto.common.v1.KeyValue~ attributes
+  + uint32 dropped_attributes_count
+  + fixed32 flags
+}
+Link --> `opentelemetry.proto.common.v1.KeyValue`
+
+```
+
+## Message: Event
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.trace.v1.Span.Event</div>
+
+<div class="comment"><span>Event is a time-stamped annotation of the span, consisting of user-supplied text description and key-value pairs.</span><br/></div>
+
+| Field                    | Ordinal | Type                                   | Label    | Description                                                                                                                                                                 |
+|--------------------------|---------|----------------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| time_unix_nano           | 1       | fixed64                                |          | time_unix_nano is the time the event occurred.                                                                                                                              |
+| name                     | 2       | string                                 |          | name of the event. This field is semantically required to be set to non-empty string.                                                                                       |
+| attributes               | 3       | opentelemetry.proto.common.v1.KeyValue | Repeated | attributes is a collection of attribute key/value pairs on the event. Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key).  |
+| dropped_attributes_count | 4       | uint32                                 |          | dropped_attributes_count is the number of dropped attributes. If the value is 0, then no attributes were dropped.                                                           |
+
+
+
+
+## Message: Link
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.trace.v1.Span.Link</div>
+
+<div class="comment"><span>A pointer from the current span to another span in the same trace or in a different trace. For example, this can be used in batching operations, where a single batch handler processes multiple requests from different traces or when the handler receives a request from a different project.</span><br/></div>
+
+| Field                    | Ordinal | Type                                   | Label    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+|--------------------------|---------|----------------------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| trace_id                 | 1       | bytes                                  |          | A unique identifier of a trace that this linked span is part of. The ID is a 16-byte array.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| span_id                  | 2       | bytes                                  |          | A unique identifier for the linked span. The ID is an 8-byte array.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| trace_state              | 3       | string                                 |          | The trace_state associated with the link.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| attributes               | 4       | opentelemetry.proto.common.v1.KeyValue | Repeated | attributes is a collection of attribute key/value pairs on the link. Attribute keys MUST be unique (it is not allowed to have more than one attribute with the same key).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| dropped_attributes_count | 5       | uint32                                 |          | dropped_attributes_count is the number of dropped attributes. If the value is 0, then no attributes were dropped.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| flags                    | 6       | fixed32                                |          | Flags, a bit field. Bits 0-7 (8 least significant bits) are the trace flags as defined in W3C Trace Context specification. To read the 8-bit W3C trace flag, use `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`. See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions. Bits 8 and 9 represent the 3 states of whether the link is remote. The states are (unknown, is not remote, is remote). To read whether the value is known, use `(flags & SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK) != 0`. To read whether the link is remote, use `(flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK) != 0`. Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero. When creating new spans, bits 10-31 (most-significant 22-bits) MUST be zero. [Optional].  |
+
+
+
+
+## Message: Status
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.trace.v1.Status</div>
+
+<div class="comment"><span>The Status type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs.</span><br/></div>
+
+| Field   | Ordinal | Type       | Label | Description                                       |
+|---------|---------|------------|-------|---------------------------------------------------|
+| message | 2       | string     |       | A developer-facing human readable error message.  |
+| code    | 3       | StatusCode |       | The status code.                                  |
+
+
+## Enum: StatusCode
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.trace.v1.Status.StatusCode</div>
+
+<div class="comment"><span>For the semantics of status codes see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status</span><br/></div>
+
+| Name              | Ordinal | Description                                                                                          |
+|-------------------|---------|------------------------------------------------------------------------------------------------------|
+| STATUS_CODE_UNSET | 0       | The default status.                                                                                  |
+| STATUS_CODE_OK    | 1       | The Span has been validated by an Application developer or Operator to have completed successfully.  |
+| STATUS_CODE_ERROR | 2       | The Span contains an error.                                                                          |
+
+
+
+
+
+
+<!-- Created by: Proto Diagram Tool -->
+<!-- https://github.com/GoogleCloudPlatform/proto-gen-md-diagrams -->

--- a/docs/generated/trace_service.proto.md
+++ b/docs/generated/trace_service.proto.md
@@ -1,0 +1,133 @@
+# Package: opentelemetry.proto.collector.trace.v1
+
+<div class="comment"><span>Copyright 2019, OpenTelemetry Authors Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</span><br/></div>
+
+## Imports
+
+| Import                                   | Description |
+|------------------------------------------|-------------|
+| opentelemetry/proto/trace/v1/trace.proto |             |
+
+
+
+## Options
+
+| Name                 | Value                                             | Description |
+|----------------------|---------------------------------------------------|-------------|
+| csharp_namespace     | OpenTelemetry.Proto.Collector.Trace.V1            |             |
+| java_multiple_files  | true                                              |             |
+| java_package         | io.opentelemetry.proto.collector.trace.v1         |             |
+| java_outer_classname | TraceServiceProto                                 |             |
+| go_package           | go.opentelemetry.io/proto/otlp/collector/trace/v1 |             |
+
+
+
+## Service: TraceService
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.trace.v1</div>
+
+<div class="comment"><span>Service that can be used to push spans between one Application instrumented with OpenTelemetry and a collector, or between a collector and a central collector (in this case spans are sent/received to/from multiple Applications).</span><br/></div>
+
+### TraceService Diagram
+
+```mermaid
+classDiagram
+direction LR
+class TraceService {
+  <<service>>
+  +Export(ExportTraceServiceRequest) ExportTraceServiceResponse
+}
+TraceService --> `ExportTraceServiceRequest`
+TraceService --> `ExportTraceServiceResponse`
+
+```
+
+| Method | Parameter (In)            | Parameter (Out)            | Description                                                                                                |
+|--------|---------------------------|----------------------------|------------------------------------------------------------------------------------------------------------|
+| Export | ExportTraceServiceRequest | ExportTraceServiceResponse | For performance reasons, it is recommended to keep this RPC alive for the entire life of the application.  |
+
+
+
+### ExportTraceServiceRequest Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% 
+
+class ExportTraceServiceRequest {
+  + List~opentelemetry.proto.trace.v1.ResourceSpans~ resource_spans
+}
+ExportTraceServiceRequest --> `opentelemetry.proto.trace.v1.ResourceSpans`
+
+```
+### ExportTraceServiceResponse Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% 
+
+class ExportTraceServiceResponse {
+  + ExportTracePartialSuccess partial_success
+}
+ExportTraceServiceResponse --> `ExportTracePartialSuccess`
+
+```
+### ExportTracePartialSuccess Diagram
+
+```mermaid
+classDiagram
+direction LR
+
+%% 
+
+class ExportTracePartialSuccess {
+  + int64 rejected_spans
+  + string error_message
+}
+
+```
+
+## Message: ExportTraceServiceRequest
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest</div>
+
+<div class="comment"><span></span><br/></div>
+
+| Field          | Ordinal | Type                                       | Label    | Description                                                                                                                                                                                                                                                                                                                   |
+|----------------|---------|--------------------------------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| resource_spans | 1       | opentelemetry.proto.trace.v1.ResourceSpans | Repeated | An array of ResourceSpans. For data coming from a single resource this array will typically contain one element. Intermediary nodes (such as OpenTelemetry Collector) that receive data from multiple origins typically batch the data before forwarding further and in that case this array will contain multiple elements.  |
+
+
+
+
+## Message: ExportTraceServiceResponse
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse</div>
+
+<div class="comment"><span></span><br/></div>
+
+| Field           | Ordinal | Type                      | Label | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+|-----------------|---------|---------------------------|-------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| partial_success | 1       | ExportTracePartialSuccess |       | The details of a partially successful export request. If the request is only partially accepted (i.e. when the server accepts only parts of the data and rejects the rest) the server MUST initialize the `partial_success` field and MUST set the `rejected_<signal>` with the number of items it rejected. Servers MAY also make use of the `partial_success` field to convey warnings/suggestions to senders even when the request was fully accepted. In such cases, the `rejected_<signal>` MUST have a value of `0` and the `error_message` MUST be non-empty. A `partial_success` message with an empty value (rejected_<signal> = 0 and `error_message` = "") is equivalent to it not being set/present. Senders SHOULD interpret it the same way as in the full success case.  |
+
+
+
+
+## Message: ExportTracePartialSuccess
+<div style="font-size: 12px; margin-top: -10px;" class="fqn">FQN: opentelemetry.proto.collector.trace.v1.ExportTracePartialSuccess</div>
+
+<div class="comment"><span></span><br/></div>
+
+| Field          | Ordinal | Type   | Label | Description                                                                                                                                                                                                                                                                                                                                                                                                |
+|----------------|---------|--------|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rejected_spans | 1       | int64  |       | The number of rejected spans. A `rejected_<signal>` field holding a `0` value indicates that the request was fully accepted.                                                                                                                                                                                                                                                                               |
+| error_message  | 2       | string |       | A developer-facing human-readable message in English. It should be used either to explain why the server rejected parts of the data during a partial success or to convey warnings/suggestions during a full success. The message should offer guidance on how users can address such issues. error_message is an optional field. An error_message with an empty value is equivalent to it not being set.  |
+
+
+
+
+
+
+<!-- Created by: Proto Diagram Tool -->
+<!-- https://github.com/GoogleCloudPlatform/proto-gen-md-diagrams -->


### PR DESCRIPTION
These were generated by [proto-gen-md-diagrams](https://github.com/GoogleCloudPlatform/proto-gen-md-diagrams).

This is not meant to be merged as-is, since I just generated these in the root directory, but if people find them useful maybe the diagrams could be added to the docs.