### PR TITLE
docs: clarify gRPC response decompression size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The full list of changes can be found in the compare view for the respective rel
 - docs: add request size limitation for HTTP body and gRPC messages. [#782](https://github.com/open-telemetry/opentelemetry-proto/pull/782)
 - docs: add response size limitation for HTTP body and gRPC messages. [#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781), [#800](https://github.com/open-telemetry/opentelemetry-proto/pull/800), [#802](https://github.com/open-telemetry/opentelemetry-proto/pull/802)
 
+### Changed
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The full list of changes can be found in the compare view for the respective rel
 ### Added
 
 - docs: add request size limitation for HTTP body and gRPC messages. [#782](https://github.com/open-telemetry/opentelemetry-proto/pull/782)
-- docs: add response size limitation for HTTP body and gRPC messages. [#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781)
+- docs: add response size limitation for HTTP body and gRPC messages. [#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781), [#800](https://github.com/open-telemetry/opentelemetry-proto/pull/800)
 
 ### Changed
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -179,13 +179,14 @@ The response MUST be the appropriate message (see below for
 the specific message to use in the [Full Success](#full-success),
 [Partial Success](#partial-success) and [Failure](#failures) cases).
 
-The client MUST enforce a message size limit when receiving the response to
-mitigate possible excessive memory usage caused by a misconfigured or malicious
-server. gRPC client implementations typically enforce a default incoming message
-size limit of 4 MiB, which is acceptable to use. Implementations MAY allow this
-limit to be configured. If the limit is exceeded, the client MUST treat the
-response as a non-retryable error. Note that in such scenario, the gRPC client
-implementations are reporting a `RESOURCE_EXHAUSTED` code to the caller.
+The client MUST enforce a message size limit when receiving the response,
+including after decompression, to mitigate possible excessive memory usage
+caused by a misconfigured or malicious server. gRPC client implementations
+typically enforce a default incoming message size limit of 4 MiB, which is
+acceptable to use. Implementations MAY allow this limit to be configured. If the
+limit is exceeded, the client MUST treat the response as a non-retryable error.
+Note that in such scenario, the gRPC client implementations are reporting a
+`RESOURCE_EXHAUSTED` code to the caller.
 
 ##### Full Success
 


### PR DESCRIPTION
Add missing ", including after decompression, " for consistency and clarity.

This can be seen as a bugfix for https://github.com/open-telemetry/opentelemetry-proto/pull/781