### PR TITLE
Prepare for release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The full list of changes can be found in the compare view for the respective rel
 ### Changed
 
 - logs: Stabilize `event_name` field in `LogRecord` message. [#643](https://github.com/open-telemetry/opentelemetry-proto/pull/643)
-- profiles: Move the lookup tables to ProfilesData. [#644](https://github.com/open-telemetry/opentelemetry-proto/pull/64)
+- profiles: Move the lookup tables to ProfilesData. [#644](https://github.com/open-telemetry/opentelemetry-proto/pull/644)
 - profiles: Move default sample_type from the string table to sample_type. [#620](https://github.com/open-telemetry/opentelemetry-proto/pull/620)
 
 ## 1.5.0 - 2024-12-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,17 @@
 
 The full list of changes can be found in the compare view for the respective release at <https://github.com/open-telemetry/opentelemetry-proto/releases>.
 
+## 1.6.0 - 2025-04-28
+
 ### Added
+
+- resource: Add EntityRef. [#635](https://github.com/open-telemetry/opentelemetry-proto/pull/635)
 
 ### Changed
 
 - logs: Stabilize `event_name` field in `LogRecord` message. [#643](https://github.com/open-telemetry/opentelemetry-proto/pull/643)
-
-### Removed
+- profiles: Move the lookup tables to ProfilesData. [#644](https://github.com/open-telemetry/opentelemetry-proto/pull/64)
+- profiles: Move default sample_type from the string table to sample_type. [#620](https://github.com/open-telemetry/opentelemetry-proto/pull/620)
 
 ## 1.5.0 - 2024-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 The full list of changes can be found in the compare view for the respective release at <https://github.com/open-telemetry/opentelemetry-proto/releases>.
 
-## 1.6.0 - 2025-04-28
+## 1.6.0 - 2025-04-29
 
 ### Added
 


### PR DESCRIPTION
1.5.0 was cut several months ago, last december.
https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.5.0

There have been several important changes that would be nice to be able to use in the proto definitions (and since we know profiles will have at least one other breaking change, it'd be nice not to have them pile up).
Hence this PR to release 1.6.0.

Note: I am opening this PR, but can't actually do the release. So whoever merges would have to publish the new release.