### PR TITLE
Move from TC + Spec sponsors as maintainers to using proto-* groups as maintainers/approvers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 #
 
 # Global owners, will be the owners for everything in the repo. Membership is tracked via https://github.com/open-telemetry/community/blob/main/community-members.md 
-*   @open-telemetry/spec-sponsors
+*   @open-telemetry/proto-maintainers @open-telemetry/proto-approvers
 
 # Profiles owners (global + profiles)
 opentelemetry/proto/profiles  @open-telemetry/spec-sponsors @open-telemetry/profiling-approvers

--- a/README.md
+++ b/README.md
@@ -151,37 +151,38 @@ is generated from the .proto files by any particular code generator.
 
 ## Maintainers
 
+- [Armin Reuch](https://github.com/arminru)
 - [Bogdan Drutu](https://github.com/bogdandrutu)
 - [Carlos Alberto Cortez](https://github.com/carlosalberto)
+- [Jack Berg](https://github.com/jack-berg)
 - [Joshua Suereth](https://github.com/jsuereth)
 - [Liudmilla Molkova](https://github.com/lmolkova)
 - [Tigran Najaryan](https://github.com/tigrannajaryan)
-- [Armin Reuch](https://github.com/arminru)
-- [Jack Berg](https://github.com/jack-berg)
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
 
 ## Approvers
 
-- [Juraci Paixão Kröhling](https://github.com/jpkrohling)
-- [Felix Geisendörfer](https://github.com/felixge)
-- [Ted Young](https://github.com/tedsuo)
-- [Tristan Sloughter](https://github.com/tsloughter)
 - [Alex Boten](https://github.com/codeboten)
-- [Jonathan Halliday](https://github.com/jhalliday)
-- [Christian Neumüller](https://github.com/Oberon00)
-- [Florian Lehner](https://github.com/florianl)
 - [Alexey Alexandrov](https://github.com/aalexand)
-- [Severin Neumann](https://github.com/svrnm)
+- [Christian Neumüller](https://github.com/Oberon00)
+- [Christos Kalkanis](https://github.com/christos68k)
+- [Cijo Thomas](https://github.com/cijothomas)
 - [Daniel Dyla](https://github.com/dyladan)
 - [David Ashpole](https://github.com/dashpole)
+- [Felix Geisendörfer](https://github.com/felixge)
+- [Florian Lehner](https://github.com/florianl)
+- [Jonathan Halliday](https://github.com/jhalliday)
 - [Josh MacDonald](https://github.com/jmacd)
-- [Robert Pająk](https://github.com/pellared)
-- [Cijo Thomas](https://github.com/cijothomas)
-- [Tyler Yahn](https://github.com/MrAlias)
+- [Juraci Paixão Kröhling](https://github.com/jpkrohling)
 - [Leighton Chen](https://github.com/lzchen)
 - [Marc Alff](https://github.com/marcalff)
-- [Christos Kalkanis](https://github.com/christos68k)
+- [Reiley Yang](https://github.com/reyang)
+- [Robert Pająk](https://github.com/pellared)
+- [Severin Neumann](https://github.com/svrnm)
+- [Ted Young](https://github.com/tedsuo)
+- [Tristan Sloughter](https://github.com/tsloughter)
+- [Tyler Yahn](https://github.com/MrAlias)
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
 

--- a/README.md
+++ b/README.md
@@ -151,12 +151,51 @@ is generated from the .proto files by any particular code generator.
 
 ## Maintainers
 
-- [OpenTelemetry Technical Committee](https://github.com/open-telemetry/community/blob/main/community-members.md#technical-committee)
+- [Bogdan Drutu](https://github.com/bogdandrutu)
+- [Carlos Alberto Cortez](https://github.com/carlosalberto)
+- [Joshua Suereth](https://github.com/jsuereth)
+- [Liudmilla Molkova](https://github.com/lmolkova)
+- [Tigran Najaryan](https://github.com/tigrannajaryan)
+- [Armin Reuch](https://github.com/arminru)
+- [Reiley Yang](https://github.com/reyang)
+- [Jack Berg](https://github.com/jack-berg)
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
 
 ## Approvers
 
-- [OpenTelemetry Specification Sponsors](https://github.com/open-telemetry/community/blob/main/community-members.md#specifications-and-proto)
+- [Juraci Paixão Kröhling](https://github.com/jpkrohling)
+- [Felix Geisendörfer](https://github.com/felixge)
+- [Ted Young](https://github.com/tedsuo)
+- [Tristan Sloughter](https://github.com/tsloughter)
+- [Alex Boten](https://github.com/codeboten)
+- [Dimitry Filimonov](https://github.com/petethepig)
+- [Jonathan Halliday](https://github.com/jhalliday)
+- [Christian Neumüller](https://github.com/Oberon00)
+- [Florian Lehner](https://github.com/florianl)
+- [Alexey Alexandrov](https://github.com/aalexand)
+- [Severin Neumann](https://github.com/svrnm)
+- [Daniel Dyla](https://github.com/dyladan)
+- [David Ashpole](https://github.com/dashpole)
+- [Josh MacDonald](https://github.com/jmacd)
+- [Robert Pająk](https://github.com/pellared)
+- [Cijo Thomas](https://github.com/cijothomas)
+- [Tyler Yahn](https://github.com/MrAlias)
+- [Leighton Chen](https://github.com/lzchen)
+- [Marc Alff](https://github.com/marcalff)
+- [Christos Kalkanis](https://github.com/christos68k)
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
+
+## Emeritus Maintainers
+
+Previously this package was maintained solely by the [OpenTelemetry Technical Committee](https://github.com/open-telemetry/community/blob/main/community-members.md#technical-committee).
+It now has a dedicated maintainer role that is independent of the OpenTelemetry
+specification.
+
+## Emeritus Approvers
+
+Previously the package had the same approvals as the specification, via
+[OpenTelemetry Specification Sponsors](https://github.com/open-telemetry/community/blob/main/community-members.md#specifications-and-proto).
+It now has a dedicated approver role that is independent of the OpenTelemetry
+specification.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ is generated from the .proto files by any particular code generator.
 - [Armin Reuch](https://github.com/arminru)
 - [Bogdan Drutu](https://github.com/bogdandrutu)
 - [Carlos Alberto Cortez](https://github.com/carlosalberto)
-- [Jack Berg](https://github.com/jack-berg)
 - [Joshua Suereth](https://github.com/jsuereth)
 - [Liudmilla Molkova](https://github.com/lmolkova)
 - [Tigran Najaryan](https://github.com/tigrannajaryan)

--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ For more information about the maintainer role, see the [community repository](h
 - [Ted Young](https://github.com/tedsuo)
 - [Tristan Sloughter](https://github.com/tsloughter)
 - [Alex Boten](https://github.com/codeboten)
-- [Dimitry Filimonov](https://github.com/petethepig)
 - [Jonathan Halliday](https://github.com/jhalliday)
 - [Christian Neumüller](https://github.com/Oberon00)
 - [Florian Lehner](https://github.com/florianl)

--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ is generated from the .proto files by any particular code generator.
 - [Liudmilla Molkova](https://github.com/lmolkova)
 - [Tigran Najaryan](https://github.com/tigrannajaryan)
 - [Armin Reuch](https://github.com/arminru)
-- [Reiley Yang](https://github.com/reyang)
 - [Jack Berg](https://github.com/jack-berg)
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).

--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ is generated from the .proto files by any particular code generator.
 - [Bogdan Drutu](https://github.com/bogdandrutu)
 - [Carlos Alberto Cortez](https://github.com/carlosalberto)
 - [Joshua Suereth](https://github.com/jsuereth)
-- [Liudmilla Molkova](https://github.com/lmolkova)
 - [Tigran Najaryan](https://github.com/tigrannajaryan)
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ For more information about the maintainer role, see the [community repository](h
 - [David Ashpole](https://github.com/dashpole)
 - [Felix Geisendörfer](https://github.com/felixge)
 - [Florian Lehner](https://github.com/florianl)
+- [Jack Berg](https://github.com/jack-berg)
 - [Jonathan Halliday](https://github.com/jhalliday)
 - [Josh MacDonald](https://github.com/jmacd)
 - [Juraci Paixão Kröhling](https://github.com/jpkrohling)

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ is generated from the .proto files by any particular code generator.
 - [Bogdan Drutu](https://github.com/bogdandrutu)
 - [Carlos Alberto Cortez](https://github.com/carlosalberto)
 - [Joshua Suereth](https://github.com/jsuereth)
+- [Robert Pająk](https://github.com/pellared)
 - [Tigran Najaryan](https://github.com/tigrannajaryan)
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
@@ -177,7 +178,6 @@ For more information about the maintainer role, see the [community repository](h
 - [Leighton Chen](https://github.com/lzchen)
 - [Marc Alff](https://github.com/marcalff)
 - [Reiley Yang](https://github.com/reyang)
-- [Robert Pająk](https://github.com/pellared)
 - [Severin Neumann](https://github.com/svrnm)
 - [Ted Young](https://github.com/tedsuo)
 - [Tristan Sloughter](https://github.com/tsloughter)


### PR DESCRIPTION
This PR formalizes moving the protocol to have an independent set of maintainers and approvers.

The list of maintainers and approvers is seeded from the existing @open-telemetry/proto-approvers and @open-telemetry/proto-maintainers groups.