### PR TITLE
docs: add request size limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The full list of changes can be found in the compare view for the respective rel
 
 ### Added
 
+- docs: add request body size limitation.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The full list of changes can be found in the compare view for the respective rel
 
 ### Added
 
-- docs: add request body size limitation.
+- docs: add request body size limitation. [#782](https://github.com/open-telemetry/opentelemetry-proto/pull/782)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The full list of changes can be found in the compare view for the respective rel
 
 ### Added
 
-- docs: add request body size limitation. [#782](https://github.com/open-telemetry/opentelemetry-proto/pull/782)
+- docs: add request size limitation for HTTP body and gRPC messages. [#782](https://github.com/open-telemetry/opentelemetry-proto/pull/782)
 
 ### Changed
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -120,12 +120,14 @@ The server MUST enforce a message size limit when receiving the request,
 including after decompression, to mitigate possible excessive memory usage
 caused by a misconfigured or malicious client sending an oversized request.
 The server implementations typically enforce a default incoming message size
-limit of 4 MiB, which is acceptable to use. If the limit is exceeded, the client
-MUST treat the error as non-retryable. Note that in such a scenario, the gRPC
-server implementations return a `RESOURCE_EXHAUSTED` status code to the caller.
+limit of 4 MiB. However, it is RECOMMENDED to use 32 MiB as the default limit.
+Implementations MAY allow this limit to be configured. If the limit is
+exceeded, the client MUST treat the error as non-retryable. Note that in such a
+scenario, the gRPC server implementations return a `RESOURCE_EXHAUSTED` status
+code to the caller.
 
 The client SHOULD limit the size of the request message, including before
-compression, to avoid overwhelming the server. It is RECOMMENDED to use 4 MiB
+compression, to avoid overwhelming the server. It is RECOMMENDED to use 32 MiB
 as the default limit. Implementations MAY allow this limit to be configured.
 
 #### OTLP/gRPC Concurrent Requests
@@ -498,14 +500,14 @@ sides.
 
 The server MUST limit the size of the request body when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
-misconfigured or malicious client client sending an oversized request. It is
-RECOMMENDED to use 20 MiB as the default limit. Implementations MAY allow this
+misconfigured or malicious client sending an oversized request. It is
+RECOMMENDED to use 32 MiB as the default limit. Implementations MAY allow this
 limit to be configured. If the limit is exceeded, the server SHOULD respond with
 `HTTP 413 Content Too Large`. The client MUST NOT retry the request when it
 receives `HTTP 413 Content Too Large` response.
 
 The client SHOULD limit the size of the request body, including before
-compression, to avoid overwhelming the server. It is RECOMMENDED to use 20 MiB
+compression, to avoid overwhelming the server. It is RECOMMENDED to use 32 MiB
 as the default limit. Implementations MAY allow this limit to be configured.
 
 #### OTLP/HTTP Response

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -116,13 +116,13 @@ paths._
 
 #### OTLP/gRPC Request
 
-The server MUST limit the size of the request message when parsing it, including
-after decompression, to mitigate possible excessive memory usage caused by a
-misconfigured or malicious client. It is RECOMMENDED to limit the request
-message to 4 MiB. If the limit is exceeded, the server SHOULD return
-`RESOURCE_EXHAUSTED` gRPC status code. In this case the `RESOURCE_EXHAUSTED`
-code MUST NOT be accompanied by a `RetryInfo` status detail so that the client
-treats the error as not-retryable (see [Failures](#failures)).
+The server MUST enforce a message size limit when receiving the request to
+mitigate possible excessive memory usage caused by a misconfigured or malicious
+server. The server implementations typically enforce a default incoming message
+size limit of 4 MiB, which is acceptable to use. If the limit is exceeded, the
+client MUST treat the error as not-retryable. Note that in such a scenario,
+the gRPC server implementations return a `RESOURCE_EXHAUSTED` status code
+to the caller.
 
 The client SHOULD limit the size of the request message, including before
 compression, to avoid overwhelming the server. It is RECOMMENDED to limit the

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -125,8 +125,8 @@ the gRPC server implementations return a `RESOURCE_EXHAUSTED` status code
 to the caller.
 
 The client SHOULD limit the size of the request message, including before
-compression, to avoid overwhelming the server. It is RECOMMENDED to limit the
-request message to 4 MiB.
+compression, to avoid overwhelming the server. It is RECOMMENDED to use 4 MiB
+as the default limit. Implementations MAY allow this limit to be configured.
 
 #### OTLP/gRPC Concurrent Requests
 
@@ -490,14 +490,15 @@ sides.
 
 The server MUST limit the size of the request body when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
-misconfigured or malicious client. It is RECOMMENDED to limit the request body
-to 20 MiB. If the limit is exceeded, the server SHOULD respond with
-`HTTP 413 Content Too Large`. The client MUST NOT retry the request when it
-receives `HTTP 413 Content Too Large` response.
+misconfigured or malicious client. It is RECOMMENDED to use 20 MiB as the
+default limit. Implementations MAY allow this limit to be configured. If the
+limit is exceeded, the server SHOULD respond with `HTTP 413 Content Too Large`.
+The client MUST NOT retry the request when it receives
+`HTTP 413 Content Too Large` response.
 
 The client SHOULD limit the size of the request body, including before
-compression, to avoid overwhelming the server. It is RECOMMENDED to limit the
-request body to 20 MiB.
+compression, to avoid overwhelming the server. It is RECOMMENDED to use 20 MiB
+as the default limit. Implementations MAY allow this limit to be configured.
 
 #### OTLP/HTTP Response
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -120,7 +120,7 @@ The server MUST enforce a message size limit when receiving the request to
 mitigate possible excessive memory usage caused by a misconfigured or malicious
 client sending an oversized request. The server implementations typically
 enforce a default incoming message size limit of 4 MiB, which is acceptable to
-use. If the limit is exceeded, the client MUST treat the error as not-retryable.
+use. If the limit is exceeded, the client MUST treat the error as non-retryable.
 Note that in such a scenario, the gRPC server implementations return a
 `RESOURCE_EXHAUSTED` status code to the caller.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -116,13 +116,13 @@ paths._
 
 #### OTLP/gRPC Request
 
-The server MUST enforce a message size limit when receiving the request to
-mitigate possible excessive memory usage caused by a misconfigured or malicious
-client sending an oversized request. The server implementations typically
-enforce a default incoming message size limit of 4 MiB, which is acceptable to
-use. If the limit is exceeded, the client MUST treat the error as non-retryable.
-Note that in such a scenario, the gRPC server implementations return a
-`RESOURCE_EXHAUSTED` status code to the caller.
+The server MUST enforce a message size limit when receiving the request,
+including after decompression, to mitigate possible excessive memory usage
+caused by a misconfigured or malicious client sending an oversized request.
+The server implementations typically enforce a default incoming message size
+limit of 4 MiB, which is acceptable to use. If the limit is exceeded, the client
+MUST treat the error as non-retryable. Note that in such a scenario, the gRPC
+server implementations return a `RESOURCE_EXHAUSTED` status code to the caller.
 
 The client SHOULD limit the size of the request message, including before
 compression, to avoid overwhelming the server. It is RECOMMENDED to use 4 MiB
@@ -490,11 +490,11 @@ sides.
 
 The server MUST limit the size of the request body when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
-misconfigured or malicious client. It is RECOMMENDED to use 20 MiB as the
-default limit. Implementations MAY allow this limit to be configured. If the
-limit is exceeded, the server SHOULD respond with `HTTP 413 Content Too Large`.
-The client MUST NOT retry the request when it receives
-`HTTP 413 Content Too Large` response.
+misconfigured or malicious client client sending an oversized request. It is
+RECOMMENDED to use 20 MiB as the default limit. Implementations MAY allow this
+limit to be configured. If the limit is exceeded, the server SHOULD respond with
+`HTTP 413 Content Too Large`. The client MUST NOT retry the request when it
+receives `HTTP 413 Content Too Large` response.
 
 The client SHOULD limit the size of the request body, including before
 compression, to avoid overwhelming the server. It is RECOMMENDED to use 20 MiB

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -32,6 +32,7 @@ nodes such as collectors and telemetry backends.
 
 - [Protocol Details](#protocol-details)
   * [OTLP/gRPC](#otlpgrpc)
+    + [OTLP/gRPC Request](#otlpgrpc-request)
     + [OTLP/gRPC Concurrent Requests](#otlpgrpc-concurrent-requests)
     + [OTLP/gRPC Response](#otlpgrpc-response)
       - [Full Success](#full-success)
@@ -112,6 +113,20 @@ delivery guarantees in such systems is outside of the scope of OTLP. The
 acknowledgements described in this protocol happen between a single
 client/server pair and do not span intermediary nodes in multi-hop delivery
 paths._
+
+#### OTLP/gRPC Request
+
+The server MUST limit the size of the request message when parsing it, including
+after decompression, to mitigate possible excessive memory usage caused by a
+misconfigured or malicious client. It is RECOMMENDED to limit the request
+message to 64 MiB. If the limit is exceeded, the server SHOULD return
+`RESOURCE_EXHAUSTED` gRPC status code. In this case the `RESOURCE_EXHAUSTED`
+code MUST NOT be accompanied by a `RetryInfo` status detail so that the client
+treats the error as not-retryable (see [Failures](#failures)).
+
+The client SHOULD limit the size of the request message, including before
+compression, to avoid overwhelming the server. It is RECOMMENDED to limit the
+request message to 64 MiB.
 
 #### OTLP/gRPC Concurrent Requests
 
@@ -472,6 +487,17 @@ The client MAY gzip the content and in that case MUST include
 
 Non-default URL paths for requests MAY be configured on the client and server
 sides.
+
+The server MUST limit the size of the request body when parsing it, including
+after decompression, to mitigate possible excessive memory usage caused by a
+misconfigured or malicious client. It is RECOMMENDED to limit the request body
+to 64 MiB. If the limit is exceeded, the server SHOULD respond with
+`HTTP 413 Content Too Large`. The client MUST NOT retry the request when it
+receives `HTTP 413 Content Too Large` response.
+
+The client SHOULD limit the size of the request body, including before
+compression, to avoid overwhelming the server. It is RECOMMENDED to limit the
+request body to 64 MiB.
 
 #### OTLP/HTTP Response
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -119,14 +119,14 @@ paths._
 The server MUST limit the size of the request message when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
 misconfigured or malicious client. It is RECOMMENDED to limit the request
-message to 64 MiB. If the limit is exceeded, the server SHOULD return
+message to 4 MiB. If the limit is exceeded, the server SHOULD return
 `RESOURCE_EXHAUSTED` gRPC status code. In this case the `RESOURCE_EXHAUSTED`
 code MUST NOT be accompanied by a `RetryInfo` status detail so that the client
 treats the error as not-retryable (see [Failures](#failures)).
 
 The client SHOULD limit the size of the request message, including before
 compression, to avoid overwhelming the server. It is RECOMMENDED to limit the
-request message to 64 MiB.
+request message to 4 MiB.
 
 #### OTLP/gRPC Concurrent Requests
 
@@ -491,13 +491,13 @@ sides.
 The server MUST limit the size of the request body when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
 misconfigured or malicious client. It is RECOMMENDED to limit the request body
-to 64 MiB. If the limit is exceeded, the server SHOULD respond with
+to 20 MiB. If the limit is exceeded, the server SHOULD respond with
 `HTTP 413 Content Too Large`. The client MUST NOT retry the request when it
 receives `HTTP 413 Content Too Large` response.
 
 The client SHOULD limit the size of the request body, including before
 compression, to avoid overwhelming the server. It is RECOMMENDED to limit the
-request body to 64 MiB.
+request body to 20 MiB.
 
 #### OTLP/HTTP Response
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -118,11 +118,11 @@ paths._
 
 The server MUST enforce a message size limit when receiving the request to
 mitigate possible excessive memory usage caused by a misconfigured or malicious
-server. The server implementations typically enforce a default incoming message
-size limit of 4 MiB, which is acceptable to use. If the limit is exceeded, the
-client MUST treat the error as not-retryable. Note that in such a scenario,
-the gRPC server implementations return a `RESOURCE_EXHAUSTED` status code
-to the caller.
+client sending an oversized request. The server implementations typically
+enforce a default incoming message size limit of 4 MiB, which is acceptable to
+use. If the limit is exceeded, the client MUST treat the error as not-retryable.
+Note that in such a scenario, the gRPC server implementations return a
+`RESOURCE_EXHAUSTED` status code to the caller.
 
 The client SHOULD limit the size of the request message, including before
 compression, to avoid overwhelming the server. It is RECOMMENDED to use 4 MiB

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -128,7 +128,9 @@ non-retryable error.
 
 The client SHOULD limit the size of the request message, including before
 compression, to avoid overwhelming the server. It is RECOMMENDED to use 32 MiB
-as the default limit. Implementations MAY allow this limit to be configured.
+as the default limit. Implementations MAY allow this limit to be configured. If
+the limit is exceeded, the client MUST NOT make the request and SHOULD record
+the fact that the request was discarded.
 
 #### OTLP/gRPC Concurrent Requests
 
@@ -508,7 +510,9 @@ receives `HTTP 413 Content Too Large` response.
 
 The client SHOULD limit the size of the request body, including before
 compression, to avoid overwhelming the server. It is RECOMMENDED to use 32 MiB
-as the default limit. Implementations MAY allow this limit to be configured.
+as the default limit. Implementations MAY allow this limit to be configured. If
+the limit is exceeded, the client MUST NOT make the request and SHOULD record
+the fact that the request was discarded.
 
 #### OTLP/HTTP Response
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -122,9 +122,9 @@ caused by a misconfigured or malicious client sending an oversized request.
 The server implementations typically enforce a default incoming message size
 limit of 4 MiB. However, it is RECOMMENDED to use 32 MiB as the default limit.
 Implementations MAY allow this limit to be configured. If the limit is
-exceeded, the client MUST treat the error as non-retryable. Note that in such a
-scenario, the gRPC server implementations return a `RESOURCE_EXHAUSTED` status
-code to the caller.
+exceeded, the gRPC server implementations MUST report a
+`RESOURCE_EXHAUSTED` code to the caller which the client MUST treat as a
+non-retryable error.
 
 The client SHOULD limit the size of the request message, including before
 compression, to avoid overwhelming the server. It is RECOMMENDED to use 32 MiB
@@ -502,7 +502,7 @@ The server MUST limit the size of the request body when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
 misconfigured or malicious client sending an oversized request. It is
 RECOMMENDED to use 32 MiB as the default limit. Implementations MAY allow this
-limit to be configured. If the limit is exceeded, the server SHOULD respond with
+limit to be configured. If the limit is exceeded, the server MUST respond with
 `HTTP 413 Content Too Large`. The client MUST NOT retry the request when it
 receives `HTTP 413 Content Too Large` response.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -121,15 +121,15 @@ including after decompression, to mitigate possible excessive memory usage
 caused by a misconfigured or malicious client sending an oversized request.
 The server implementations typically enforce a default incoming message size
 limit of 4 MiB. However, it is RECOMMENDED to use 64 MiB as the default limit.
-Implementations MAY allow this limit to be configured. If the limit is
+Implementations SHOULD allow this limit to be configured. If the limit is
 exceeded, the gRPC server implementations MUST report a
 `RESOURCE_EXHAUSTED` code to the caller which the client MUST treat as a
 non-retryable error.
 
 The client SHOULD limit the size of the request message, including before
 compression, to avoid overwhelming the server. It is RECOMMENDED to use 64 MiB
-as the default limit. Implementations MAY allow this limit to be configured. If
-the limit is exceeded, the client MUST NOT make the request and SHOULD record
+as the default limit. Implementations SHOULD allow this limit to be configured.
+If the limit is exceeded, the client MUST NOT make the request and SHOULD record
 the fact that the request was discarded.
 
 #### OTLP/gRPC Concurrent Requests
@@ -503,15 +503,15 @@ sides.
 The server MUST limit the size of the request body when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
 misconfigured or malicious client sending an oversized request. It is
-RECOMMENDED to use 64 MiB as the default limit. Implementations MAY allow this
-limit to be configured. If the limit is exceeded, the server MUST respond with
-`HTTP 413 Content Too Large`. The client MUST NOT retry the request when it
+RECOMMENDED to use 64 MiB as the default limit. Implementations SHOULD allow
+this limit to be configured. If the limit is exceeded, the server MUST respond
+with `HTTP 413 Content Too Large`. The client MUST NOT retry the request when it
 receives `HTTP 413 Content Too Large` response.
 
 The client SHOULD limit the size of the request body, including before
 compression, to avoid overwhelming the server. It is RECOMMENDED to use 64 MiB
-as the default limit. Implementations MAY allow this limit to be configured. If
-the limit is exceeded, the client MUST NOT make the request and SHOULD record
+as the default limit. Implementations SHOULD allow this limit to be configured.
+If the limit is exceeded, the client MUST NOT make the request and SHOULD record
 the fact that the request was discarded.
 
 #### OTLP/HTTP Response

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -123,8 +123,7 @@ The server implementations typically enforce a default incoming message size
 limit of 4 MiB. However, it is RECOMMENDED to use 64 MiB as the default limit.
 Implementations SHOULD allow this limit to be configured. If the limit is
 exceeded, the gRPC server implementations MUST report a
-`RESOURCE_EXHAUSTED` code to the caller which the client MUST treat as a
-non-retryable error.
+`RESOURCE_EXHAUSTED` code as a non-retryable error.
 
 The client SHOULD limit the size of the request message, including before
 compression, to avoid overwhelming the server. It is RECOMMENDED to use 64 MiB
@@ -505,8 +504,7 @@ after decompression, to mitigate possible excessive memory usage caused by a
 misconfigured or malicious client sending an oversized request. It is
 RECOMMENDED to use 64 MiB as the default limit. Implementations SHOULD allow
 this limit to be configured. If the limit is exceeded, the server MUST respond
-with `HTTP 413 Content Too Large`. The client MUST NOT retry the request when it
-receives `HTTP 413 Content Too Large` response.
+with `HTTP 413 Content Too Large`.
 
 The client SHOULD limit the size of the request body, including before
 compression, to avoid overwhelming the server. It is RECOMMENDED to use 64 MiB

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -120,14 +120,14 @@ The server MUST enforce a message size limit when receiving the request,
 including after decompression, to mitigate possible excessive memory usage
 caused by a misconfigured or malicious client sending an oversized request.
 The server implementations typically enforce a default incoming message size
-limit of 4 MiB. However, it is RECOMMENDED to use 32 MiB as the default limit.
+limit of 4 MiB. However, it is RECOMMENDED to use 64 MiB as the default limit.
 Implementations MAY allow this limit to be configured. If the limit is
 exceeded, the gRPC server implementations MUST report a
 `RESOURCE_EXHAUSTED` code to the caller which the client MUST treat as a
 non-retryable error.
 
 The client SHOULD limit the size of the request message, including before
-compression, to avoid overwhelming the server. It is RECOMMENDED to use 32 MiB
+compression, to avoid overwhelming the server. It is RECOMMENDED to use 64 MiB
 as the default limit. Implementations MAY allow this limit to be configured. If
 the limit is exceeded, the client MUST NOT make the request and SHOULD record
 the fact that the request was discarded.
@@ -503,13 +503,13 @@ sides.
 The server MUST limit the size of the request body when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
 misconfigured or malicious client sending an oversized request. It is
-RECOMMENDED to use 32 MiB as the default limit. Implementations MAY allow this
+RECOMMENDED to use 64 MiB as the default limit. Implementations MAY allow this
 limit to be configured. If the limit is exceeded, the server MUST respond with
 `HTTP 413 Content Too Large`. The client MUST NOT retry the request when it
 receives `HTTP 413 Content Too Large` response.
 
 The client SHOULD limit the size of the request body, including before
-compression, to avoid overwhelming the server. It is RECOMMENDED to use 32 MiB
+compression, to avoid overwhelming the server. It is RECOMMENDED to use 64 MiB
 as the default limit. Implementations MAY allow this limit to be configured. If
 the limit is exceeded, the client MUST NOT make the request and SHOULD record
 the fact that the request was discarded.


### PR DESCRIPTION
Per https://github.com/open-telemetry/opentelemetry-proto/pull/781#issuecomment-4156611205

Add request size limitation for HTTP body and gRPC messages to mitigate memory usage risks.

Reference: https://cwe.mitre.org/data/definitions/789.html

The values are taken from ~~[otlpreceiver](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/config.md) defaults~~ https://github.com/open-telemetry/opentelemetry-proto/pull/782#discussion_r3032163377
- gRPC - ~~4 MiB~~ 64 MiB
- HTTP - ~~20 MiB~~ 64 MiB

OTel implementations:
- https://github.com/open-telemetry/opentelemetry-go/pull/8157

