### PR TITLE
docs: add response size limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The full list of changes can be found in the compare view for the respective rel
 
 ### Added
 
+- docs: add response body size limitation. [#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781)
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The full list of changes can be found in the compare view for the respective rel
 
 ### Added
 
-- docs: add response body size limitation. [#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781)
+- docs: add response size limitation for HTTP body and gRPC messages. [#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781)
 
 ### Changed
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -164,10 +164,10 @@ the specific message to use in the [Full Success](#full-success),
 The client MUST enforce a message size limit when receiving the response to
 mitigate possible excessive memory usage caused by a misconfigured or malicious
 server. gRPC client implementations typically enforce a default incoming message
-size limit of 4 MiB, which is acceptable to use. If the limit is exceeded, the
-client MUST treat the response as a not-retryable error. Note that in such
-scenario, the gRPC client implementations are reporting a `RESOURCE_EXHAUSTED`
-code to the caller.
+size limit of 4 MiB, which is acceptable to use. Implementations MAY allow this
+limit to be configured. If the limit is exceeded, the client MUST treat the
+response as a not-retryable error. Note that in such scenario, the gRPC client
+implementations are reporting a `RESOURCE_EXHAUSTED` code to the caller.
 
 ##### Full Success
 
@@ -489,9 +489,10 @@ below for the specific message to use in the [Full Success](#full-success-1),
 
 The client MUST limit the size of the response body when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
-misconfigured or malicious server. It is RECOMMENDED to limit the response body
-to 4 MiB. If the limit is exceeded, the client MUST treat the response as a
-not-retryable error and SHOULD record the fact that the response was discarded.
+misconfigured or malicious server. It is RECOMMENDED to use 4 MiB
+as the default limit. Implementations MAY allow this limit to be configured. If
+the limit is exceeded, the client MUST treat the response as a not-retryable
+error and SHOULD record the fact that the response was discarded.
 
 The server MUST set "Content-Type: application/x-protobuf" header if the
 response body is binary-encoded Protobuf payload. The server MUST set

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -161,11 +161,13 @@ The response MUST be the appropriate message (see below for
 the specific message to use in the [Full Success](#full-success),
 [Partial Success](#partial-success) and [Failure](#failures) cases).
 
-The client MUST limit the size of the response body when parsing it, including
-after decompression, to mitigate possible excessive memory usage caused by a
-misconfigured or malicious server. It is RECOMMENDED to limit the response body
-to 32 KiB. If the limit is exceeded, the client MUST treat the response as a
-not-retryable error and SHOULD record the fact that the response was discarded.
+The client MUST enforce a message size limit when receiving the response to
+mitigate possible excessive memory usage caused by a misconfigured or malicious
+server. gRPC client implementations typically enforce a default incoming message
+size limit of 4 MiB, which is acceptable to use. Implementations MAY apply a
+tighter limit (e.g. 32 KiB) since OTLP response messages are expected to be
+small. If the limit is exceeded, the client MUST treat the response as a
+not-retryable error (typically by returning `RESOURCE_EXHAUSTED` code).
 
 ##### Full Success
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -164,7 +164,8 @@ the specific message to use in the [Full Success](#full-success),
 The client MUST limit the size of the response body when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
 misconfigured or malicious server. It is RECOMMENDED to limit the response body
-to 32 KiB.
+to 32 KiB. If the limit is exceeded, the client MUST treat the response as a
+non-retryable error and SHOULD record the fact that the response was discarded.
 
 ##### Full Success
 
@@ -487,7 +488,8 @@ below for the specific message to use in the [Full Success](#full-success-1),
 The client MUST limit the size of the response body when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
 misconfigured or malicious server. It is RECOMMENDED to limit the response body
-to 32 KiB.
+to 32 KiB. If the limit is exceeded, the client MUST treat the response as a
+non-retryable error and SHOULD record the fact that the response was discarded.
 
 The server MUST set "Content-Type: application/x-protobuf" header if the
 response body is binary-encoded Protobuf payload. The server MUST set

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -165,7 +165,7 @@ The client MUST limit the size of the response body when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
 misconfigured or malicious server. It is RECOMMENDED to limit the response body
 to 32 KiB. If the limit is exceeded, the client MUST treat the response as a
-non-retryable error and SHOULD record the fact that the response was discarded.
+not-retryable error and SHOULD record the fact that the response was discarded.
 
 ##### Full Success
 
@@ -305,7 +305,7 @@ This is signaled by the server by returning
 [RetryInfo](https://github.com/googleapis/googleapis/blob/6a8c7914d1b79bd832b5157a09a9332e8cbd16d4/google/rpc/error_details.proto#L40).
 In this case the behavior of the server and the client is exactly as described in
 [OTLP/gRPC Throttling](#otlpgrpc-throttling) section. If no such status is returned,
-then the `RESOURCE_EXHAUSTED` code SHOULD be treated as non-retryable.
+then the `RESOURCE_EXHAUSTED` code SHOULD be treated as not-retryable.
 
 #### OTLP/gRPC Throttling
 
@@ -489,7 +489,7 @@ The client MUST limit the size of the response body when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
 misconfigured or malicious server. It is RECOMMENDED to limit the response body
 to 32 KiB. If the limit is exceeded, the client MUST treat the response as a
-non-retryable error and SHOULD record the fact that the response was discarded.
+not-retryable error and SHOULD record the fact that the response was discarded.
 
 The server MUST set "Content-Type: application/x-protobuf" header if the
 response body is binary-encoded Protobuf payload. The server MUST set

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -164,9 +164,9 @@ the specific message to use in the [Full Success](#full-success),
 The client MUST enforce a message size limit when receiving the response to
 mitigate possible excessive memory usage caused by a misconfigured or malicious
 server. gRPC client implementations typically enforce a default incoming message
-size limit of 4 MiB, which is acceptable to use.
-If the limit is exceeded, the client MUST treat the response as a
-not-retryable error (typically by returning `RESOURCE_EXHAUSTED` code).
+size limit of 4 MiB, which is acceptable to use. If the limit is exceeded, the
+client MUST treat the response as a not-retryable error (typically by returning
+`RESOURCE_EXHAUSTED` code).
 
 ##### Full Success
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -161,6 +161,11 @@ The response MUST be the appropriate message (see below for
 the specific message to use in the [Full Success](#full-success),
 [Partial Success](#partial-success) and [Failure](#failures) cases).
 
+The client MUST limit the size of the response body when parsing it, including
+after decompression, to mitigate possible excessive memory usage caused by a
+misconfigured or malicious server. It is RECOMMENDED to limit the response body
+to 32 KiB.
+
 ##### Full Success
 
 The success response indicates telemetry data is successfully accepted by the
@@ -478,6 +483,11 @@ sides.
 The response body MUST be the appropriate serialized Protobuf message (see
 below for the specific message to use in the [Full Success](#full-success-1),
 [Partial Success](#partial-success-1) and [Failure](#failures-1) cases).
+
+The client MUST limit the size of the response body when parsing it, including
+after decompression, to mitigate possible excessive memory usage caused by a
+misconfigured or malicious server. It is RECOMMENDED to limit the response body
+to 32 KiB.
 
 The server MUST set "Content-Type: application/x-protobuf" header if the
 response body is binary-encoded Protobuf payload. The server MUST set

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -165,8 +165,9 @@ The client MUST enforce a message size limit when receiving the response to
 mitigate possible excessive memory usage caused by a misconfigured or malicious
 server. gRPC client implementations typically enforce a default incoming message
 size limit of 4 MiB, which is acceptable to use. If the limit is exceeded, the
-client MUST treat the response as a not-retryable error (typically by returning
-`RESOURCE_EXHAUSTED` code).
+client MUST treat the response as a not-retryable error. Note that in such
+scenario, the gRPC client implementations are reporting a `RESOURCE_EXHAUSTED`
+code to the caller.
 
 ##### Full Success
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -164,9 +164,8 @@ the specific message to use in the [Full Success](#full-success),
 The client MUST enforce a message size limit when receiving the response to
 mitigate possible excessive memory usage caused by a misconfigured or malicious
 server. gRPC client implementations typically enforce a default incoming message
-size limit of 4 MiB, which is acceptable to use. Implementations MAY apply a
-tighter limit (e.g. 32 KiB) since OTLP response messages are expected to be
-small. If the limit is exceeded, the client MUST treat the response as a
+size limit of 4 MiB, which is acceptable to use.
+If the limit is exceeded, the client MUST treat the response as a
 not-retryable error (typically by returning `RESOURCE_EXHAUSTED` code).
 
 ##### Full Success
@@ -490,7 +489,7 @@ below for the specific message to use in the [Full Success](#full-success-1),
 The client MUST limit the size of the response body when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
 misconfigured or malicious server. It is RECOMMENDED to limit the response body
-to 32 KiB. If the limit is exceeded, the client MUST treat the response as a
+to 4 MiB. If the limit is exceeded, the client MUST treat the response as a
 not-retryable error and SHOULD record the fact that the response was discarded.
 
 The server MUST set "Content-Type: application/x-protobuf" header if the


### PR DESCRIPTION
Add response body size limitation to mitigate memory usage risks

Reference: https://cwe.mitre.org/data/definitions/789.html

OTel implementations: 
- https://github.com/open-telemetry/opentelemetry-go/pull/8108
- https://github.com/open-telemetry/opentelemetry-dotnet/pull/7017
- https://github.com/open-telemetry/opentelemetry-java/pull/8224
- https://github.com/open-telemetry/opentelemetry-kotlin/pull/361
- https://github.com/open-telemetry/opentelemetry-js/pull/6552

### Follow-ups 

- [x] Add limit for request on the server side (and client side?) https://github.com/open-telemetry/opentelemetry-proto/pull/781#issuecomment-4156611205
  - https://github.com/open-telemetry/opentelemetry-proto/pull/782
- [x] Create issues for all SDKs https://github.com/open-telemetry/opentelemetry-proto/pull/781#issuecomment-4156632535
   - All SIGs have been already been notified (even a few times).
- [x] Add limit for response on server side https://github.com/open-telemetry/opentelemetry-proto/pull/782
- [x] Change wording (not-retryable -> non-retryable) https://github.com/open-telemetry/opentelemetry-proto/pull/781#discussion_r3016594120