### PR TITLE
Add an agentic issue triage skill

### DIFF
--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: issue-triage
 description: This project skill defines a systematic workflow to harvest, categorize, cluster, and prioritize open issues in the `open-telemetry/opentelemetry-proto` repository.
-
 ---
 
-## 🛠️ Step-by-Step Triage Instructions
+## Step-by-Step Triage Instructions
 
-### 📥 Phase 1: Tool-Agnostic Harvesting
+### Phase 1: Tool-Agnostic Harvesting
+
 * **Goal**: Download all open issues into a unified JSON dataset (`.agents/triage/open_issues.json`) to serve as the single source of truth.
 * **Agent Guidelines**:
   - Do not force specific helper modules. Harvest using whatever interface is active:
@@ -17,14 +17,16 @@ description: This project skill defines a systematic workflow to harvest, catego
     - Using the Github MCP tool1
   - Mandatory dataset properties: Issue number, title, body markdown, tags/labels, comments count, creation date, and author username.
 
-### 🔍 Phase 2: Semantic Similarity Clustering
+### Phase 2: Semantic Similarity Clustering
+
 * **Goal**: Scan the active dataset to detect duplicates, tracking epics, and overlapping problem clusters.
 * **Target Convergence Clusters**:
   - **Cluster A: Profiles Serialization & Merging**: Group feedback on the experimental profiling signal spec (e.g. issues concerning `ProfilesDictionary` optimization, global vs resource-level dictionaries, attribute units reinvention, sample length validation).
   - **Cluster B: Bazel, Build, & BCR Publishing**: Group build integration issues (e.g. broken Bazel Central Registry tagging releases, lack of version identification in archives, Renovate dashboards).
   - **Cluster C: OTLP Transport, Responses, & Retries**: Group network recovery feedback (e.g. OTLP/HTTP failure decoding crashes, infinite Retry-After loops, log partial-success indexes).
 
-### 🏷️ Phase 3: Multidimensional Categorization Schema
+### Phase 3: Multidimensional Categorization Schema
+
 * **Goal**: Map every harvested issue precisely along three independent technical axes:
 
 | Classification Axis | Permitted Categories | Mapping Rules |
@@ -33,15 +35,18 @@ description: This project skill defines a systematic workflow to harvest, catego
 | **2. Technical Area** | `Core Protocol/Schema`, `Build Systems & CI/CD`, `Documentation & Examples`, `Ecosystem Integration` | Map to `Core Protocol` if it targets `.proto` file declarations, and `Build Systems` if it concerns compilers, make files, or module packaging. |
 | **3. Issue Nature** | `Bug Fix`, `Enhancement`, `Specification Clarification`, `Chore/Cleanup`, `Invalid` | Map to `Clarification` if it targets documentation ambiguities or TODO items, and `Invalid` if it is spam. |
 
-### 📂 Phase 4: Strategic Theme Synthesis (Signal Insulation)
+### Phase 4: Strategic Theme Synthesis (Signal Insulation)
+
 * **Goal**: Synthesize individual categories into unified epic initiatives.
 * **Agent Guideline**:
   - **Insulate Profiling Spec Work**: The experimental **Profiles** signal spec is under active development by a dedicated Special Interest Group (SIG). Keep all Profiling issues bundled under a single tracking track to prevent experimental layout details from bleeding into stable telemetry signals (Traces, Metrics, Logs).
 
-### 🏆 Phase 5: Dynamic Roadmap Prioritization Engine
+### Phase 5: Dynamic Roadmap Prioritization Engine
+
 * **Goal**: Score, sort, and prioritize categorized themes and issues dynamically on the fly, avoiding hardcoded mappings. Priorities MUST be drawn from live ecosystem states.
 
-#### 📡 Ecosystem Priority Discovery & Search Pathways
+#### Ecosystem Priority Discovery & Search Pathways
+
 AI agents MUST dynamically harvest priority milestones at runtime:
 1. **Local Repository Audit**:
    - Check the repository root context for a `ROADMAP.md` or `.github/ROADMAP.md` manifest if available.
