### PR TITLE
docs: fix lychee link failure for slack channel

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -2,7 +2,9 @@ include_fragments = true
 
 exclude = [
     # excluding links to pull requests and issues is done for performance
-    "^https://github.com/open-telemetry/opentelemetry-proto/(pull|issue)/\\d+$"
+    "^https://github.com/open-telemetry/opentelemetry-proto/(pull|issue)/\\d+$",
+    # Slack links can return 403 or fail due to bot protection
+    "^https://.*\\.slack\\.com/.*"
 ]
 
 # better to be safe and avoid failures

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ OpenTelemetry follows the [Protobuf style guide](https://protobuf.dev/programmin
 
 ## Further Help
 
-If you have any questions or need assistance while contributing, feel free to reach out to the [`#otel-specification`](https://cloud-native.slack.com/archives/C01N7PP1THC) Slack channel.
+If you have any questions or need assistance while contributing, feel free to reach out to the [`#otel-specification`](https://app.slack.com/client/T08PSQ7BQ/C01N7PP1THC) channel on the [CNCF Slack](https://slack.cncf.io/).
 View meeting notes of previous SIG calls in this [google doc](https://docs.google.com/spreadsheets/d/1SYKfjYhZdm2Wh2Cl6KVQalKg_m4NhTPZqq-8SzEVO6s/edit?gid=0#gid=0) as stated [here](https://github.com/open-telemetry/community/?tab=readme-ov-file#governing-bodies) to stay up to date.
 
 Also see the [specification](https://github.com/open-telemetry/opentelemetry-specification?tab=readme-ov-file#questions) repo for more info. Thank you.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ OpenTelemetry follows the [Protobuf style guide](https://protobuf.dev/programmin
 
 ## Further Help
 
-If you have any questions or need assistance while contributing, feel free to reach out to the [`#otel-specification`](https://app.slack.com/client/T08PSQ7BQ/C01N7PP1THC) channel on the [CNCF Slack](https://slack.cncf.io/).
+If you have any questions or need assistance while contributing, feel free to reach out to the [`#otel-specification`](https://cloud-native.slack.com/archives/C01N7PP1THC) channel on the [CNCF Slack](https://slack.cncf.io/).
 View meeting notes of previous SIG calls in this [google doc](https://docs.google.com/spreadsheets/d/1SYKfjYhZdm2Wh2Cl6KVQalKg_m4NhTPZqq-8SzEVO6s/edit?gid=0#gid=0) as stated [here](https://github.com/open-telemetry/community/?tab=readme-ov-file#governing-bodies) to stay up to date.
 
 Also see the [specification](https://github.com/open-telemetry/opentelemetry-specification?tab=readme-ov-file#questions) repo for more info. Thank you.


### PR DESCRIPTION
Updates link to one that requires auth - also includes link to CNCF