### PR TITLE
profiles: improve documentation on single value without timestamp

### DIFF
--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -390,8 +390,8 @@ message ValueType {
 //    values: []
 //    timestamps_unix_nano: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 //
-// Aggregated value without timestamps:
-//   values: [10]
+// Single aggregated value without timestamps (one element representing the total):
+//    values: [10]
 //    timestamps_unix_nano: []
 //
 // Per-timestamp value (each point in time records a specific value):


### PR DESCRIPTION
Clarify the second case of the three possible and supported sample/timestamp combinations and point out that only a single value without timestamp is expected.

For visibility: @open-telemetry/profiling-approvers 