### PR TITLE
Add Profiling maintainers/approvers to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,28 @@ is generated from the .proto files by any particular code generator.
 
 ## Maintainers
 
+### All Signals
+
 - [OpenTelemetry Technical Committee](https://github.com/open-telemetry/community/blob/main/community-members.md#technical-committee)
+
+### Profiling
+
+- [Christos Kalkanis](https://github.com/christos68k)
+- [Dmitry Filimonov](https://github.com/petethepig)
+- [Felix Geisendörfer](https://github.com/felixge)
+- [Jonathan Halliday](https://github.com/jhalliday)
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
 
 ## Approvers
 
+### All Signals
+
 - [OpenTelemetry Specification Sponsors](https://github.com/open-telemetry/community/blob/main/community-members.md#specifications-and-proto)
+
+### Profiling
+
+- [Alexey Alexandrov](https://github.com/aalexand)
+- [Florian Lehner](https://github.com/florianl)
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).


### PR DESCRIPTION
We didn't have the profiling maintainers and approvers listed anywhere. This adds the list to README.md to make sure:

- The names are prominently listed,
- PRs that introduce new maintainers and approvers can modify an actual file (README.md) to maintain a record of change in the commit history.