### PR TITLE
Add `since <version>` requirement to new proto fields and backfill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,21 @@
+# OpenTelemetry Proto Repository Instructions
+
+First-pass PR review rules for OpenTelemetry Protobuf definitions.
+**Prefer silence over uncertainty.** Only flag substantive issues on changed lines.
+Skip stylistic preferences not listed in the guidelines. Do not nitpick.
+
+Do not flag anything CI will catch (compilation errors, `buf lint` issues, `buf breaking` violations, or code formatting).
+
+When flagging issues, cite the relevant rule and link to [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## [Versioning] "Since" Annotations
+Ensure all newly added messages, enums, enum values, fields, and RPCs include a `// [Since next]` comment annotation per [CONTRIBUTING.md#version-annotations-since-labels](../CONTRIBUTING.md#version-annotations-since-labels).
+
+## [Documentation] Explanatory Comments
+Ensure messages and fields have clear, meaningful doc comments written with active verbs or dictionary noun phrases per [CONTRIBUTING.md#documentation-comments](../CONTRIBUTING.md#documentation-comments).
+
+## [Naming] Protobuf Conventions
+Ensure all newly defined identifiers align with [CONTRIBUTING.md#naming-conventions](../CONTRIBUTING.md#naming-conventions).
+
+## [Schema Design] Evolution & Package Placement
+Ensure new experimental signals and capabilities reside in `v1development` packages and follow [CONTRIBUTING.md#schema-evolution-and-compatibility](../CONTRIBUTING.md#schema-evolution-and-compatibility).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,13 +9,17 @@ Do not flag anything CI will catch (compilation errors, `buf lint` issues, `buf 
 When flagging issues, cite the relevant rule and link to [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 ## [Versioning] "Since" Annotations
+
 Ensure all newly added messages, enums, enum values, fields, and RPCs include a `// [Since next]` comment annotation per [CONTRIBUTING.md#version-annotations-since-labels](../CONTRIBUTING.md#version-annotations-since-labels).
 
 ## [Documentation] Explanatory Comments
+
 Ensure messages and fields have clear, meaningful doc comments written with active verbs or dictionary noun phrases per [CONTRIBUTING.md#documentation-comments](../CONTRIBUTING.md#documentation-comments).
 
 ## [Naming] Protobuf Conventions
+
 Ensure all newly defined identifiers align with [CONTRIBUTING.md#naming-conventions](../CONTRIBUTING.md#naming-conventions).
 
 ## [Schema Design] Evolution & Package Placement
+
 Ensure new experimental signals and capabilities reside in `v1development` packages and follow [CONTRIBUTING.md#schema-evolution-and-compatibility](../CONTRIBUTING.md#schema-evolution-and-compatibility).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,12 @@ for general information about the project.
 ## Making Changes to the .proto Files
 
 When proposing schema changes or additions:
+
 1. Ensure all new messages, enums, enum values, and fields include a `// [Since next]` annotation in their leading doc comment (see [Version Annotations](#version-annotations-since-labels)).
 2. Follow the [Schema Evolution and Compatibility](#schema-evolution-and-compatibility) and [Style Guide](#style-guide) rules.
 3. Run `make gen-all` to regenerate implementation stubs across all supported target languages.
 4. Validate schema linting and backward compatibility before opening a pull request:
+
    ```bash
    make check
    ```
@@ -41,12 +43,14 @@ OpenTelemetry protocol definitions are the foundation of the OTLP ecosystem and 
 OpenTelemetry follows the [Protobuf style guide](https://protobuf.dev/programming-guides/style/) with the following clarifications:
 
 ### Naming Conventions
+
 - **Fields**: Use `snake_case` (e.g. `trace_id`, `dropped_attributes_count`).
 - **Messages & Enums**: Use `PascalCase` (e.g. `ResourceMetrics`, `SpanFlags`).
 - **Enum Values**: Use `UPPER_SNAKE_CASE` prefixed with the enum name (e.g. `SPAN_FLAGS_TRACE_FLAGS_MASK`).
 - **Service RPCs**: Use `PascalCase` for RPC methods (e.g. `Export`).
 
 ### Documentation Comments
+
 - All messages, enums, enum values, and fields MUST be documented via comments.
 - Field comments should document purpose or behavior with active verbs, or a simple definition noun phrase (similar to a dictionary entry).
   - valid: "Represents ..."
@@ -58,7 +62,7 @@ OpenTelemetry follows the [Protobuf style guide](https://protobuf.dev/programmin
 
 ### Version Annotations ("Since" Labels)
 
-To assist downstream OTLP implementors in identifying when schema capabilities were introduced post v1.0, any element added MUST include a `[Since ...]` annotation in its doc comment (see [docs/specification.md#capability-versioning--schema-comments](docs/specification.md#capability-versioning--schema-comments)):
+To assist downstream OTLP implementors in identifying when schema capabilities were introduced post v1.0, any element added MUST include a `[Since ...]` annotation in its doc comment (see [docs/specification.md#future-versions-and-interoperability](docs/specification.md#future-versions-and-interoperability)):
 
 Prior to release - use the placeholder `// [Since next]`. During the release process, maintainers will automatically convert this placeholder to the released version tag (e.g. `// [Since v1.11.0]`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,10 @@ When proposing schema changes or additions:
 
 1. Ensure all new messages, enums, enum values, and fields include a `// [Since next]` annotation in their leading doc comment (see [Version Annotations](#version-annotations-since-labels)).
 2. Follow the [Schema Evolution and Compatibility](#schema-evolution-and-compatibility) and [Style Guide](#style-guide) rules.
-3. Run `make gen-all` to regenerate implementation stubs across all supported target languages.
-4. Validate schema linting and backward compatibility before opening a pull request:
+3. Run `make all` to regenerate all language bindings and update documentation:
 
    ```bash
-   make check
+   make all
    ```
 
 ## Schema Evolution and Compatibility

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,24 +16,60 @@ for general information about the project.
 
 - `Docker`
 
-## Making changes to the .proto files
+## Making Changes to the .proto Files
 
-After making any changes to .proto files make sure to generate all
-implementation by running `make gen-all`.
+When proposing schema changes or additions:
+1. Ensure all new messages, enums, enum values, and fields include a `// [Since next]` annotation in their leading doc comment (see [Version Annotations](#version-annotations-since-labels)).
+2. Follow the [Schema Evolution and Compatibility](#schema-evolution-and-compatibility) and [Style Guide](#style-guide) rules.
+3. Run `make gen-all` to regenerate implementation stubs across all supported target languages.
+4. Validate schema linting and backward compatibility before opening a pull request:
+   ```bash
+   make check
+   ```
 
-## Style-Guide
+## Schema Evolution and Compatibility
+
+OpenTelemetry protocol definitions are the foundation of the OTLP ecosystem and demand strict backward compatibility (see [docs/specification.md#future-versions-and-interoperability](docs/specification.md#future-versions-and-interoperability)):
+
+- **Preserve Field Numbers and Types**: Never change the field tag number or data type of an existing field.
+- **Deprecation over Deletion**: Never delete active fields. Mark obsolete fields with `[deprecated = true]`, or explicitly reserve removed field numbers and names using `reserved N;` and `reserved "field_name";`.
+- **Enum Defaults and Unspecified Values**: The zero value of an enum MUST represent the default or unspecified state (`<ENUM_NAME>_UNSPECIFIED = 0;`).
+- **Experimental vs Stable Packages**: New experimental signals and capabilities MUST reside in a `v1development` package (e.g. `profiles/v1development`, `processcontext/v1development`) until they reach maturity and are promoted to `v1`.
+
+## Style Guide
 
 OpenTelemetry follows the [Protobuf style guide](https://protobuf.dev/programming-guides/style/) with the following clarifications:
 
-- All Messages and fields should be documented via comments.
-- Field comments should document purpose or behavior with active verbs, or
-  a simple definition noun phrase (similar to a dictionary entry).
+### Naming Conventions
+- **Fields**: Use `snake_case` (e.g. `trace_id`, `dropped_attributes_count`).
+- **Messages & Enums**: Use `PascalCase` (e.g. `ResourceMetrics`, `SpanFlags`).
+- **Enum Values**: Use `UPPER_SNAKE_CASE` prefixed with the enum name (e.g. `SPAN_FLAGS_TRACE_FLAGS_MASK`).
+- **Service RPCs**: Use `PascalCase` for RPC methods (e.g. `Export`).
+
+### Documentation Comments
+- All messages, enums, enum values, and fields MUST be documented via comments.
+- Field comments should document purpose or behavior with active verbs, or a simple definition noun phrase (similar to a dictionary entry).
   - valid: "Represents ..."
     valid: "Additional attributes that describe the scope."
   - not-valid: "used to represent..."
 - Message and field comments may reference the field or message by name.
   - valid: "AnyValue ..."
   - valid: "The value ..."
+
+### Version Annotations ("Since" Labels)
+
+To assist downstream OTLP implementors in identifying when schema capabilities were introduced post v1.0, any element added MUST include a `[Since ...]` annotation in its doc comment (see [docs/specification.md#capability-versioning--schema-comments](docs/specification.md#capability-versioning--schema-comments)):
+
+Prior to release - use the placeholder `// [Since next]`. During the release process, maintainers will automatically convert this placeholder to the released version tag (e.g. `// [Since v1.11.0]`).
+
+Place the annotation on its own line within or directly below the element's doc comment block. Example:
+
+```protobuf
+// Additional metadata attributes that describe the metric. [Optional].
+//
+// [Since next]
+repeated opentelemetry.proto.common.v1.KeyValue metadata = 12;
+```
 
 ## Further Help
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,11 +6,13 @@ _Instruction for Maintainers only._
 [this PR](https://github.com/open-telemetry/opentelemetry-proto/pull/537).
 
 - Update any `// [Since next]` annotations in `.proto` files to the new release version tag (e.g. `// [Since v1.11.0]`):
+
   ```bash
   sed -i 's/\[Since next\]/\[Since v1.11.0\]/g' $(find opentelemetry/proto -name "*.proto")
   make gen-all
   ```
-Merge the PR. From this point on no new PRs can be merged until the release is complete.
+
+  Merge the PR. From this point on no new PRs can be merged until the release is complete.
 
 - Go to Github [release page](https://github.com/open-telemetry/opentelemetry-proto/releases),
 click `Draft a new release`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,12 @@ _Instruction for Maintainers only._
 
 - Prepare the release by updating [CHANGELOG.md](CHANGELOG.md), see for example
 [this PR](https://github.com/open-telemetry/opentelemetry-proto/pull/537).
+
+- Update any `// [Since next]` annotations in `.proto` files to the new release version tag (e.g. `// [Since v1.11.0]`):
+  ```bash
+  sed -i 's/\[Since next\]/\[Since v1.11.0\]/g' $(find opentelemetry/proto -name "*.proto")
+  make gen-all
+  ```
 Merge the PR. From this point on no new PRs can be merged until the release is complete.
 
 - Go to Github [release page](https://github.com/open-telemetry/opentelemetry-proto/releases),

--- a/opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
+++ b/opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
@@ -26,11 +26,15 @@ option go_package = "go.opentelemetry.io/proto/otlp/collector/profiles/v1develop
 
 // Service that can be used to push profiles between one Application instrumented with
 // OpenTelemetry and a collector, or between a collector and a central collector.
+//
+// [Since v1.4.0]
 service ProfilesService {
   rpc Export(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
 }
 
 // Status: [Alpha]
+//
+// [Since v1.4.0]
 message ExportProfilesServiceRequest {
   // An array of ResourceProfiles.
   // For data coming from a single resource this array will typically contain one
@@ -40,10 +44,14 @@ message ExportProfilesServiceRequest {
   repeated opentelemetry.proto.profiles.v1development.ResourceProfiles resource_profiles = 1;
 
   // The reference table containing all data shared by profiles across the message being sent.
+  //
+  // [Since v1.7.0]
   opentelemetry.proto.profiles.v1development.ProfilesDictionary dictionary = 2;
 }
 
 // Status: [Alpha]
+//
+// [Since v1.4.0]
 message ExportProfilesServiceResponse {
   // The details of a partially successful export request.
   //
@@ -64,6 +72,8 @@ message ExportProfilesServiceResponse {
 }
 
 // Status: [Alpha]
+//
+// [Since v1.4.0]
 message ExportProfilesPartialSuccess {
   // The number of rejected profiles.
   //

--- a/opentelemetry/proto/common/v1/common.proto
+++ b/opentelemetry/proto/common/v1/common.proto
@@ -46,6 +46,8 @@ message AnyValue {
     // empty, ignoring its semantic content for the non-Profiling signal.
     //
     // Status: [Alpha]
+    //
+    // [Since v1.10.0]
     int32 string_value_strindex = 8;
   }
 }
@@ -93,6 +95,8 @@ message KeyValue {
   // empty, ignoring its semantic content for the non-Profiling signal.
   //
   // Status: [Alpha]
+  //
+  // [Since v1.10.0]
   int32 key_strindex = 3;
 }
 
@@ -123,6 +127,8 @@ message InstrumentationScope {
 // Entity represents an object of interest associated with produced telemetry: e.g spans, metrics, profiles, or logs.
 //
 // Status: [Development]
+//
+// [Since v1.6.0]
 message EntityRef {
   // The Schema URL, if known. This is the identifier of the Schema that the entity data
   // is recorded in. To learn more about Schema URL see

--- a/opentelemetry/proto/logs/v1/logs.proto
+++ b/opentelemetry/proto/logs/v1/logs.proto
@@ -222,5 +222,7 @@ message LogRecord {
   // as an event.
   //
   // [Optional].
+  //
+  // [Since v1.5.0]
   string event_name = 12;
 }

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -217,6 +217,8 @@ message Metric {
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
   // The behavior of software that receives duplicated keys can be unpredictable.
+  //
+  // [Since v1.2.0]
   repeated opentelemetry.proto.common.v1.KeyValue metadata = 12;
 }
 

--- a/opentelemetry/proto/processcontext/v1development/process_context.proto
+++ b/opentelemetry/proto/processcontext/v1development/process_context.proto
@@ -37,6 +37,8 @@ option go_package = "go.opentelemetry.io/proto/otlp/processcontext/v1development
 // for details of this mechanism.
 //
 // Status: [Development]
+//
+// [Since next]
 message ProcessContext {
   // The resource for this process.
   // If this field is not set then no resource info is known.

--- a/opentelemetry/proto/processcontext/v1development/process_context.proto
+++ b/opentelemetry/proto/processcontext/v1development/process_context.proto
@@ -38,7 +38,7 @@ option go_package = "go.opentelemetry.io/proto/otlp/processcontext/v1development
 //
 // Status: [Development]
 //
-// [Since next]
+// [Since v1.11.0]
 message ProcessContext {
   // The resource for this process.
   // If this field is not set then no resource info is known.

--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -122,21 +122,29 @@ option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1development";
 //   MUST NOT have any observable effects for consumers.
 //
 // Status: [Alpha]
+//
+// [Since v1.7.0]
 message ProfilesDictionary {
   // Mappings from address ranges to the image/binary/library mapped
   // into that address range referenced by locations via Location.mapping_index.
   //
   // mapping_table[0] MUST be the zero value (Mapping{}) and present.
+  //
+  // [Since v1.7.0]
   repeated Mapping mapping_table = 1;
 
   // Locations referenced by samples via Stack.location_indices.
   //
   // location_table[0] MUST be the zero value (Location{}) and present.
+  //
+  // [Since v1.7.0]
   repeated Location location_table = 2;
 
   // Functions referenced by locations via Line.function_index.
   //
   // function_table[0] MUST be the zero value (Function{}) and present.
+  //
+  // [Since v1.7.0]
   repeated Function function_table = 3;
 
   // Links referenced by samples via Sample.link_index.
@@ -147,11 +155,15 @@ message ProfilesDictionary {
   // are both appropriate zero/invalid values per the trace.proto:Span definition,
   // the latter SHOULD be used for link_table[0] for better compatibility with codecs
   // strictly expecting 16/8 byte array lengths.
+  //
+  // [Since v1.7.0]
   repeated Link link_table = 4;
 
   // A common table for strings referenced by various messages.
   //
   // string_table[0] MUST be "" and present.
+  //
+  // [Since v1.7.0]
   repeated string string_table = 5;
 
   // A common table for attributes referenced by the Profile, Sample, Mapping
@@ -175,11 +187,15 @@ message ProfilesDictionary {
   //     "allocation_size": 128 bytes
   //
   // attribute_table[0] MUST be the zero value (KeyValueAndUnit{}) and present.
+  //
+  // [Since v1.7.0]
   repeated KeyValueAndUnit attribute_table = 6;
 
   // Stacks referenced by samples via Sample.stack_index.
   //
   // stack_table[0] MUST be the zero value (Stack{}) and present.
+  //
+  // [Since v1.8.0]
   repeated Stack stack_table = 7;
 }
 
@@ -195,6 +211,8 @@ message ProfilesDictionary {
 // as well.
 //
 // Status: [Alpha]
+//
+// [Since v1.4.0]
 message ProfilesData {
   // An array of ResourceProfiles.
   // For data coming from an SDK profiler, this array will typically contain one
@@ -205,9 +223,13 @@ message ProfilesData {
   // Resource.attributes and semantic conventions.
   // Tools that visualize profiles SHOULD prefer displaying
   // resources_profiles[0].scope_profiles[0].profiles[0] by default.
+  //
+  // [Since v1.4.0]
   repeated ResourceProfiles resource_profiles = 1;
 
   // A single instance of ProfilesDictionary shared across the entire message.
+  //
+  // [Since v1.7.0]
   ProfilesDictionary dictionary = 2;
 }
 
@@ -215,14 +237,20 @@ message ProfilesData {
 // A collection of ScopeProfiles from a Resource.
 //
 // Status: [Alpha]
+//
+// [Since v1.4.0]
 message ResourceProfiles {
   reserved 1000;
 
   // The resource for the profiles in this message.
   // If this field is not set then no resource info is known.
+  //
+  // [Since v1.4.0]
   opentelemetry.proto.resource.v1.Resource resource = 1;
 
   // A list of ScopeProfiles that originate from this resource.
+  //
+  // [Since v1.4.0]
   repeated ScopeProfiles scope_profiles = 2;
 
   // The Schema URL, if known. This is the identifier of the Schema that the resource data
@@ -231,19 +259,27 @@ message ResourceProfiles {
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to the data in the "resource" field. It does not apply
   // to the data in the "scope_profiles" field, which has its own schema_url field.
+  //
+  // [Since v1.4.0]
   string schema_url = 3;
 }
 
 // A collection of Profiles produced by an InstrumentationScope.
 //
 // Status: [Alpha]
+//
+// [Since v1.4.0]
 message ScopeProfiles {
   // The instrumentation scope information for the profiles in this message.
   // Semantically when InstrumentationScope isn't set, it is equivalent with
   // an empty instrumentation scope name (unknown).
+  //
+  // [Since v1.4.0]
   opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
 
   // A list of Profiles that originate from this instrumentation scope.
+  //
+  // [Since v1.4.0]
   repeated Profile profiles = 2;
 
   // The Schema URL, if known. This is the identifier of the Schema that the profile data
@@ -252,6 +288,8 @@ message ScopeProfiles {
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to the data in the "scope" field and all profiles in the
   // "profiles" field.
+  //
+  // [Since v1.4.0]
   string schema_url = 3;
 }
 
@@ -286,26 +324,36 @@ message ScopeProfiles {
 // specific fields.
 //
 // Status: [Alpha]
+//
+// [Since v1.4.0]
 message Profile {
   // The type and unit of all Sample.values in this profile.
   // For a cpu or off-cpu profile this might be:
   //   ["cpu","nanoseconds"] or ["off_cpu","nanoseconds"]
   // For a heap profile, this might be:
   //   ["allocated_objects","count"] or ["allocated_space","bytes"],
+  //
+  // [Since v1.4.0]
   ValueType sample_type = 1;
   // The set of samples recorded in this profile.
+  //
+  // [Since v1.9.0]
   repeated Sample samples = 2;
 
   // The following fields 3-12 are informational, do not affect
   // interpretation of results.
 
   // Time of collection (UTC) as nanoseconds since the UNIX epoch.
+  //
+  // [Since v1.4.0]
   fixed64 time_unix_nano = 3;
   // Duration of the profile in nanoseconds. For instant profiles like
   // live heap snapshot, the duration can be zero but it may be preferable
   // to set time_unix_nano to the process start time and duration_nano to
   // the relative time when the profile was gathered so that Sample.timestamps_unix_nano
   // values fall within the profile time range.
+  //
+  // [Since v1.8.0]
   uint64 duration_nano = 4;
   // The type and the unit of the events between sampled occurrences for
   // periodic sampling profiles. It can be the same as sample_type or it can be
@@ -321,9 +369,13 @@ message Profile {
   //   period=262144 might represent a heap profile where the recorded sample
   //   metric is the size of the live heap while the periodic sampling is done
   //   using the number of cumulatively allocated bytes.
+  //
+  // [Since v1.8.0]
   ValueType period_type = 5;
   // The distance between sampled occurrences for periodic sampling profiles.
   // The value is of the period_type type and unit.
+  //
+  // [Since v1.8.0]
   int64 period = 6;
 
   // A globally unique identifier for a profile. The ID is a 16-byte array. An ID with
@@ -332,11 +384,15 @@ message Profile {
   // in this field as not equal, even if they represented the same object at an earlier
   // time.
   // This field is optional; an ID may be assigned to an ID-less profile in a later step.
+  //
+  // [Since v1.9.0]
   bytes profile_id = 7;
 
   // The number of attributes that were discarded. Attributes
   // can be discarded because their keys are too long or because there are too many
   // attributes. If this value is 0, then no attributes were dropped.
+  //
+  // [Since v1.9.0]
   uint32 dropped_attributes_count = 8;
 
   // The original payload format. See also original_payload. It MUST be set
@@ -350,12 +406,18 @@ message Profile {
   // Profiles format. Including the original data allows receivers to store or
   // reexport the data without loss. Because the original payload can be large,
   // its inclusion is optional.
+  //
+  // [Since v1.9.0]
   string original_payload_format = 9;
   // The original payload bytes. See also original_payload_format. It MUST be set
   // together with original_payload_format or both left unset [optional].
+  //
+  // [Since v1.9.0]
   bytes original_payload = 10;
 
   // References to attributes in attribute_table. [optional]
+  //
+  // [Since v1.9.0]
   repeated int32 attribute_indices = 11;
 }
 
@@ -363,23 +425,35 @@ message Profile {
 // Connects a profile sample to a trace span, identified by unique trace and span IDs.
 //
 // Status: [Alpha]
+//
+// [Since v1.4.0]
 message Link {
   // A unique identifier of the trace that this linked span is part of. The ID is a
   // 16-byte array.
+  //
+  // [Since v1.4.0]
   bytes trace_id = 1;
 
   // A unique identifier for the linked span. The ID is an 8-byte array.
+  //
+  // [Since v1.4.0]
   bytes span_id = 2;
 }
 
 // ValueType describes the type and units of a value.
 //
 // Status: [Alpha]
+//
+// [Since v1.4.0]
 message ValueType {
   // Index into ProfilesDictionary.string_table.
+  //
+  // [Since v1.4.0]
   int32 type_strindex = 1;
 
   // Index into ProfilesDictionary.string_table.
+  //
+  // [Since v1.4.0]
   int32 unit_strindex = 2;
 }
 
@@ -415,21 +489,33 @@ message ValueType {
 // adopt the same data recording style.
 //
 // Status: [Alpha]
+//
+// [Since v1.4.0]
 message Sample {
   // Reference to stack in ProfilesDictionary.stack_table.
+  //
+  // [Since v1.8.0]
   int32 stack_index = 1;
   // References to attributes in ProfilesDictionary.attribute_table. [optional]
+  //
+  // [Since v1.5.0]
   repeated int32 attribute_indices = 2;
   // Reference to link in ProfilesDictionary.link_table. [optional]
   // 0 means no link exists.
+  //
+  // [Since v1.10.0]
   int32 link_index = 3;
 
   // The following fields may contain per-observation data and do not form part of the Sample's identity.
 
   // Measured values. The type and unit of each value is defined by Profile.sample_type.
+  //
+  // [Since v1.10.0]
   repeated int64 values = 4;
   // Timestamps (UTC) as nanoseconds since the UNIX epoch. The timestamps SHOULD fall within the
   // [Profile.time_unix_nano, Profile.time_unix_nano + Profile.duration_nano) interval.
+  //
+  // [Since v1.8.0]
   repeated fixed64 timestamps_unix_nano = 5;
 }
 
@@ -437,18 +523,30 @@ message Sample {
 // file offset, and metadata like build ID
 //
 // Status: [Alpha]
+//
+// [Since v1.4.0]
 message Mapping {
   // Address at which the binary (or DLL) is loaded into memory.
+  //
+  // [Since v1.4.0]
   uint64 memory_start = 1;
   // The limit of the address range occupied by this mapping.
+  //
+  // [Since v1.4.0]
   uint64 memory_limit = 2;
   // Offset in the binary that corresponds to the first mapped address.
+  //
+  // [Since v1.4.0]
   uint64 file_offset = 3;
   // The object this entry is loaded from.  This can be a filename on
   // disk for the main binary and shared libraries, or a virtual
   // abstraction like "[vdso]".
+  //
+  // [Since v1.4.0]
   int32 filename_strindex = 4;  // Index into ProfilesDictionary.string_table.
   // References to attributes in ProfilesDictionary.attribute_table. [optional]
+  //
+  // [Since v1.4.0]
   repeated int32 attribute_indices = 5;
 }
 
@@ -459,24 +557,34 @@ message Mapping {
 // [Location{"main"}, Location{"foo"}, Location{"bar"}].
 //
 // Status: [Alpha]
+//
+// [Since v1.8.0]
 message Stack {
   // References to locations in ProfilesDictionary.location_table.
   // The first location is the leaf frame.
+  //
+  // [Since v1.8.0]
   repeated int32 location_indices = 1;
 }
 
 // Contains function and line table debug information for a single frame.
 //
 // Status: [Alpha]
+//
+// [Since v1.4.0]
 message Location {
   // Reference to mapping in ProfilesDictionary.mapping_table.
   // 0 means unknown or not applicable.
+  //
+  // [Since v1.4.0]
   int32 mapping_index = 1;
   // The instruction address for this location, if available.  It
   // SHOULD be within [Mapping.memory_start, Mapping.memory_limit]
   // for the corresponding mapping. A non-leaf address may be in the
   // middle of a call instruction. It is up to display tools to find
   // the beginning of the instruction if necessary.
+  //
+  // [Since v1.4.0]
   uint64 address = 2;
   // Multiple lines indicate this location has inlined functions,
   // where the last entry represents the caller into which the
@@ -485,20 +593,32 @@ message Location {
   // E.g., if memcpy() is inlined into printf:
   //    lines[0].function_name == "memcpy"
   //    lines[1].function_name == "printf"
+  //
+  // [Since v1.9.0]
   repeated Line lines = 3;
   // References to attributes in ProfilesDictionary.attribute_table. [optional]
+  //
+  // [Since v1.4.0]
   repeated int32 attribute_indices = 4;
 }
 
 // Details a specific line in a source code, linked to a function.
 //
 // Status: [Alpha]
+//
+// [Since v1.4.0]
 message Line {
   // Reference to function in ProfilesDictionary.function_table.
+  //
+  // [Since v1.4.0]
   int32 function_index = 1;
   // Line number in source code. 1-based, 0 means unset.
+  //
+  // [Since v1.4.0]
   int64 line = 2;
   // Column number in source code. 1-based, 0 means unset.
+  //
+  // [Since v1.4.0]
   int64 column = 3;
 }
 
@@ -507,15 +627,25 @@ message Line {
 // {name_strindex, system_name_strindex, filename_strindex} MUST be present.
 //
 // Status: [Alpha]
+//
+// [Since v1.4.0]
 message Function {
   // The function name. Empty string if not available.
+  //
+  // [Since v1.4.0]
   int32 name_strindex = 1;
   // Function name, as identified by the system. For instance,
   // it can be a C++ mangled name. Empty string if not available.
+  //
+  // [Since v1.4.0]
   int32 system_name_strindex = 2;
   // Source file containing the function. Empty string if not available.
+  //
+  // [Since v1.4.0]
   int32 filename_strindex = 3;
   // Line number in source file. 1-based, 0 means unset.
+  //
+  // [Since v1.4.0]
   int64 start_line = 4;
 }
 
@@ -525,13 +655,21 @@ message Function {
 // and allows optional unit information.
 //
 // Status: [Alpha]
+//
+// [Since v1.8.0]
 message KeyValueAndUnit {
   // The index into the string table for the attribute's key.
+  //
+  // [Since v1.8.0]
   int32 key_strindex  = 1;
   // The value of the attribute.
+  //
+  // [Since v1.8.0]
   opentelemetry.proto.common.v1.AnyValue value = 2;
   // The index into the string table for the attribute's unit.
   // zero indicates implicit (by semconv) or non-defined unit.
   // If present, the unit string SHOULD be in UCUM format.
+  //
+  // [Since v1.8.0]
   int32 unit_strindex = 3;
 }

--- a/opentelemetry/proto/resource/v1/resource.proto
+++ b/opentelemetry/proto/resource/v1/resource.proto
@@ -41,5 +41,7 @@ message Resource {
   // Note: keys in the references MUST exist in attributes of this message.
   //
   // Status: [Development]
+  //
+  // [Since v1.6.0]
   repeated opentelemetry.proto.common.v1.EntityRef entity_refs = 3;
 }

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -133,6 +133,8 @@ message Span {
   // Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero.
   //
   // [Optional].
+  //
+  // [Since v1.1.0]
   fixed32 flags = 16;
 
   // A description of the span's operation.
@@ -287,6 +289,8 @@ message Span {
     // When creating new spans, bits 10-31 (most-significant 22-bits) MUST be zero.
     //
     // [Optional].
+    //
+    // [Since v1.1.0]
     fixed32 flags = 6;
   }
 
@@ -341,6 +345,8 @@ message Status {
 // OpenTelemetry protocol.  Older Span producers do not set this
 // field, consequently consumers should not rely on the absence of a
 // particular flag bit to indicate the presence of a particular feature.
+//
+// [Since v1.1.0]
 enum SpanFlags {
   // The zero value for the enum. Should not be used for comparisons.
   // Instead use bitwise "and" with the appropriate mask as shown above.
@@ -352,7 +358,10 @@ enum SpanFlags {
   // Bits 8 and 9 are used to indicate that the parent span or link span is remote.
   // Bit 8 (`HAS_IS_REMOTE`) indicates whether the value is known.
   // Bit 9 (`IS_REMOTE`) indicates whether the span or link is remote.
+  //
+  // [Since v1.5.0]
   SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK = 0x00000100;
+  // [Since v1.5.0]
   SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK = 0x00000200;
 
   // Bits 10-31 are reserved for future use.

--- a/opentelemetry/proto/trace/v1/trace.proto
+++ b/opentelemetry/proto/trace/v1/trace.proto
@@ -359,9 +359,9 @@ enum SpanFlags {
   // Bit 8 (`HAS_IS_REMOTE`) indicates whether the value is known.
   // Bit 9 (`IS_REMOTE`) indicates whether the span or link is remote.
   //
-  // [Since v1.5.0]
+  // [Since v1.2.0]
   SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK = 0x00000100;
-  // [Since v1.5.0]
+  // [Since v1.2.0]
   SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK = 0x00000200;
 
   // Bits 10-31 are reserved for future use.


### PR DESCRIPTION
Fixes #535

- Updated CONTRIBUTING.md, RELEASING.md etc. to define this requirement
- Adds copilot instructions to do automatic code review based on CONTRIBUTING.md sections.
- Backfills `since`


Note: for *profiling* this is a little ugly since profiling never really released, but it was interesting seeing the history.  cc @florianl for thoughts

Also - `event_name` is an interesting one because I think we added it after dropping it.  I'm leaving the "since" for when it was restored.