### PR TITLE
fix: OTLP JSON Event example body

### DIFF
--- a/examples/events.json
+++ b/examples/events.json
@@ -1,75 +1,77 @@
 {
-    "resourceLogs": [
-      {
-        "resource": {
-          "attributes": [
-            {
-              "key": "service.name",
-              "value": {
-                "stringValue": "my.service"
-              }
-            }
-          ]
-        },
-        "scopeLogs": [
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
           {
-            "scope": {
-              "name": "my.library",
-              "version": "1.0.0",
-              "attributes": [
-                {
-                  "key": "my.scope.attribute",
-                  "value": {
-                    "stringValue": "some scope attribute"
-                  }
-                }
-              ]
-            },
-            "logRecords": [
+            "key": "service.name",
+            "value": {
+              "stringValue": "my.service"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {
+            "name": "my.library",
+            "version": "1.0.0",
+            "attributes": [
               {
-                "timeUnixNano": "1544712660300000000",
-                "observedTimeUnixNano": "1544712660300000000",
-                "severityNumber": 9,
-                "attributes": [
-                    {
-                      "key": "event.name",
-                      "value": {
-                        "stringValue": "browser.page_view"
-                      }
-                    }
-                ],  
-                "body": {
-                    "kvlistValue": [
-                        {
-                            "key": "type",
-                            "value": {
-                            "intValue": "0"
-                            }
-                        },
-                        {
-                            "key": "url",
-                            "value": {
-                            "stringValue": "https://www.guidgenerator.com/online-guid-generator.aspx"
-                            }
-                        },
-                        {
-                            "key": "referrer",
-                            "value": {
-                            "stringValue": "https://wwww.google.com"
-                            }
-                        },
-                        {
-                            "key": "title",
-                            "value": {
-                            "stringValue": "Free Online GUID Generator"
-                            }
-                        }
-                    ]
+                "key": "my.scope.attribute",
+                "value": {
+                  "stringValue": "some scope attribute"
                 }
               }
             ]
-          }
-        ]
-      }
-    ]
-  }
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1544712660300000000",
+              "observedTimeUnixNano": "1544712660300000000",
+              "severityNumber": 9,
+              "attributes": [
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "browser.page_view"
+                  }
+                }
+              ],
+              "body": {
+                "kvlistValue": {
+                  "values": [
+                    {
+                      "key": "type",
+                      "value": {
+                        "intValue": "0"
+                      }
+                    },
+                    {
+                      "key": "url",
+                      "value": {
+                        "stringValue": "https://www.guidgenerator.com/online-guid-generator.aspx"
+                      }
+                    },
+                    {
+                      "key": "referrer",
+                      "value": {
+                        "stringValue": "https://wwww.google.com"
+                      }
+                    },
+                    {
+                      "key": "title",
+                      "value": {
+                        "stringValue": "Free Online GUID Generator"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/events.json
+++ b/examples/events.json
@@ -27,14 +27,16 @@
           },
           "logRecords": [
             {
+              "eventName": "browser.page_view",
               "timeUnixNano": "1544712660300000000",
               "observedTimeUnixNano": "1544712660300000000",
               "severityNumber": 9,
+              "severityText": "test severity text",
               "attributes": [
                 {
-                  "key": "event.name",
+                  "key": "event.attribute",
                   "value": {
-                    "stringValue": "browser.page_view"
+                    "stringValue": "some event attribute"
                   }
                 }
               ],


### PR DESCRIPTION
### What
* fix `events.json` example by wrapping `kvlistValue` content in a `values` property
* fix indentation

###  Why
Following the [example README](https://github.com/open-telemetry/opentelemetry-proto/blob/main/examples/README.md) and running

```
$ curl -X POST -H "Content-Type: application/json" -d @events.json -i localhost:4318/v1/logs
```

results in

```
HTTP/1.1 400 Bad Request
Content-Type: application/json
Vary: Origin
Date: Sat, 31 May 2025 13:29:10 GMT
Content-Length: 253

{"code":3,"message":"ReadObjectCB: expect { or n, but found [, error found in #10 byte of ...|tValue\": [          |..., bigger context ...|         \"body\": {                \"kvlistValue\": [                  {                    \"key\": \"typ|..."}%
```

Seems like the [kvlistValue(KeyValueList)](https://pkg.go.dev/go.opentelemetry.io/proto/otlp/common/v1#KeyValueList) values need to be wrapped in a `values` property.

After fixing the example the request response and collector output seem fine:
```
HTTP/1.1 200 OK
Content-Type: application/json
Vary: Origin
Date: Sat, 31 May 2025 12:31:00 GMT
Content-Length: 21

{"partialSuccess":{}}
```

collector output:
```
collector-otel-collector-1  | 2025-05-31T13:29:24.995Z  info    Logs    {"resource": {}, "otelcol.component.id": "debug", "otelcol.component.kind": "exporter", "otelcol.signal": "logs", "resource logs": 1, "log records": 1}
collector-otel-collector-1  | 2025-05-31T13:29:24.996Z  info    ResourceLog #0
collector-otel-collector-1  | Resource SchemaURL:
collector-otel-collector-1  | Resource attributes:
collector-otel-collector-1  |      -> service.name: Str(my.service)
collector-otel-collector-1  | ScopeLogs #0
collector-otel-collector-1  | ScopeLogs SchemaURL:
collector-otel-collector-1  | InstrumentationScope my.library 1.0.0
collector-otel-collector-1  | InstrumentationScope attributes:
collector-otel-collector-1  |      -> my.scope.attribute: Str(some scope attribute)
collector-otel-collector-1  | LogRecord #0
collector-otel-collector-1  | ObservedTimestamp: 2018-12-13 14:51:00.3 +0000 UTC
collector-otel-collector-1  | Timestamp: 2018-12-13 14:51:00.3 +0000 UTC
collector-otel-collector-1  | SeverityText:
collector-otel-collector-1  | SeverityNumber: Info(9)
collector-otel-collector-1  | Body: Map({"referrer":"https://wwww.google.com","title":"Free Online GUID Generator","type":0,"url":"https://www.guidgenerator.com/online-guid-generator.aspx"})
collector-otel-collector-1  | Attributes:
collector-otel-collector-1  |      -> event.name: Str(browser.page_view)
collector-otel-collector-1  | Trace ID:
collector-otel-collector-1  | Span ID:
collector-otel-collector-1  | Flags: 0
collector-otel-collector-1  |   {"resource": {}, "otelcol.component.id": "debug", "otelcol.component.kind": "exporter", "otelcol.signal": "logs"}
```

Tested using docker image `otel/opentelemetry-collector-contrib:0.127.0`