@@ -52,7 +57,8 @@ AI agents MUST dynamically harvest priority milestones at runtime:
 3. **Execution Safety Rule**:
    - Since GitHub API file fetching tools (such as `get_file_contents` or `search_code`) may return file metadata rather than inline string content, or can place downloaded files outside the workspace search path, the agent MUST fallback to a direct Python programmatic fetch (via `urllib.request`) if local workspace searches for `roadmap.md` return empty.
 
-#### 🧮 Dynamic Semantic Reconciliation Rules
+#### Dynamic Semantic Reconciliation Rules
+
 Audit the categorized themes and issues against the fetched community priorities (e.g. OTel central P0, P1, P2 tiers):
 - **OTel P0: Existing Artifacts Maintenance & Stabilizations**: 
   - *Mapping target*: Direct priority targets to issues affecting baseline build stability, core dependency upgrades, tagging workflows (Bazel/BCR/VERSION), and multi-architecture compiler runner bugs blocking Collector/SDK developers.
@@ -63,7 +69,8 @@ Audit the categorized themes and issues against the fetched community priorities
 - **OTel Backlog (Dynamic logging, CI/CD signals)**:
   - *Mapping target*: Defer to lowest priority category; prioritize minor doc Hugo edits or legacy TODO comment cleanups.
 
-#### 🏆 Prioritized Roadmap Matrix Generation
+#### Prioritized Roadmap Matrix Generation
+
 Output the finalized prioritized roadmap matrix sorted dynamically by these live mapped categories: OTel P0 (P1 Local), OTel P1 (P2 Local), OTel P2 (P3 Local), and OTel Backlog (P4 Local).
 
 The matrix MUST be delivered to the `ISSUE_TRIAGE.md` file.

