### PR TITLE
Add special note about UTF-8 handling to help impelmentors.

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -59,7 +59,7 @@ nodes such as collectors and telemetry backends.
 - [Implementation Recommendations](#implementation-recommendations)
   * [Multi-Destination Exporting](#multi-destination-exporting)
   * [Empty Telemetry Envelopes](#empty-telemetry-envelopes)
-    + [UTF-8 String Handling](#utf-8-string-handling)
+  * [UTF-8 String Handling](#utf-8-string-handling)
 - [Known Limitations](#known-limitations)
   * [Request Acknowledgements](#request-acknowledgements)
     + [Duplicate Data](#duplicate-data)
@@ -747,7 +747,7 @@ payloads that contain zero spans, zero metric points or zero log records),
 receivers MAY ignore empty envelopes, and implementations that receive and send
 (forward) OTLP payloads MAY drop empty envelopes.
 
-#### UTF-8 String Handling
+### UTF-8 String Handling
 
 While, by specification, all protocol buffer implementations are required to
 send UTF-8 or ASCII-7 strings, in practice many implementations allow native
@@ -762,19 +762,17 @@ benefit not worth the performance hit.
 
 Consequently:
 
+* Encoders SHOULD ensure `string` fields contain valid UTF-8. Producing
+  invalid UTF-8 is not specification compliant and is considered a bug within
+  OpenTelemetry.
+* Decoders SHOULD be prepared to receive non-compliant strings from permissive
+  runtimes and SHOULD replace invalid UTF-8 sequences (code units) with the
+  Unicode replacement character (`U+FFFD`).
 * Intermediary nodes (such as the OpenTelemetry Collector) are not required
   to perform in-line UTF-8 validation on `string` fields and MAY pass them
-  them through without inspection.
-* Implementations should be aware that many Protobuf runtimes are permissive and
-  allow non-compliant strings to be serialized, which may cause downstream nodes
-  using stricter Protobuf runtimes to fail deserialization. Implementations
-  which do NOT provide valid UTF-8 are not specification compliant, and this is
-  considered a bug within OpenTelemetry.
+  through without inspection.
 * Intermediary components MAY provide optional, configurable validation or
   sanitization.
-* Implementations SHOULD replace invalid UTF-8 sequences (code units) with
-  the Unicode replacement character (`U+FFFD`) when interacting with invalid
-  Unicode strings.
 
 ## Known Limitations
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -772,8 +772,9 @@ Consequently:
   considered a bug within OpenTelemetry.
 * Intermediary components MAY provide optional, configurable validation or
   sanitization.
-* We recommend replacing invalid UTF-8 with the unicode replacement character
-  (`U+FFFD`) when interacting with an invalid string.
+* Implementations SHOULD replace invalid UTF-8 sequences (code units) with
+  the Unicode replacement character (`U+FFFD`) when interacting with invalid
+  Unicode strings. 
 
 ## Known Limitations
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -746,6 +746,34 @@ payloads that contain zero spans, zero metric points or zero log records),
 receivers MAY ignore empty envelopes, and implementations that receive and send
 (forward) OTLP payloads MAY drop empty envelopes.
 
+#### UTF-8 String Handling
+
+While, by specification, all protocol buffer implementations are required to
+send UTF-8 or ASCII-7 strings, in practice many implementations allow native
+byte strings and perform no validation prior to serialization, and sometimes
+deserialization.
+
+This is because validating UTF-8 can be relatively expensive (e.g. requires
+iterating through all bytes, even for an intermediary server, requires
+deserializing the entirety of the protobuf when otherwise just looking at
+outer headers may be acceptable). Many implementations view the correctness
+benefit not worth the performance hit.
+
+Consequently:
+
+* Intermediary nodes (such as the OpenTelemetry Collector) are not required
+  to perform in-line UTF-8 validation on `string` fields and MAY pass them
+  them through without inspection.
+* Implementations should be aware that many Protobuf runtimes are permissive and
+  allow non-compliant strings to be serialized, which may cause downstream nodes
+  using stricter Protobuf runtimes to fail deserialization. Implementations
+  which do NOT provide valid UTF-8 are not specification compliant, and this is
+  considered a bug within OpenTelemetry.
+* Intermediary components MAY provide optional, configurable validation or
+  sanitization.
+* We recommend replacing invalid UTF-8 with the unicode replacement character
+  (`U+FFFD`) when interacting with an invalid string.
+
 ## Known Limitations
 
 ### Request Acknowledgements

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -59,6 +59,7 @@ nodes such as collectors and telemetry backends.
 - [Implementation Recommendations](#implementation-recommendations)
   * [Multi-Destination Exporting](#multi-destination-exporting)
   * [Empty Telemetry Envelopes](#empty-telemetry-envelopes)
+    + [UTF-8 String Handling](#utf-8-string-handling)
 - [Known Limitations](#known-limitations)
   * [Request Acknowledgements](#request-acknowledgements)
     + [Duplicate Data](#duplicate-data)

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -774,7 +774,7 @@ Consequently:
   sanitization.
 * Implementations SHOULD replace invalid UTF-8 sequences (code units) with
   the Unicode replacement character (`U+FFFD`) when interacting with invalid
-  Unicode strings. 
+  Unicode strings.
 
 ## Known Limitations
 


### PR DESCRIPTION
Closes #814 


Updates our policy to be clear:

- We are no stricter than Protobuf itself
- JSON already requires valid UTF-8 string for both sending/parsing so it is unaffected here.
- Offer recommendations to implementors for addressing this issue.