### PR TITLE
Clean up release tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,17 @@
 * text=auto eol=lf
+
+# Export substitution for release archive version identification (#434)
+VERSION export-subst
+
+# Exclude spurious internal tooling and CI files from release tar archives (#604)
+.agents/ export-ignore
+.bcr/ export-ignore
+.github/ export-ignore
+.vscode/ export-ignore
+.gitignore export-ignore
+.lychee.toml export-ignore
+.markdownlint.yaml export-ignore
+buf.yaml export-ignore
+dependencies.Dockerfile export-ignore
+package.json export-ignore
+package-lock.json export-ignore

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,2 @@
+open-telemetry/opentelemetry-proto
+$Format:refnames=%D commit=%H date=%cI$


### PR DESCRIPTION
Fixes #604
Fixes #434

- Add VERSION file with `git export` substring formatting
- Configure `.gitattributes` to ignore non-proto files and deal with VERSION file.