--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: issue-triage
+description: This project skill defines a systematic workflow to harvest, categorize, cluster, and prioritize open issues in the `open-telemetry/opentelemetry-proto` repository.
+
+---
+
+## 🛠️ Step-by-Step Triage Instructions
+
+### 📥 Phase 1: Tool-Agnostic Harvesting
+* **Goal**: Download all open issues into a unified JSON dataset (`.agents/triage/open_issues.json`) to serve as the single source of truth.
+* **Agent Guidelines**:
+  - Do not force specific helper modules. Harvest using whatever interface is active:
+    - **GitHub CLI**: `gh issue list --state open --limit 100 --json number,title,body,labels,comments,createdAt,updatedAt,author`
+    - **GitHub REST/GraphQL API**: Query the endpoint directly, filtering by state = open.
+    - **Local File System**: If a local data backup exists, parse it directly using standard library parsers.
+    - Using the Github MCP tool
+  - Mandatory dataset properties: Issue number, title, body markdown, tags/labels, comments count, creation date, and author username.
+
+### 🔍 Phase 2: Semantic Similarity Clustering
+* **Goal**: Scan the active dataset to detect duplicates, tracking epics, and overlapping problem clusters.
+* **Target Convergence Clusters**:
+  - **Cluster A: Profiles Serialization & Merging**: Group feedback on the experimental profiling signal spec (e.g. issues concerning `ProfilesDictionary` optimization, global vs resource-level dictionaries, attribute units reinvention, sample length validation).
+  - **Cluster B: Bazel, Build, & BCR Publishing**: Group build integration issues (e.g. broken Bazel Central Registry tagging releases, lack of version identification in archives, Renovate dashboards).
+  - **Cluster C: OTLP Transport, Responses, & Retries**: Group network recovery feedback (e.g. OTLP/HTTP failure decoding crashes, infinite Retry-After loops, log partial-success indexes).
+
+### 🏷️ Phase 3: Multidimensional Categorization Schema
+* **Goal**: Map every harvested issue precisely along three independent technical axes:
+
+| Classification Axis | Permitted Categories | Mapping Rules |
+| :--- | :--- | :--- |
+| **1. Telemetry Signal** | `Traces`, `Metrics`, `Logs`, `Profiles`, `Common` | Map to `Common` if it concerns general protocol features (attributes, failure formats, retries) sharing multiple signal types. |
+| **2. Technical Area** | `Core Protocol/Schema`, `Build Systems & CI/CD`, `Documentation & Examples`, `Ecosystem Integration` | Map to `Core Protocol` if it targets `.proto` file declarations, and `Build Systems` if it concerns compilers, make files, or module packaging. |
+| **3. Issue Nature** | `Bug Fix`, `Enhancement`, `Specification Clarification`, `Chore/Cleanup`, `Invalid` | Map to `Clarification` if it targets documentation ambiguities or TODO items, and `Invalid` if it is spam. |
+
+### 📂 Phase 4: Strategic Theme Synthesis (Signal Insulation)
+* **Goal**: Synthesize individual categories into unified epic initiatives.
+* **Agent Guideline**:
+  - **Insulate Profiling Spec Work**: The experimental **Profiles** signal spec is under active development by a dedicated Special Interest Group (SIG). Keep all Profiling issues bundled under a single tracking track to prevent experimental layout details from bleeding into stable telemetry signals (Traces, Metrics, Logs).
+
+### 🏆 Phase 5: Dynamic Roadmap Prioritization Engine
+* **Goal**: Score, sort, and prioritize categorized themes and issues dynamically on the fly, avoiding hardcoded mappings. Priorities MUST be drawn from live ecosystem states.
+
+#### 📡 Ecosystem Priority Discovery & Search Pathways
+AI agents MUST dynamically harvest priority milestones at runtime:
+1. **Local Repository Audit**:
+   - Check the repository root context for a `ROADMAP.md` or `.github/ROADMAP.md` manifest if available.
+2. **Global Community Registry Query**:
+   - Query the central standard open-source repository `open-telemetry/community` on GitHub:
+     - Pull and parse the live central project roadmap from `roadmap.md` on the main branch (served raw at `https://raw.githubusercontent.com/open-telemetry/community/main/roadmap.md`).
+     - Query and index active GitHub Projects or Milestones inside `open-telemetry/community` repository if available.
+3. **Execution Safety Rule**:
+   - Since GitHub API file fetching tools (such as `get_file_contents` or `search_code`) may return file metadata rather than inline string content, or can place downloaded files outside the workspace search path, the agent MUST fallback to a direct Python programmatic fetch (via `urllib.request`) if local workspace searches for `roadmap.md` return empty.
+
+#### 🧮 Dynamic Semantic Reconciliation Rules
+Audit the categorized themes and issues against the fetched community priorities (e.g. OTel central P0, P1, P2 tiers):
+- **OTel P0: Existing Artifacts Maintenance & Stabilizations**: 
+  - *Mapping target*: Direct priority targets to issues affecting baseline build stability, core dependency upgrades, tagging workflows (Bazel/BCR/VERSION), and multi-architecture compiler runner bugs blocking Collector/SDK developers.
+- **OTel P1: Core Reliability (OTLP Logs, Transport & Semantic conventions)**:
+  - *Mapping target*: Direct priority targets to critical transport recovers (HTTP failure body decoding crashes, Retry-After lockups, Logs partial success indexes).
+- **OTel P2: New Capabilities & Subsystems (Profiling SIG, Client/RUM)**:
+  - *Mapping target*: Direct priority targets to experimental signal specification blocks (Profiles signal dictionary merges, sample mapping arrays) or browser/client performance improvements.
+- **OTel Backlog (Dynamic logging, CI/CD signals)**:
+  - *Mapping target*: Defer to lowest priority category; prioritize minor doc Hugo edits or legacy TODO comment cleanups.
+
+#### 🏆 Prioritized Roadmap Matrix Generation
+Output the finalized prioritized roadmap matrix sorted dynamically by these live mapped categories: OTel P0 (P1 Local), OTel P1 (P2 Local), OTel P2 (P3 Local), and OTel Backlog (P4 Local).
+
+The matrix MUST be delivered to the `ISSUE_TRIAGE.md` file.

