### PR TITLE
Fixes to build for latest docker image of protobuf tools.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ gen-all: gen-cpp gen-csharp gen-go gen-java gen-kotlin gen-objc gen-openapi gen-
 
 DEPENDENCIES_DOCKERFILE=./dependencies.Dockerfile
 
-OTEL_DOCKER_PROTOBUF ?= otel/build-protobuf:0.9.0
+OTEL_DOCKER_PROTOBUF ?= otel/build-protobuf:latest
 BUF_DOCKER ?= bufbuild/buf:1.7.0
 
 PROTOC := docker run --rm -u ${shell id -u} -v${PWD}:${PWD} -w${PWD} ${OTEL_DOCKER_PROTOBUF} --proto_path=${PWD}
@@ -77,7 +77,7 @@ gen-csharp:
 gen-go:
 	rm -rf ./$(PROTO_GEN_GO_DIR)
 	mkdir -p ./$(PROTO_GEN_GO_DIR)
-	$(foreach file,$(PROTO_FILES),$(call exec-command,$(PROTOC) --go_out=plugins=grpc:./$(PROTO_GEN_GO_DIR) $(file)))
+	$(foreach file,$(PROTO_FILES),$(call exec-command,$(PROTOC) --go_out=./$(PROTO_GEN_GO_DIR) --go-grpc_out=./$(PROTO_GEN_GO_DIR) $(file)))
 	$(PROTOC) --grpc-gateway_out=logtostderr=true,grpc_api_configuration=opentelemetry/proto/collector/trace/v1/trace_service_http.yaml:./$(PROTO_GEN_GO_DIR) opentelemetry/proto/collector/trace/v1/trace_service.proto
 	$(PROTOC) --grpc-gateway_out=logtostderr=true,grpc_api_configuration=opentelemetry/proto/collector/metrics/v1/metrics_service_http.yaml:./$(PROTO_GEN_GO_DIR) opentelemetry/proto/collector/metrics/v1/metrics_service.proto
 	$(PROTOC) --grpc-gateway_out=logtostderr=true,grpc_api_configuration=opentelemetry/proto/collector/logs/v1/logs_service_http.yaml:./$(PROTO_GEN_GO_DIR) opentelemetry/proto/collector/logs/v1/logs_service.proto

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,8 @@ all: gen-all markdown-link-check markdownlint markdown-toc
 gen-all: gen-cpp gen-csharp gen-go gen-java gen-kotlin gen-objc gen-openapi gen-php gen-python gen-ruby
 
 DEPENDENCIES_DOCKERFILE=./dependencies.Dockerfile
-
-OTEL_DOCKER_PROTOBUF ?= otel/build-protobuf:latest
-BUF_DOCKER ?= bufbuild/buf:1.7.0
+OTEL_DOCKER_PROTOBUF := $(shell awk '$$4=="build-protobuf" {print $$2}' $(DEPENDENCIES_DOCKERFILE))
+BUF_DOCKER := $(shell awk '$$4=="bufbuild" {print $$2}' $(DEPENDENCIES_DOCKERFILE))
 
 PROTOC := docker run --rm -u ${shell id -u} -v${PWD}:${PWD} -w${PWD} ${OTEL_DOCKER_PROTOBUF} --proto_path=${PWD}
 BUF := docker run --rm -v "${PWD}:/workspace" -w /workspace ${BUF_DOCKER}

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ all: gen-all markdown-link-check markdownlint markdown-toc
 gen-all: gen-cpp gen-csharp gen-go gen-java gen-kotlin gen-objc gen-openapi gen-php gen-python gen-ruby
 
 DEPENDENCIES_DOCKERFILE=./dependencies.Dockerfile
-OTEL_DOCKER_PROTOBUF := $(shell awk '$$4=="build-protobuf" {print $$2}' $(DEPENDENCIES_DOCKERFILE))
-BUF_DOCKER := $(shell awk '$$4=="bufbuild" {print $$2}' $(DEPENDENCIES_DOCKERFILE))
+OTEL_DOCKER_PROTOBUF ?= $(shell awk '$$4=="build-protobuf" {print $$2}' $(DEPENDENCIES_DOCKERFILE))
+BUF_DOCKER ?= $(shell awk '$$4=="bufbuild" {print $$2}' $(DEPENDENCIES_DOCKERFILE))
 
 PROTOC := docker run --rm -u ${shell id -u} -v${PWD}:${PWD} -w${PWD} ${OTEL_DOCKER_PROTOBUF} --proto_path=${PWD}
 BUF := docker run --rm -v "${PWD}:/workspace" -w /workspace ${BUF_DOCKER}

--- a/dependencies.Dockerfile
+++ b/dependencies.Dockerfile
@@ -1,5 +1,5 @@
 # This is a renovate-friendly source of Docker images.
 FROM davidanson/markdownlint-cli2:v0.23.1@sha256:f382ea4fdc949883e79de678009437fb40c339323654c7b0dd4d5221cda8ed20 AS markdownlint
 FROM lycheeverse/lychee:sha-3a09227-alpine@sha256:5853bd7c283663a1200dbb15924a5047f8d4c50adfa7a4c212a94f04bbac831c AS lychee
-FROM otel/build-protobuf:latest AS build-protobuf
+FROM otel/build-protobuf:0.26.0 AS build-protobuf
 FROM bufbuild/buf:1.7.0 AS bufbuild

--- a/dependencies.Dockerfile
+++ b/dependencies.Dockerfile
@@ -1,3 +1,5 @@
 # This is a renovate-friendly source of Docker images.
 FROM davidanson/markdownlint-cli2:v0.23.1@sha256:f382ea4fdc949883e79de678009437fb40c339323654c7b0dd4d5221cda8ed20 AS markdownlint
 FROM lycheeverse/lychee:sha-3a09227-alpine@sha256:5853bd7c283663a1200dbb15924a5047f8d4c50adfa7a4c212a94f04bbac831c AS lychee
+FROM otel/build-protobuf:latest AS build-protobuf
+FROM bufbuild/buf:1.7.0 AS bufbuild


### PR DESCRIPTION
Update our protobuf build verification to latest versions.

- New 'go' protoc plugin has different arguments.
- Update to use `Docker.dependencyfile` for all docker images, so rennovate will propose version bumps.