### PR TITLE
profiles: drop Location.is_folded

### DIFF
--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -468,15 +468,8 @@ message Location {
   //    line[0].function_name == "memcpy"
   //    line[1].function_name == "printf"
   repeated Line line = 3;
-  // Provides an indication that multiple symbols map to this location's
-  // address, for example due to identical code folding by the linker. In that
-  // case the line information above represents one of the multiple
-  // symbols. This field must be recomputed when the symbolization state of the
-  // profile changes.
-  bool is_folded = 4;
-
   // References to attributes in ProfilesDictionary.attribute_table. [optional]
-  repeated int32 attribute_indices = 5;
+  repeated int32 attribute_indices = 4;
 }
 
 // Details a specific line in a source code, linked to a function.


### PR DESCRIPTION
Similar to the boolean attributes `Mapping.has_*` (https://github.com/open-telemetry/opentelemetry-proto/pull/595 and https://github.com/open-telemetry/semantic-conventions/pull/2522) also drop `Location.is_folded`.


The complementary PR for the OTel SemConv, that builds on top of https://github.com/open-telemetry/semantic-conventions/pull/2522 is https://github.com/florianl/semantic-conventions/pull/1.

FYI: @open-telemetry/profiling-approvers