--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -10,10 +10,11 @@ description: This project skill defines a systematic workflow to harvest, catego
 * **Goal**: Download all open issues into a unified JSON dataset (`.agents/triage/open_issues.json`) to serve as the single source of truth.
 * **Agent Guidelines**:
   - Do not force specific helper modules. Harvest using whatever interface is active:
+    - Use the provided `harvest_issues.py` script if python is available.
     - **GitHub CLI**: `gh issue list --state open --limit 100 --json number,title,body,labels,comments,createdAt,updatedAt,author`
     - **GitHub REST/GraphQL API**: Query the endpoint directly, filtering by state = open.
     - **Local File System**: If a local data backup exists, parse it directly using standard library parsers.
-    - Using the Github MCP tool
+    - Using the Github MCP tool1
   - Mandatory dataset properties: Issue number, title, body markdown, tags/labels, comments count, creation date, and author username.
 
 ### 🔍 Phase 2: Semantic Similarity Clustering

--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -3,9 +3,9 @@ name: issue-triage
 description: This project skill defines a systematic workflow to harvest, categorize, cluster, and prioritize open issues in the `open-telemetry/opentelemetry-proto` repository.
 ---
 
-## Step-by-Step Triage Instructions
+# Step-by-Step Triage Instructions
 
-### Phase 1: Tool-Agnostic Harvesting
+## Phase 1: Tool-Agnostic Harvesting
 
 * **Goal**: Download all open issues into a unified JSON dataset (`.agents/triage/open_issues.json`) to serve as the single source of truth.
 * **Agent Guidelines**:
@@ -17,7 +17,7 @@ description: This project skill defines a systematic workflow to harvest, catego
     - Using the Github MCP tool
   - Mandatory dataset properties: Issue number, title, body markdown, tags/labels, comments count, creation date, and author username.
 
-### Phase 2: Semantic Similarity Clustering
+## Phase 2: Semantic Similarity Clustering
 
 * **Goal**: Scan the active dataset to detect duplicates, tracking epics, and overlapping problem clusters.
 * **Target Convergence Clusters**:
@@ -25,7 +25,7 @@ description: This project skill defines a systematic workflow to harvest, catego
   - **Cluster B: Bazel, Build, & BCR Publishing**: Group build integration issues (e.g. broken Bazel Central Registry tagging releases, lack of version identification in archives, Renovate dashboards).
   - **Cluster C: OTLP Transport, Responses, & Retries**: Group network recovery feedback (e.g. OTLP/HTTP failure decoding crashes, infinite Retry-After loops, log partial-success indexes).
 
-### Phase 3: Multidimensional Categorization Schema
+## Phase 3: Multidimensional Categorization Schema
 
 * **Goal**: Map every harvested issue precisely along three independent technical axes:
 
@@ -35,19 +35,20 @@ description: This project skill defines a systematic workflow to harvest, catego
 | **2. Technical Area** | `Core Protocol/Schema`, `Build Systems & CI/CD`, `Documentation & Examples`, `Ecosystem Integration` | Map to `Core Protocol` if it targets `.proto` file declarations, and `Build Systems` if it concerns compilers, make files, or module packaging. |
 | **3. Issue Nature** | `Bug Fix`, `Enhancement`, `Specification Clarification`, `Chore/Cleanup`, `Invalid` | Map to `Clarification` if it targets documentation ambiguities or TODO items, and `Invalid` if it is spam. |
 
-### Phase 4: Strategic Theme Synthesis (Signal Insulation)
+## Phase 4: Strategic Theme Synthesis (Signal Insulation)
 
 * **Goal**: Synthesize individual categories into unified epic initiatives.
 * **Agent Guideline**:
   - **Insulate Profiling Spec Work**: The experimental **Profiles** signal spec is under active development by a dedicated Special Interest Group (SIG). Keep all Profiling issues bundled under a single tracking track to prevent experimental layout details from bleeding into stable telemetry signals (Traces, Metrics, Logs).
 
