### PR TITLE
Update ScopeProfiles to Profile relationships diagram to 1-n

### DIFF
--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -59,7 +59,7 @@ option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1development";
 // │  ScopeProfiles   │
 // └──────────────────┘
 //   │
-//   │ 1-1
+//   │ 1-n
 //   ▼
 // ┌──────────────────┐
 // │      Profile     │


### PR DESCRIPTION
Updated the relationship between `ScopeProfiles` and `Profile` from 1-1 to 1-n in the relationships diagram. This is a documentation-only change that fixes the diagram to accurately reflect the actual data model. 

The protobuf message definition shows:
```
message ScopeProfiles {
  // The instrumentation scope information for the profiles in this message.
  // Semantically when InstrumentationScope isn't set, it is equivalent with
  // an empty instrumentation scope name (unknown).
  opentelemetry.proto.common.v1.InstrumentationScope scope = 1;

  // A list of Profiles that originate from an instrumentation scope.
  repeated Profile profiles = 2;
  ...
}
```
The `repeated Profile profiles` field indicates a one-to-many relationship, where a single `ScopeProfiles` can contain multiple `Profile` instances. The inconsistency in the diagram seems to have originated [here](https://github.com/open-telemetry/opentelemetry-proto/commit/7312bdf63218acf27fe96430b7231de37fd091f2) when removing `ProfileContainer`.
