### PR TITLE
Profiles: simplify profile stack trace representation

### DIFF
--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -99,7 +99,7 @@ message ProfilesDictionary {
   // so that _index fields can use 0 to indicate null/unset.
   repeated Mapping mapping_table = 1;
 
-  // Locations referenced by samples via Profile.location_indices.
+  // Locations referenced by samples via Stack.location_indices.
   repeated Location location_table = 2;
 
   // Functions referenced by locations via Line.function_index.
@@ -119,6 +119,9 @@ message ProfilesDictionary {
 
   // Represents a mapping between Attribute Keys and Units.
   repeated AttributeUnit attribute_units = 7;
+
+  // Stacks referenced by samples via Sample.stack_index.
+  repeated Stack stack_table = 8;
 }
 
 // ProfilesData represents the profiles data that can be stored in persistent storage,
@@ -201,18 +204,19 @@ message ScopeProfiles {
 //   information present to determine the original sampled values.
 //
 // - The profile is represented as a set of samples, where each sample
-//   references a sequence of locations, and where each location belongs
+//   references a stack trace which is a list of locations, each belonging
 //   to a mapping.
-// - There is a N->1 relationship from sample.location_id entries to
-//   locations. For every sample.location_id entry there must be a
+// - There is a N->1 relationship from Stack.location_indices entries to
+//   locations. For every Stack.location_indices entry there must be a
 //   unique Location with that index.
 // - There is an optional N->1 relationship from locations to
 //   mappings. For every nonzero Location.mapping_id there must be a
 //   unique Mapping with that index.
 
-// Represents a complete profile, including sample types, samples,
-// mappings to binaries, locations, functions, string table, and additional metadata.
-// It modifies and annotates pprof Profile with OpenTelemetry specific fields.
+// Represents a complete profile, including sample types, samples, mappings to
+// binaries, stacks, locations, functions, string table, and additional
+// metadata. It modifies and annotates pprof Profile with OpenTelemetry
+// specific fields.
 //
 // Note that whilst fields in this message retain the name and field id from pprof in most cases
 // for ease of understanding data migration, it is not intended that pprof:Profile and
@@ -227,27 +231,24 @@ message Profile {
   // The set of samples recorded in this profile.
   repeated Sample sample = 2;
 
-  // References to locations in ProfilesDictionary.location_table.
-  repeated int32 location_indices = 3;
-
-  // The following fields 4-14 are informational, do not affect
+  // The following fields 3-13 are informational, do not affect
   // interpretation of results.
 
   // Time of collection (UTC) represented as nanoseconds past the epoch.
-  int64 time_nanos = 4;
+  int64 time_nanos = 3;
   // Duration of the profile, if a duration makes sense.
-  int64 duration_nanos = 5;
+  int64 duration_nanos = 4;
   // The kind of events between sampled occurrences.
   // e.g [ "cpu","cycles" ] or [ "heap","bytes" ]
-  ValueType period_type = 6;
+  ValueType period_type = 5;
   // The number of events between sampled occurrences.
-  int64 period = 7;
+  int64 period = 6;
   // Free-form text associated with the profile. The text is displayed as is
   // to the user by the tools that read profiles (e.g. by pprof). This field
   // should not be used to store any machine-readable information, it is only
   // for human-friendly content. The profile must stay functional if this field
   // is cleaned.
-  repeated int32 comment_strindices = 8; // Indices into ProfilesDictionary.string_table.
+  repeated int32 comment_strindices = 7; // Indices into ProfilesDictionary.string_table.
 
   // A globally unique identifier for a profile. The ID is a 16-byte array. An ID with
   // all zeroes is considered invalid. It may be used for deduplication and signal
@@ -255,15 +256,15 @@ message Profile {
   // in this field as not equal, even if they represented the same object at an earlier
   // time.
   // This field is optional; an ID may be assigned to an ID-less profile in a later step.
-  bytes profile_id = 9;
+  bytes profile_id = 8;
 
   // dropped_attributes_count is the number of attributes that were discarded. Attributes
   // can be discarded because their keys are too long or because there are too many
   // attributes. If this value is 0, then no attributes were dropped.
-  uint32 dropped_attributes_count = 10;
+  uint32 dropped_attributes_count = 9;
 
   // Specifies format of the original payload. Common values are defined in semantic conventions. [required if original_payload is present]
-  string original_payload_format = 11;
+  string original_payload_format = 10;
 
   // Original payload can be stored in this field. This can be useful for users who want to get the original payload.
   // Formats such as JFR are highly extensible and can contain more information than what is defined in this spec.
@@ -271,7 +272,7 @@ message Profile {
   // If the original payload is in pprof format, it SHOULD not be included in this field.
   // The field is optional, however if it is present then equivalent converted data should be populated in other fields
   // of this message as far as is practicable.
-  bytes original_payload = 12;
+  bytes original_payload = 11;
 
   // References to attributes in attribute_table. [optional]
   // It is a collection of key/value pairs. Note, global attributes
@@ -286,7 +287,7 @@ message Profile {
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  repeated int32 attribute_indices = 13;
+  repeated int32 attribute_indices = 12;
 }
 
 // Represents a mapping between Attribute Keys and Units.
@@ -407,23 +408,20 @@ message ValueType {
 //    values: [2, 2, 3, 3]
 //    timestamps_unix_nano: [1, 2, 3, 4]
 message Sample {
-  // locations_start_index along with locations_length refers to to a slice of locations in Profile.location_indices.
-  int32 locations_start_index = 1;
-  // locations_length along with locations_start_index refers to a slice of locations in Profile.location_indices.
-  // Supersedes location_index.
-  int32 locations_length = 2;
+  // Reference to stack in ProfilesDictionary.stack_table.
+  int32 stack_index = 1;
   // The type and unit of each value is defined by Profile.sample_type.
-  repeated int64 values = 3;
+  repeated int64 values = 2;
   // References to attributes in ProfilesDictionary.attribute_table. [optional]
-  repeated int32 attribute_indices = 4;
+  repeated int32 attribute_indices = 3;
 
   // Reference to link in ProfilesDictionary.link_table. [optional]
   // It can be unset / set to 0 if no link exists, as link_table[0] is always a 'null' default value.
-  int32 link_index = 5;
+  int32 link_index = 4;
 
   // Timestamps associated with Sample represented in nanoseconds. These
   // timestamps should fall within the Profile's time range.
-  repeated uint64 timestamps_unix_nano = 6;
+  repeated uint64 timestamps_unix_nano = 5;
 }
 
 // Describes the mapping of a binary in memory, including its address range,
@@ -446,6 +444,13 @@ message Mapping {
   bool has_filenames = 7;
   bool has_line_numbers = 8;
   bool has_inline_frames = 9;
+}
+
+// A Stack represents a stack trace as a list of locations. The first location
+// is the leaf frame.
+message Stack {
+  // References to locations in ProfilesDictionary.location_table.
+  repeated int32 location_indices = 1;
 }
 
 // Describes function and line table debug information.


### PR DESCRIPTION
## Changes

- Introduce a first-class Stack message type and lookup table.
- Replace location index range based stack trace encoding on Sample with a single stack_index reference.
- Remove the location_indices lookup table.

## Motivation

**tl;dr:** Let's KISS. The stack trace encoding proposed in this PR is competitive with more advanced stack trace encoding formats, but much simpler to implement. See table below or @christos68k's [benchmark for details](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/524).

|              | Uncompressed | vs Dedup | Compressed | vs Dedup |
| ------------ | ------------ | -------- | ---------- | -------- |
| ExportDedup (current)  | 688709       | 0.0%    | 277955     | 0.0%    |
| ExportStacks (this PR) | 703704       | 2.8%    | 277713     | \-0.1%  |
| ExportArrays ([PR #651][array-encoding proposal]) | 602920       | \-12.5% | 305235     | 9.8%    |

The current stack trace encoding is somewhat complex as it tries to optimize for CPU profiling stack traces where it's relatively common to see prefixes of a stack trace.

For example, a program that looks like this ...

```a.go
func a() { b() }
func b() { c() }

func c() {
	for {
		d()
		e()
	}
}
```

... will produce a CPU profile with stack traces like the ones shown below. The number indicate samples taken at different locations (program counters) within the same function:

```
a;b;c;d1
a;b;c;d2
a;b;c;d3
...
a;b;c;e1
a;b;c;e2
a;b;c;e3
...
a;b;c
```

This makes it attractive to optimize away the prefix repetition (`a;b;c`) in the stack trace dictionary table. But the current format doesn't quite succeed in this, as it would only allow us to get rid of the last stack trace in the table. This probably explains why it doesn't end up performing very differently from the encoding proposed in this PR.

The alternative [double array proposal][array-encoding proposal] from @aalexand achieves over 12% reduction in profile size before compression, because it can exploit this pattern effectively. However, for some reason the resulting data patterns end up being much harder to compress, and the encoding loses by almost 10% after compression has been applied.

Last but not least, not all profiling data will benefit from prefix-encoding as much as CPU profiles. For example memory allocations and especially Off-CPU stack traces have significantly less prefix repetition. We don't have a good benchmark for this, but I hope this argument is easy to follow regardless.

Given the above, I'm proposing to chose the most trivial stack trace encoding format as outlined in this PR as it seems to hit a sweet spot between complexity and efficiency. The main tasks for reviewers is to validate benchmarks from @christos68k's and confirm if they're okay with this direction.

It seems like we had rough consensus around this change in previous SIG meetings.

[array-encoding proposal]: https://github.com/open-telemetry/opentelemetry-proto/pull/651
[timestamp proposal]: https://github.com/open-telemetry/opentelemetry-proto/pull/594
[off-cpu pr]: https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/196
[benchmarks]: https://docs.google.com/spreadsheets/d/1Q-6MlegV8xLYdz5WD5iPxQU2tsfodX1-CDV1WeGzyQ0/edit?gid=2069300294#gid=2069300294