### PR TITLE
profiles: improve attribute encoding in ProfilesDictionary

### DIFF
--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -115,10 +115,7 @@ message ProfilesDictionary {
   repeated string string_table = 5;
 
   // A common table for attributes referenced by various messages.
-  repeated opentelemetry.proto.common.v1.KeyValue attribute_table = 6;
-
-  // Represents a mapping between Attribute Keys and Units.
-  repeated AttributeUnit attribute_units = 7;
+  repeated KeyValueAndUnit attribute_table = 6;
 }
 
 // ProfilesData represents the profiles data that can be stored in persistent storage,
@@ -501,4 +498,13 @@ message Function {
   int32 filename_strindex = 3;
   // Line number in source file. 0 means unset.
   int64 start_line = 4;
+}
+
+// A custom 'dictionary native' style of encoding attributes which is more specialized
+// for our use than opentelemetry.proto.common.v1.KeyValue
+// Specifically, uses the string table for keys and allows optional unit information.
+message KeyValueAndUnit {
+  int32 key_strindex  = 1;
+  opentelemetry.proto.common.v1.AnyValue value = 2;
+  int32 unit_strindex = 3; // non-zero where the unit cannot be derived from the name by semconv.
 }

--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -93,15 +93,10 @@ option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1development";
 // ProfilesDictionary represents the profiles data shared across the
 // entire message being sent.
 message ProfilesDictionary {
-
-  // Note all fields in this message MUST have a zero value encoded as the first element.
-  // This allows for _index fields pointing into the dictionary to use a 0 pointer value to indicate 'null' / 'not set'
-  // without requiring 'optional' encoding, which would be less compact.
-  // Unless otherwise defined, a 'zero value' message value is one with all default field values,
-  // so as to minimize wire encoded size.
-
   // Mappings from address ranges to the image/binary/library mapped
   // into that address range referenced by locations via Location.mapping_index.
+  // mapping_table[0] must always be set to a zero value default mapping,
+  // so that _index fields can use 0 to indicate null/unset.
   repeated Mapping mapping_table = 1;
 
   // Locations referenced by samples via Profile.location_indices.
@@ -111,6 +106,8 @@ message ProfilesDictionary {
   repeated Function function_table = 3;
 
   // Links referenced by samples via Sample.link_index.
+  // link_table[0] must always be set to a zero value default link,
+  // so that _index fields can use 0 to indicate null/unset.
   repeated Link link_table = 4;
 
   // A common table for strings referenced by various messages.

--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -93,10 +93,15 @@ option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1development";
 // ProfilesDictionary represents the profiles data shared across the
 // entire message being sent.
 message ProfilesDictionary {
+
+  // Note all fields in this message MUST have a zero value encoded as the first element.
+  // This allows for _index fields pointing into the dictionary to use a 0 pointer value to indicate 'null' / 'not set'
+  // without requiring 'optional' encoding, which would be less compact.
+  // Unless otherwise defined, a 'zero value' message value is one with all default field values,
+  // so as to minimize wire encoded size.
+
   // Mappings from address ranges to the image/binary/library mapped
   // into that address range referenced by locations via Location.mapping_index.
-  // mapping_table[0] must always be set to a zero value default mapping,
-  // so that _index fields can use 0 to indicate null/unset.
   repeated Mapping mapping_table = 1;
 
   // Locations referenced by samples via Profile.location_indices.
@@ -106,8 +111,6 @@ message ProfilesDictionary {
   repeated Function function_table = 3;
 
   // Links referenced by samples via Sample.link_index.
-  // link_table[0] must always be set to a zero value default link,
-  // so that _index fields can use 0 to indicate null/unset.
   repeated Link link_table = 4;
 
   // A common table for strings referenced by various messages.

--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -67,9 +67,9 @@ option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1development";
 //   │                                n-1
 //   │ 1-n         ┌───────────────────────────────────────┐
 //   ▼             │                                       ▽
-// ┌──────────────────┐   1-n   ┌──────────────┐      ┌──────────┐
-// │      Sample      │ ──────▷ │   KeyValue   │      │   Link   │
-// └──────────────────┘         └──────────────┘      └──────────┘
+// ┌──────────────────┐   1-n   ┌─────────────────┐   ┌──────────┐
+// │      Sample      │ ──────▷ │ KeyValueAndUnit │   │   Link   │
+// └──────────────────┘         └─────────────────┘   └──────────┘
 //   │                    1-n       △      △
 //   │ 1-n        ┌─────────────────┘      │ 1-n
 //   ▽            │                        │
@@ -286,14 +286,6 @@ message Profile {
   repeated int32 attribute_indices = 13;
 }
 
-// Represents a mapping between Attribute Keys and Units.
-message AttributeUnit {
-  // Index into string table.
-  int32 attribute_key_strindex = 1;
-  // Index into string table.
-  int32 unit_strindex = 2;
-}
-
 // A pointer from a profile Sample to a trace Span.
 // Connects a profile sample to a trace span, identified by unique trace and span IDs.
 message Link {
@@ -500,11 +492,11 @@ message Function {
   int64 start_line = 4;
 }
 
-// A custom 'dictionary native' style of encoding attributes which is more specialized
-// for our use than opentelemetry.proto.common.v1.KeyValue
+// A custom 'dictionary native' style of encoding attributes which is more convenient
+// for profiles than opentelemetry.proto.common.v1.KeyValue
 // Specifically, uses the string table for keys and allows optional unit information.
 message KeyValueAndUnit {
   int32 key_strindex  = 1;
   opentelemetry.proto.common.v1.AnyValue value = 2;
-  int32 unit_strindex = 3; // non-zero where the unit cannot be derived from the name by semconv.
+  int32 unit_strindex = 3; // zero indicates implicit (by semconv) or non-defined unit.
 }


### PR DESCRIPTION
Subsequent to https://github.com/open-telemetry/opentelemetry-proto/pull/659 (profiles: avoid 'optional' keyword usage) and in accordance with discussions in the profiling SIG, this PR updates the dictionary message docs to impose a more consistent handling of 'null pointer' semantics in the encoding pattern.