### PR TITLE
Add EntityRef ID context type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The full list of changes can be found in the compare view for the respective rel
 
 - docs: add request size limitation for HTTP body and gRPC messages. [#782](https://github.com/open-telemetry/opentelemetry-proto/pull/782)
 - docs: add response size limitation for HTTP body and gRPC messages. [#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781), [#800](https://github.com/open-telemetry/opentelemetry-proto/pull/800), [#802](https://github.com/open-telemetry/opentelemetry-proto/pull/802)
+- common: add `id_context_type` to `EntityRef`.
 
 ### Changed
 

--- a/opentelemetry/proto/common/v1/common.proto
+++ b/opentelemetry/proto/common/v1/common.proto
@@ -151,4 +151,10 @@ message EntityRef {
   // These attribute keys are not part of entity's identity.
   // These keys MUST exist in the containing {message}.attributes.
   repeated string description_keys = 4;
+
+  // Type of the entity that establishes the context within which this entity's ID is unique.
+  // For entities with globally unique IDs, this field MUST be empty.
+  // For entities with locally unique IDs, this field SHOULD contain the type of the context
+  // entity present on the same Resource. It MAY be empty when the context is unknown.
+  string id_context_type = 5;
 }


### PR DESCRIPTION
Adds `EntityRef.id_context_type` to carry the identity context type proposed in open-telemetry/opentelemetry-specification#5067.