### PR TITLE
Fix wording in README regarding language libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ and the corresponding Language Independent Interface Types ([.proto files](opent
 
 The proto files can be consumed as GIT submodules or copied and built directly in the consumer project.
 
-The compiled files are published to central repositories (Maven, ...) from OpenTelemetry client libraries.
+OpenTelemetry [language libraries](https://opentelemetry.io/docs/languages/) may 
+publish generated language bindings. Check the documentation of the language 
+library you are using for more details.
 
 See [contribution guidelines](CONTRIBUTING.md) if you would like to make any changes.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ and the corresponding Language Independent Interface Types ([.proto files](opent
 
 The proto files can be consumed as GIT submodules or copied and built directly in the consumer project.
 
-OpenTelemetry [language libraries](https://opentelemetry.io/docs/languages/) may 
-publish generated language bindings. Check the documentation of the language 
+OpenTelemetry [language libraries](https://opentelemetry.io/docs/languages/) may
+publish generated language bindings. Check the documentation of the language
 library you are using for more details.
 
 See [contribution guidelines](CONTRIBUTING.md) if you would like to make any changes.


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-proto/issues/670

The wording is currently confusing. This makes it clear that some languages may publish bindings and that it won't be in this repo.