### PR TITLE
Unsigned Profile time_nanos and duration_nanos

### DIFF
--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -232,9 +232,9 @@ message Profile {
   // interpretation of results.
 
   // Time of collection (UTC) represented as nanoseconds past the epoch.
-  uint64 time_nanos = 4;
+  fixed64 time_unix_nano = 4;
   // Duration of the profile, if a duration makes sense.
-  uint64 duration_nanos = 5;
+  uint64 duration_nano = 5;
   // The kind of events between sampled occurrences.
   // e.g [ "cpu","cycles" ] or [ "heap","bytes" ]
   ValueType period_type = 6;
@@ -421,7 +421,7 @@ message Sample {
 
   // Timestamps associated with Sample represented in nanoseconds. These
   // timestamps should fall within the Profile's time range.
-  repeated uint64 timestamps_unix_nano = 6;
+  repeated fixed64 timestamps_unix_nano = 6;
 }
 
 // Describes the mapping of a binary in memory, including its address range,

--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -232,9 +232,9 @@ message Profile {
   // interpretation of results.
 
   // Time of collection (UTC) represented as nanoseconds past the epoch.
-  int64 time_nanos = 4;
+  uint64 time_nanos = 4;
   // Duration of the profile, if a duration makes sense.
-  int64 duration_nanos = 5;
+  uint64 duration_nanos = 5;
   // The kind of events between sampled occurrences.
   // e.g [ "cpu","cycles" ] or [ "heap","bytes" ]
   ValueType period_type = 6;


### PR DESCRIPTION
### Summary

We are already using unsigned type for [Sample.timestamps_unix_nano](https://github.com/open-telemetry/opentelemetry-proto/blob/b14635e74b7909c9f55db39666c667d4ea3092b7/opentelemetry/proto/profiles/v1development/profiles.proto#L422-L424) but not for the time-related fields in [Profile](https://github.com/open-telemetry/opentelemetry-proto/blob/b14635e74b7909c9f55db39666c667d4ea3092b7/opentelemetry/proto/profiles/v1development/profiles.proto#L235-L237).

Also see:
- #691 