-### Phase 5: Dynamic Roadmap Prioritization Engine
+## Phase 5: Dynamic Roadmap Prioritization Engine
 
 * **Goal**: Score, sort, and prioritize categorized themes and issues dynamically on the fly, avoiding hardcoded mappings. Priorities MUST be drawn from live ecosystem states.
 
-#### Ecosystem Priority Discovery & Search Pathways
+### Ecosystem Priority Discovery & Search Pathways
 
 AI agents MUST dynamically harvest priority milestones at runtime:
+
 1. **Local Repository Audit**:
    - Check the repository root context for a `ROADMAP.md` or `.github/ROADMAP.md` manifest if available.
 2. **Global Community Registry Query**:
@@ -57,10 +58,11 @@ AI agents MUST dynamically harvest priority milestones at runtime:
 3. **Execution Safety Rule**:
    - Since GitHub API file fetching tools (such as `get_file_contents` or `search_code`) may return file metadata rather than inline string content, or can place downloaded files outside the workspace search path, the agent MUST fallback to a direct Python programmatic fetch (via `urllib.request`) if local workspace searches for `roadmap.md` return empty.
 
-#### Dynamic Semantic Reconciliation Rules
+### Dynamic Semantic Reconciliation Rules
 
 Audit the categorized themes and issues against the fetched community priorities (e.g. OTel central P0, P1, P2 tiers):
-- **OTel P0: Existing Artifacts Maintenance & Stabilizations**: 
+
+- **OTel P0: Existing Artifacts Maintenance & Stabilizations**:
   - *Mapping target*: Direct priority targets to issues affecting baseline build stability, core dependency upgrades, tagging workflows (Bazel/BCR/VERSION), and multi-architecture compiler runner bugs blocking Collector/SDK developers.
 - **OTel P1: Core Reliability (OTLP Logs, Transport & Semantic conventions)**:
   - *Mapping target*: Direct priority targets to critical transport recovers (HTTP failure body decoding crashes, Retry-After lockups, Logs partial success indexes).
@@ -69,7 +71,7 @@ Audit the categorized themes and issues against the fetched community priorities
 - **OTel Backlog (Dynamic logging, CI/CD signals)**:
   - *Mapping target*: Defer to lowest priority category; prioritize minor doc Hugo edits or legacy TODO comment cleanups.
 
-#### Prioritized Roadmap Matrix Generation
+### Prioritized Roadmap Matrix Generation
 
 Output the finalized prioritized roadmap matrix sorted dynamically by these live mapped categories: OTel P0 (P1 Local), OTel P1 (P2 Local), OTel P2 (P3 Local), and OTel Backlog (P4 Local).
 

--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -14,7 +14,7 @@ description: This project skill defines a systematic workflow to harvest, catego
     - **GitHub CLI**: `gh issue list --state open --limit 100 --json number,title,body,labels,comments,createdAt,updatedAt,author`
     - **GitHub REST/GraphQL API**: Query the endpoint directly, filtering by state = open.
     - **Local File System**: If a local data backup exists, parse it directly using standard library parsers.
-    - Using the Github MCP tool1
+    - Using the Github MCP tool
   - Mandatory dataset properties: Issue number, title, body markdown, tags/labels, comments count, creation date, and author username.
 
 ### Phase 2: Semantic Similarity Clustering

