### PR TITLE
Prepare the v1.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,23 @@ The full list of changes can be found in the compare view for the respective rel
 
 ### Added
 
-- docs: add request size limitation for HTTP body and gRPC messages. [#782](https://github.com/open-telemetry/opentelemetry-proto/pull/782)
-- docs: add response size limitation for HTTP body and gRPC messages. [#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781), [#800](https://github.com/open-telemetry/opentelemetry-proto/pull/800), [#801](https://github.com/open-telemetry/opentelemetry-proto/pull/801), [#802](https://github.com/open-telemetry/opentelemetry-proto/pull/802)
-- processcontext: add `ProcessContext` message described in [OTEP 4719](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/4719-process-ctx.md). [#783](https://github.com/open-telemetry/opentelemetry-proto/pull/783)
-
 ### Changed
 
 ### Fixed
 
-- docs: clarify that `Retry-After` header value can be an HTTP-date. [#806](https://github.com/open-telemetry/opentelemetry-proto/pull/806)
-
 ### Removed
+
+## 1.11.0 - 2026-07-21
+
+### Added
+
+- docs: add request size limitation for HTTP body and gRPC messages. [#782](https://github.com/open-telemetry/opentelemetry-proto/pull/782)
+- docs: add response size limitation for HTTP body and gRPC messages. [#781](https://github.com/open-telemetry/opentelemetry-proto/pull/781), [#800](https://github.com/open-telemetry/opentelemetry-proto/pull/800), [#801](https://github.com/open-telemetry/opentelemetry-proto/pull/801), [#802](https://github.com/open-telemetry/opentelemetry-proto/pull/802)
+- processcontext: add `ProcessContext` message described in [OTEP 4719](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/4719-process-ctx.md). [#783](https://github.com/open-telemetry/opentelemetry-proto/pull/783)
+
+### Fixed
+
+- docs: clarify that `Retry-After` header value can be an HTTP-date. [#806](https://github.com/open-telemetry/opentelemetry-proto/pull/806)
 
 ## 1.10.0 - 2026-03-09
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-proto/issues/817.

This release adds documentation on size limitations for HTTP body and gRPC request/response messages, along with a clarification on the Retry-After header format. Additionally, it introduces the ProcessContext message specification to support enhanced process-level telemetry context.