### PR TITLE
docs: client response limit SHOULD be configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The full list of changes can be found in the compare view for the respective rel
 ### Added
 
 - docs: add request size limitation for HTTP body and gRPC messages. [#782](https://github.com/open-telemetry/opentelemetry-proto/pull/782)
-- docs: add response size limitation for HTTP body and gRPC messages. [#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781)
+- docs: add response size limitation for HTTP body and gRPC messages. [#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781), [#802](https://github.com/open-telemetry/opentelemetry-proto/pull/802)
 
 ### Changed
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -182,8 +182,8 @@ the specific message to use in the [Full Success](#full-success),
 The client MUST enforce a message size limit when receiving the response to
 mitigate possible excessive memory usage caused by a misconfigured or malicious
 server. gRPC client implementations typically enforce a default incoming message
-size limit of 4 MiB, which is acceptable to use. Implementations MAY allow this
-limit to be configured. If the limit is exceeded, the client MUST treat the
+size limit of 4 MiB, which is acceptable to use. Implementations SHOULD allow
+this limit to be configured. If the limit is exceeded, the client MUST treat the
 response as a non-retryable error. Note that in such scenario, the gRPC client
 implementations are reporting a `RESOURCE_EXHAUSTED` code to the caller.
 
@@ -521,8 +521,8 @@ below for the specific message to use in the [Full Success](#full-success-1),
 The client MUST limit the size of the response body when parsing it, including
 after decompression, to mitigate possible excessive memory usage caused by a
 misconfigured or malicious server. It is RECOMMENDED to use 4 MiB
-as the default limit. Implementations MAY allow this limit to be configured. If
-the limit is exceeded, the client MUST treat the response as a non-retryable
+as the default limit. Implementations SHOULD allow this limit to be configured.
+If the limit is exceeded, the client MUST treat the response as a non-retryable
 error and SHOULD record the fact that the response was discarded.
 
 The server MUST set "Content-Type: application/x-protobuf" header if the


### PR DESCRIPTION
Later in https://github.com/open-telemetry/opentelemetry-proto/pull/782 we agreed that the limits SHOULD be configurable and we want to also allow configuration via declarative config. This also improves consistency in the specification. 