### PR TITLE
Remove comment on each service about keeping the RPC alive

### DIFF
--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -28,8 +28,6 @@ option go_package = "go.opentelemetry.io/proto/otlp/collector/logs/v1";
 // OpenTelemetry and an collector, or between an collector and a central collector (in this
 // case logs are sent/received to/from multiple Applications).
 service LogsService {
-  // For performance reasons, it is recommended to keep this RPC
-  // alive for the entire life of the application.
   rpc Export(ExportLogsServiceRequest) returns (ExportLogsServiceResponse) {}
 }
 

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -28,8 +28,6 @@ option go_package = "go.opentelemetry.io/proto/otlp/collector/metrics/v1";
 // instrumented with OpenTelemetry and a collector, or between a collector and a
 // central collector.
 service MetricsService {
-  // For performance reasons, it is recommended to keep this RPC
-  // alive for the entire life of the application.
   rpc Export(ExportMetricsServiceRequest) returns (ExportMetricsServiceResponse) {}
 }
 

--- a/opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
+++ b/opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
@@ -27,8 +27,6 @@ option go_package = "go.opentelemetry.io/proto/otlp/collector/profiles/v1develop
 // Service that can be used to push profiles between one Application instrumented with
 // OpenTelemetry and a collector, or between a collector and a central collector.
 service ProfilesService {
-  // For performance reasons, it is recommended to keep this RPC
-  // alive for the entire life of the application.
   rpc Export(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
 }
 

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -28,8 +28,6 @@ option go_package = "go.opentelemetry.io/proto/otlp/collector/trace/v1";
 // OpenTelemetry and a collector, or between a collector and a central collector (in this
 // case spans are sent/received to/from multiple Applications).
 service TraceService {
-  // For performance reasons, it is recommended to keep this RPC
-  // alive for the entire life of the application.
   rpc Export(ExportTraceServiceRequest) returns (ExportTraceServiceResponse) {}
 }
 


### PR DESCRIPTION
Tigran explained this comment was likely a hold over from the OpenCensus protobufs which did use streaming RPC's. Unary RPC's, which are used by the OpenTelemetry protocol, can not be kept alive making the comment out of place.