### PR TITLE
Exclude buf.yaml from release archives via .gitattributes (#604)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto eol=lf
+
+buf.yaml export-ignore


### PR DESCRIPTION
Adds an export-ignore rule for buf.yaml to prevent it from appearing in GitHub release
tarballs and zip files.

Background:
- Release archives currently include all tracked files, which previously caused
  buf.yaml to appear in the tarball.
- package.json and package-lock.json are no longer in the repo, so no action needed.

Impact:
- Low-risk, does not affect .proto files or SDK consumers.
- Existing release workflow remains unchanged.

Closes #604