--- a/.agents/skills/issue-triage/scripts/harvest_issues.py
+++ b/.agents/skills/issue-triage/scripts/harvest_issues.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Mechanical Data Harvester for OpenTelemetry Protocol Issue Triage.
+
+This script performs ONLY deterministic, tool-agnostic data harvesting:
+1. Downloads open issues into `.agents/triage/open_issues.json`.
+2. Downloads the live community roadmap into `.agents/triage/community_roadmap.md`.
+
+All classification, clustering, prioritization, and synthesis decisions are left
+entirely to the LLM agent during execution of the `/issue-triage` skill.
+"""
+
+import json
+import subprocess
+import urllib.request
+from pathlib import Path
+
+REPO_OWNER = "open-telemetry"
+REPO_NAME = "opentelemetry-proto"
+ROADMAP_URL = "https://raw.githubusercontent.com/open-telemetry/community/main/roadmap.md"
+
+
+def harvest_open_issues(output_path: Path) -> list[dict]:
+    """Fetch open issues from GitHub CLI or REST API into JSON dataset."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # 1. Try gh CLI first
+    try:
+        cmd = [
+            "gh",
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            "100",
+            "--json",
+            "number,title,body,labels,comments,createdAt,updatedAt,author",
+        ]
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=True
+        )
+        raw_issues = json.loads(result.stdout)
+        formatted = []
+        for iss in raw_issues:
+            formatted.append(
+                {
+                    "number": iss.get("number"),
+                    "title": iss.get("title"),
+                    "body": iss.get("body"),
+                    "labels": [
+                        lbl["name"] if isinstance(lbl, dict) else lbl
+                        for lbl in iss.get("labels", [])
+                    ],
+                    "comments": (
+                        len(iss["comments"])
+                        if isinstance(iss.get("comments"), list)
+                        else iss.get("comments", 0)
+                    ),
+                    "createdAt": iss.get("createdAt"),
+                    "author": (
+                        iss.get("author", {}).get("login")
+                        if isinstance(iss.get("author"), dict)
+                        else str(iss.get("author"))
+                    ),
+                }
+            )
+        output_path.write_text(json.dumps(formatted, indent=2))
+        return formatted
+    except Exception:
+        pass
+
+    # 2. Fallback to urllib public REST API
+    api_url = f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/issues?state=open&per_page=100"
+    req = urllib.request.Request(
+        api_url, headers={"User-Agent": "OTel-Harvester"}
+    )
+    with urllib.request.urlopen(req) as resp:
+        raw_issues = json.loads(resp.read().decode("utf-8"))
+
+    formatted = []
+    for iss in raw_issues:
+        if "pull_request" in iss:
+            continue
+        formatted.append(
+            {
+                "number": iss.get("number"),
+                "title": iss.get("title"),
+                "body": iss.get("body"),
+                "labels": [
+                    lbl["name"] if isinstance(lbl, dict) else lbl
+                    for lbl in iss.get("labels", [])
+                ],
+                "comments": iss.get("comments", 0),
+                "createdAt": iss.get("created_at"),
+                "author": (
+                    iss.get("user", {}).get("login")
+                    if isinstance(iss.get("user"), dict)
+                    else str(iss.get("user"))
+                ),
+            }
+        )
+
+    output_path.write_text(json.dumps(formatted, indent=2))
+    return formatted
+
+
+def harvest_community_roadmap(output_path: Path):
+    """Fetch live roadmap markdown from open-telemetry/community repository."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    req = urllib.request.Request(
+        ROADMAP_URL, headers={"User-Agent": "OTel-Harvester"}
+    )
+    with urllib.request.urlopen(req) as resp:
+        text = resp.read().decode("utf-8")
+    output_path.write_text(text)
+
+
+def main():
+    root = Path(__file__).resolve().parents[4]
+    issues_file = root / ".agents" / "triage" / "open_issues.json"
+    roadmap_file = root / ".agents" / "triage" / "community_roadmap.md"
+
+    issues = harvest_open_issues(issues_file)
+    harvest_community_roadmap(roadmap_file)
+
+    print(f"Harvested {len(issues)} open issues -> {issues_file.relative_to(root)}")
+    print(f"Harvested community roadmap -> {roadmap_file.relative_to(root)}")
+    print("Ready for LLM semantic clustering, categorization, and prioritization.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /gen/
 
 node_modules
+
+# Agent state
+.agents/triage/


### PR DESCRIPTION
I spent some time optimising a triage skill for the proto repo.  THere are elements of this that are useful for *other* repositories, but this is focused on Proto, where I think we need some help triaging issues, generally.


[Example output in this comment](https://github.com/open-telemetry/opentelemetry-proto/pull/825#issuecomment-4982978377)