### PR TITLE
Move zero-element comment about dictionary tables

### DIFF
--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -92,13 +92,11 @@ option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1development";
 
 // ProfilesDictionary represents the profiles data shared across the
 // entire message being sent.
+// Note all fields in this message MUST have a zero value encoded as the first element.
+// This allows for _index fields pointing into the dictionary to use a 0 pointer value
+// to indicate 'null' / 'not set'. Unless otherwise defined, a 'zero value' message value
+// is one with all default field values, so as to minimize wire encoded size.
 message ProfilesDictionary {
-
-  // Note all fields in this message MUST have a zero value encoded as the first element.
-  // This allows for _index fields pointing into the dictionary to use a 0 pointer value
-  // to indicate 'null' / 'not set'. Unless otherwise defined, a 'zero value' message value
-  // is one with all default field values, so as to minimize wire encoded size.
-
   // Mappings from address ranges to the image/binary/library mapped
   // into that address range referenced by locations via Location.mapping_index.
   repeated Mapping mapping_table = 1;


### PR DESCRIPTION
This at least gives language generators to put this comment into the generated code as well.

Even though I frequent the meeting around this format a lot myself, I almost implemented handling of this incorrectly because the comment did not end up in the generated Go code.

@florianl @felixge 