### PR TITLE
Prepare for release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 The full list of changes can be found in the compare view for the respective release at <https://github.com/open-telemetry/opentelemetry-proto/releases>.
 
+## 1.7.0 - 2025-05-19
+
+### Added
+
+- profiles: introduce Dictionary message in ProfilesData, and move the lookup tables into it. [#650](https://github.com/open-telemetry/opentelemetry-proto/pull/650)
+
 ## 1.6.0 - 2025-04-29
 
 ### Added


### PR DESCRIPTION
1.6.0 makes profiles unusable, as the lookup tables can't be retrieved anymore. So I think we should release 1.7.0 now.