### PR TITLE
docs: add server response size limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The full list of changes can be found in the compare view for the respective rel
 
 - docs: add request size limitation for HTTP body and gRPC messages. [#782](https://github.com/open-telemetry/opentelemetry-proto/pull/782)
 - docs: add response size limitation for HTTP body and gRPC messages. [#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781)
+- docs: add server response size limitation for HTTP body and gRPC messages.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ The full list of changes can be found in the compare view for the respective rel
 ### Added
 
 - docs: add request size limitation for HTTP body and gRPC messages. [#782](https://github.com/open-telemetry/opentelemetry-proto/pull/782)
-- docs: add response size limitation for HTTP body and gRPC messages. [#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781)
-- docs: add server response size limitation for HTTP body and gRPC messages.
+- docs: add response size limitation for HTTP body and gRPC messages. [#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781), [#801](https://github.com/open-telemetry/opentelemetry-proto/pull/801)
 
 ### Changed
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -197,8 +197,8 @@ semantics if it is possible. To do so, the server MAY decrease the verbosity of
 optional diagnostic fields, such as `partial_success.error_message`, or omit
 optional diagnostic fields. If the response still cannot fit within the limit,
 the server MUST fail the request with the `RESOURCE_EXHAUSTED` code as a
-non-retryable error and MUST NOT partially accept telemetry data from the
-request.
+non-retryable error. After such a failure, whether any telemetry data from the
+request was accepted is unspecified.
 
 ##### Full Success
 
@@ -546,8 +546,9 @@ the limit, the server MUST reduce the response size without changing response
 semantics if it is possible. To do so, the server MAY decrease the verbosity of
 optional diagnostic fields, such as `partial_success.error_message`, or omit
 optional diagnostic fields. If the response still cannot fit within the limit,
-the server MUST fail the request with `HTTP 500 Internal Server Error` and MUST
-NOT partially accept telemetry data from the request.
+the server MUST fail the request with `HTTP 500 Internal Server Error`. After
+such a failure, whether any telemetry data from the request was accepted is
+unspecified.
 
 The server MUST set "Content-Type: application/x-protobuf" header if the
 response body is binary-encoded Protobuf payload. The server MUST set

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -187,6 +187,12 @@ limit to be configured. If the limit is exceeded, the client MUST treat the
 response as a non-retryable error. Note that in such scenario, the gRPC client
 implementations are reporting a `RESOURCE_EXHAUSTED` code to the caller.
 
+The server MUST limit the size of the response message, including before
+compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
+as the default limit. Implementations MAY allow this limit to be configured. If
+the limit is exceeded, the server MUST NOT send the oversized response message
+and SHOULD record the fact that the response was discarded.
+
 ##### Full Success
 
 The success response indicates telemetry data is successfully accepted by the
@@ -524,6 +530,12 @@ misconfigured or malicious server. It is RECOMMENDED to use 4 MiB
 as the default limit. Implementations MAY allow this limit to be configured. If
 the limit is exceeded, the client MUST treat the response as a non-retryable
 error and SHOULD record the fact that the response was discarded.
+
+The server MUST limit the size of the response body, including before
+compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
+as the default limit. Implementations MAY allow this limit to be configured. If
+the limit is exceeded, the server MUST NOT send the oversized response body and
+SHOULD record the fact that the response was discarded.
 
 The server MUST set "Content-Type: application/x-protobuf" header if the
 response body is binary-encoded Protobuf payload. The server MUST set

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -193,10 +193,11 @@ compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
 as the default limit. Implementations MAY allow this limit to be configured.
 For a [Partial Success](#partial-success) response that would otherwise exceed
 the limit, the server MUST reduce the response size without changing response
-semantics. To do so, the server MAY decrease the verbosity of optional
-diagnostic fields, such as `partial_success.error_message`, or omit optional
-diagnostic fields. If the response cannot fit within the limit, the server MUST
-fail the request with the `RESOURCE_EXHAUSTED` code as a non-retryable error.
+semantics if it is possible. To do so, the server MAY decrease the verbosity of
+optional diagnostic fields, such as `partial_success.error_message`, or omit
+optional diagnostic fields. If the response cannot fit within the limit, the
+server MUST fail the request with the `RESOURCE_EXHAUSTED` code as a
+non-retryable error.
 
 ##### Full Success
 
@@ -541,10 +542,10 @@ compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
 as the default limit. Implementations MAY allow this limit to be configured.
 For a [Partial Success](#partial-success-1) response that would otherwise exceed
 the limit, the server MUST reduce the response size without changing response
-semantics. To do so, the server MAY decrease the verbosity of optional
-diagnostic fields, such as `partial_success.error_message`, or omit optional
-diagnostic fields. If the response cannot fit within the limit, the server MUST
-fail the request with `HTTP 500 Internal Server Error`.
+semantics if it is possible. To do so, the server MAY decrease the verbosity of
+optional diagnostic fields, such as `partial_success.error_message`, or omit
+optional diagnostic fields. If the response cannot fit within the limit, the
+server MUST fail the request with `HTTP 500 Internal Server Error`.
 
 The server MUST set "Content-Type: application/x-protobuf" header if the
 response body is binary-encoded Protobuf payload. The server MUST set

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -190,13 +190,13 @@ reporting a `RESOURCE_EXHAUSTED` code to the caller.
 
 The server MUST limit the size of the response message, including before
 compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
-as the default limit. Implementations MAY allow this limit to be configured. For
-a [Partial Success](#partial-success) response, if necessary, the server MUST
-reduce the response size by shortening or omitting optional diagnostic fields,
-such as `partial_success.error_message`, if doing so preserves the response
-semantics so that the response message does not exceed the limit. If the
-response cannot fit within the limit, the server MUST fail the request with
-the `RESOURCE_EXHAUSTED` code as a non-retryable error.
+as the default limit. Implementations MAY allow this limit to be configured.
+For a [Partial Success](#partial-success) response that would otherwise exceed
+the limit, the server MUST reduce the response size without changing response
+semantics. To do so, the server MAY decrease the verbosity of optional
+diagnostic fields, such as `partial_success.error_message`, or omit optional
+diagnostic fields. If the response cannot fit within the limit, the server MUST
+fail the request with the `RESOURCE_EXHAUSTED` code as a non-retryable error.
 
 ##### Full Success
 
@@ -538,13 +538,13 @@ error and SHOULD record the fact that the response was discarded.
 
 The server MUST limit the size of the response body, including before
 compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
-as the default limit. Implementations MAY allow this limit to be configured. For
-a [Partial Success](#partial-success-1) response, if necessary, the server MUST
-reduce the response size by shortening or omitting optional diagnostic fields,
-such as `partial_success.error_message`, if doing so preserves the response
-semantics so that the response body does not exceed the limit. If the response
-cannot fit within the limit, the server MUST fail the request with
-`HTTP 500 Internal Server Error`.
+as the default limit. Implementations MAY allow this limit to be configured.
+For a [Partial Success](#partial-success-1) response that would otherwise exceed
+the limit, the server MUST reduce the response size without changing response
+semantics. To do so, the server MAY decrease the verbosity of optional
+diagnostic fields, such as `partial_success.error_message`, or omit optional
+diagnostic fields. If the response cannot fit within the limit, the server MUST
+fail the request with `HTTP 500 Internal Server Error`.
 
 The server MUST set "Content-Type: application/x-protobuf" header if the
 response body is binary-encoded Protobuf payload. The server MUST set

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -192,8 +192,8 @@ The server MUST limit the size of the response message, including before
 compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
 as the default limit. Implementations SHOULD allow this limit to be configured.
 For a [Partial Success](#partial-success) response that would otherwise exceed
-the limit, the server MUST reduce the response size without changing response
-semantics if it is possible. To do so, the server MAY decrease the verbosity of
+the limit, the server SHOULD reduce the response size without changing response
+semantics if it is possible and practical. To do so, the server MAY decrease the verbosity of
 optional diagnostic fields, such as `partial_success.error_message`, or omit
 optional diagnostic fields. If the response still cannot fit within the limit,
 the server MUST fail the request with the `RESOURCE_EXHAUSTED` code as a
@@ -542,8 +542,8 @@ The server MUST limit the size of the response body, including before
 compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
 as the default limit. Implementations SHOULD allow this limit to be configured.
 For a [Partial Success](#partial-success-1) response that would otherwise exceed
-the limit, the server MUST reduce the response size without changing response
-semantics if it is possible. To do so, the server MAY decrease the verbosity of
+the limit, the server SHOULD reduce the response size without changing response
+semantics if it is possible and practical. To do so, the server MAY decrease the verbosity of
 optional diagnostic fields, such as `partial_success.error_message`, or omit
 optional diagnostic fields. If the response still cannot fit within the limit,
 the server MUST fail the request with `HTTP 500 Internal Server Error`. After

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -193,12 +193,13 @@ compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
 as the default limit. Implementations SHOULD allow this limit to be configured.
 For a [Partial Success](#partial-success) response that would otherwise exceed
 the limit, the server SHOULD reduce the response size without changing response
-semantics if it is possible and practical. To do so, the server MAY decrease the verbosity of
-optional diagnostic fields, such as `partial_success.error_message`, or omit
-optional diagnostic fields. If the response still cannot fit within the limit,
-the server MUST fail the request with the `RESOURCE_EXHAUSTED` code as a
-non-retryable error. After such a failure, whether any telemetry data from the
-request was accepted is unspecified.
+semantics if it is possible and practical. To do so, the server MAY decrease the
+verbosity of optional diagnostic fields, such as
+`partial_success.error_message`, or omit optional diagnostic fields. If the
+response still cannot fit within the limit, the server MUST fail the request
+with the `RESOURCE_EXHAUSTED` code as a non-retryable error. After such a
+failure, whether any telemetry data from the request was accepted is
+unspecified.
 
 ##### Full Success
 
@@ -543,12 +544,12 @@ compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
 as the default limit. Implementations SHOULD allow this limit to be configured.
 For a [Partial Success](#partial-success-1) response that would otherwise exceed
 the limit, the server SHOULD reduce the response size without changing response
-semantics if it is possible and practical. To do so, the server MAY decrease the verbosity of
-optional diagnostic fields, such as `partial_success.error_message`, or omit
-optional diagnostic fields. If the response still cannot fit within the limit,
-the server MUST fail the request with `HTTP 500 Internal Server Error`. After
-such a failure, whether any telemetry data from the request was accepted is
-unspecified.
+semantics if it is possible and practical. To do so, the server MAY decrease the
+verbosity of optional diagnostic fields, such as
+`partial_success.error_message`, or omit optional diagnostic fields. If the
+response still cannot fit within the limit, the server MUST fail the request
+with `HTTP 500 Internal Server Error`. After such a failure, whether any
+telemetry data from the request was accepted is unspecified.
 
 The server MUST set "Content-Type: application/x-protobuf" header if the
 response body is binary-encoded Protobuf payload. The server MUST set

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -195,9 +195,10 @@ For a [Partial Success](#partial-success) response that would otherwise exceed
 the limit, the server MUST reduce the response size without changing response
 semantics if it is possible. To do so, the server MAY decrease the verbosity of
 optional diagnostic fields, such as `partial_success.error_message`, or omit
-optional diagnostic fields. If the response cannot fit within the limit, the
-server MUST fail the request with the `RESOURCE_EXHAUSTED` code as a
-non-retryable error.
+optional diagnostic fields. If the response still cannot fit within the limit,
+the server MUST fail the request with the `RESOURCE_EXHAUSTED` code as a
+non-retryable error and MUST NOT partially accept telemetry data from the
+request.
 
 ##### Full Success
 
@@ -544,8 +545,9 @@ For a [Partial Success](#partial-success-1) response that would otherwise exceed
 the limit, the server MUST reduce the response size without changing response
 semantics if it is possible. To do so, the server MAY decrease the verbosity of
 optional diagnostic fields, such as `partial_success.error_message`, or omit
-optional diagnostic fields. If the response cannot fit within the limit, the
-server MUST fail the request with `HTTP 500 Internal Server Error`.
+optional diagnostic fields. If the response still cannot fit within the limit,
+the server MUST fail the request with `HTTP 500 Internal Server Error` and MUST
+NOT partially accept telemetry data from the request.
 
 The server MUST set "Content-Type: application/x-protobuf" header if the
 response body is binary-encoded Protobuf payload. The server MUST set

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -190,8 +190,10 @@ implementations are reporting a `RESOURCE_EXHAUSTED` code to the caller.
 The server MUST limit the size of the response message, including before
 compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
 as the default limit. Implementations MAY allow this limit to be configured. If
-the limit is exceeded, the server MUST NOT send the oversized response message
-and SHOULD record the fact that the response was discarded.
+necessary, the server MUST reduce the response size by shortening
+or omitting optional diagnostic fields, such as `partial_success.error_message`,
+if doing so preserves the response semantics so that the response message does
+not exceed the limit.
 
 ##### Full Success
 
@@ -534,8 +536,10 @@ error and SHOULD record the fact that the response was discarded.
 The server MUST limit the size of the response body, including before
 compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
 as the default limit. Implementations MAY allow this limit to be configured. If
-the limit is exceeded, the server MUST NOT send the oversized response body and
-SHOULD record the fact that the response was discarded.
+necessary, the server MUST reduce the response size by shortening
+or omitting optional diagnostic fields, such as `partial_success.error_message`,
+if doing so preserves the response semantics so that the response body does
+not exceed the limit.
 
 The server MUST set "Content-Type: application/x-protobuf" header if the
 response body is binary-encoded Protobuf payload. The server MUST set

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -190,7 +190,7 @@ reporting a `RESOURCE_EXHAUSTED` code to the caller.
 
 The server MUST limit the size of the response message, including before
 compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
-as the default limit. Implementations MAY allow this limit to be configured.
+as the default limit. Implementations SHOULD allow this limit to be configured.
 For a [Partial Success](#partial-success) response that would otherwise exceed
 the limit, the server MUST reduce the response size without changing response
 semantics if it is possible. To do so, the server MAY decrease the verbosity of
@@ -540,7 +540,7 @@ error and SHOULD record the fact that the response was discarded.
 
 The server MUST limit the size of the response body, including before
 compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
-as the default limit. Implementations MAY allow this limit to be configured.
+as the default limit. Implementations SHOULD allow this limit to be configured.
 For a [Partial Success](#partial-success-1) response that would otherwise exceed
 the limit, the server MUST reduce the response size without changing response
 semantics if it is possible. To do so, the server MAY decrease the verbosity of

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -189,11 +189,13 @@ implementations are reporting a `RESOURCE_EXHAUSTED` code to the caller.
 
 The server MUST limit the size of the response message, including before
 compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
-as the default limit. Implementations MAY allow this limit to be configured. If
-necessary, the server MUST reduce the response size by shortening
-or omitting optional diagnostic fields, such as `partial_success.error_message`,
-if doing so preserves the response semantics so that the response message does
-not exceed the limit.
+as the default limit. Implementations MAY allow this limit to be configured. For
+a [Partial Success](#partial-success) response, if necessary, the server MUST
+reduce the response size by shortening or omitting optional diagnostic fields,
+such as `partial_success.error_message`, if doing so preserves the response
+semantics so that the response message does not exceed the limit. If the
+response cannot fit within the limit, the server MUST fail the request with
+the `RESOURCE_EXHAUSTED` code as a non-retryable error.
 
 ##### Full Success
 
@@ -535,11 +537,13 @@ error and SHOULD record the fact that the response was discarded.
 
 The server MUST limit the size of the response body, including before
 compression, to avoid overwhelming the client. It is RECOMMENDED to use 4 MiB
-as the default limit. Implementations MAY allow this limit to be configured. If
-necessary, the server MUST reduce the response size by shortening
-or omitting optional diagnostic fields, such as `partial_success.error_message`,
-if doing so preserves the response semantics so that the response body does
-not exceed the limit.
+as the default limit. Implementations MAY allow this limit to be configured. For
+a [Partial Success](#partial-success-1) response, if necessary, the server MUST
+reduce the response size by shortening or omitting optional diagnostic fields,
+such as `partial_success.error_message`, if doing so preserves the response
+semantics so that the response body does not exceed the limit. If the response
+cannot fit within the limit, the server MUST fail the request with
+`HTTP 500 Internal Server Error`.
 
 The server MUST set "Content-Type: application/x-protobuf" header if the
 response body is binary-encoded Protobuf payload. The server MUST set


### PR DESCRIPTION
## Changes

Adds server-side OTLP response size limit requirements:

- OTLP/gRPC servers MUST limit response message size before compression.
- OTLP/HTTP servers MUST limit response body size before compression.
- If a Partial Success response would otherwise exceed the limit, the server SHOULD reduce the response size without changing response semantics if it is possible and practical.
- To reduce the response size, the server MAY decrease the verbosity of optional diagnostic fields, such as `partial_success.error_message`, or omit optional diagnostic fields.
- If the response still cannot fit within the limit, the server MUST fail the request. After such a failure, whether any telemetry data from the request was accepted is unspecified.
- OTLP/gRPC servers MUST fail this request with the `RESOURCE_EXHAUSTED` code as a non-retryable error.
- OTLP/HTTP servers MUST fail this request with `HTTP 500 Internal Server Error`.
- Reuses the existing recommended default response limit of 4 MiB.

## Motivation

The specification already requires clients to enforce response size limits when receiving responses. This change completes the server-side behavior so servers avoid producing responses that can overwhelm clients.

This is inspired by the work done in [open-telemetry/opamp-spec#346](https://github.com/open-telemetry/opamp-spec/pull/346).

Follows [open-telemetry/opentelemetry-proto#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781).