### PR TITLE
Retry-After can be an HTTP-date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The full list of changes can be found in the compare view for the respective rel
 
 ### Fixed
 
+- docs: clarify that `Retry-After` header value can be an HTTP-date. [#806](https://github.com/open-telemetry/opentelemetry-proto/pull/806)
+
 ### Removed
 
 ## 1.10.0 - 2026-03-09

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -638,7 +638,9 @@ If the server receives more requests than the client is allowed or the server is
 overloaded, the server SHOULD respond with `HTTP 429 Too Many Requests` or
 `HTTP 503 Service Unavailable` and MAY include
 ["Retry-After"](https://tools.ietf.org/html/rfc7231#section-7.1.3) header to
-indicate how long the client ought to wait before retrying.
+indicate how long the client ought to wait before retrying. Note that the value
+can be either an HTTP-date or a number of seconds to delay after the response is
+received.
 
 The client SHOULD honour the waiting interval specified in the "Retry-After"
 header if it is present. If the client receives a retryable error code (see

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -642,8 +642,8 @@ indicate how long the client ought to wait before retrying. Note that the value
 can be either an HTTP-date or a number of seconds to delay after the response is
 received.
 
-The client SHOULD honour the waiting interval specified in the "Retry-After"
-header if it is present. If the client receives a retryable error code (see
+The client SHOULD honour the value specified in the "Retry-After" header if it is
+present. If the client receives a retryable error code (see
 [table above](#retryable-response-codes)) and the "Retry-After" header is
 not present in the response, then the client SHOULD implement an exponential backoff
 strategy between retries.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -637,8 +637,8 @@ response.
 If the server receives more requests than the client is allowed or the server is
 overloaded, the server SHOULD respond with `HTTP 429 Too Many Requests` or
 `HTTP 503 Service Unavailable` and MAY include
-["Retry-After"](https://tools.ietf.org/html/rfc7231#section-7.1.3) header with a
-recommended time interval in seconds to wait before retrying.
+["Retry-After"](https://tools.ietf.org/html/rfc7231#section-7.1.3) header to
+indicate how long the client ought to wait before retrying.
 
 The client SHOULD honour the waiting interval specified in the "Retry-After"
 header if it is present. If the client receives a retryable error code (see


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-proto/issues/805



`Retry-After` header according to https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.3 can be either an HTTP-date or a number of seconds to delay after the response is received.

Prototype: https://github.com/open-telemetry/opentelemetry-go/pull/8417

The collector is already compliant:
- https://github.com/open-telemetry/opentelemetry-collector/blob/a345b4e43d33fcc3e32516d7a22ccb9403246b12/exporter/otlphttpexporter/otlp.go#L242-L253

Some information according to AI below

- Java OTLP/HTTP exporter :question: 
  - Does not handle `Retry-After` as HTTP-date.
  - **Appears not to honor `Retry-After` at all in the inspected retry paths.**
  - Retry loops use configured exponential backoff/jitter and retryable status codes, without reading the response header.

- Python OTLP/HTTP exporter :question: 
  - Does not handle `Retry-After` as HTTP-date.
  - **Appears not to honor `Retry-After` at all in the inspected retry paths.**
  - Retry loops use exponential backoff, not the response header.
  - Note: the inspected `_is_retryable` helper marks `408` and `5xx` retryable; `429` is not included.

- C++ OTLP/HTTP retry preview :question: 
  - Does not handle `Retry-After` as HTTP-date.
  - **Appears not to honor `Retry-After` at all in the inspected retry path.**
  - Retry preview checks retryable status codes and computes retry delay from configured retry policy.

- Go SDK OTLP/HTTP exporters :x: 
  - Does not handle `Retry-After` as HTTP-date.
  - Supports numeric `delay-seconds` only.
  - Trace, metrics, and logs HTTP exporters parse `Retry-After` using integer parsing and multiply by seconds.

- .NET OTLP exporter :x: 
  - Does not handle `Retry-After` as HTTP-date.
  - Supports `Retry-After` delta-seconds only.
  - The inspected code reads `responseHeaders?.RetryAfter?.Delta` but not `RetryAfter.Date`.

- JavaScript OTLP exporter base :heavy_check_mark: 
  - Handles `Retry-After` as HTTP-date.
  - Parses numeric seconds first, then falls back to date parsing.

- PHP SDK HTTP export utilities  :heavy_check_mark: 
  - Handles `Retry-After` as HTTP-date.
  - Parses numeric seconds and date values.

- Ruby OTLP HTTP exporters  :heavy_check_mark: 
  - Handles `Retry-After` as HTTP-date.
  - Parses numeric seconds and HTTP-date values.

- Rust OTLP HTTP exporter  :heavy_check_mark: 
  - Handles `Retry-After` as HTTP-date when `experimental-http-retry` is enabled.
  - This support is behind the `experimental-http-retry` feature and is not enabled by default.

- OpenTelemetry Collector `otlphttpexporter`  :heavy_check_mark: 
  - Handles `Retry-After` as HTTP-date.
  - Parses numeric seconds and RFC1123 HTTP-date values.
