### PR TITLE
Stabilize event_name in LogRecord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The full list of changes can be found in the compare view for the respective rel
 
 ### Changed
 
+- logs: Stabilize `event_name` field in `LogRecord` message. [#643](https://github.com/open-telemetry/opentelemetry-proto/pull/643)
+
 ### Removed
 
 ## 1.5.0 - 2024-12-12

--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -221,7 +221,5 @@ message LogRecord {
   // as an event.
   //
   // [Optional].
-  //
-  // Status: [Development]
   string event_name = 12;
 }


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-specification/issues/4459

Stabilize `event_name` in `LogRecord` that was introduced in https://github.com/open-telemetry/opentelemetry-proto/pull/600.

See also: https://github.com/open-telemetry/opentelemetry-specification/pull/4475