### PR TITLE
Fixes #460 - Add note that Timestamps are not RFC 3339 compatible in JSON

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -480,8 +480,13 @@ for mapping between Protobuf and JSON, with the following deviations from that m
 
 Note that according to [Protobuf specs](
 https://developers.google.com/protocol-buffers/docs/proto3#json) 64-bit integer
-numbers in JSON-encoded payloads are encoded as decimal strings, and either
-numbers or strings are accepted when decoding.
+numbers (`int64`, `sint64`, `uint64`, `fixed64`, `sfixed64`) in JSON-encoded
+payloads are encoded as decimal strings, and either numbers or strings are accepted
+when decoding. Because timestamp fields in OTLP (such as `timeUnixNano`,
+`startTimeUnixNano`, `endTimeUnixNano`, and `observedTimeUnixNano`) are defined as
+`fixed64` (representing nanoseconds since the Unix epoch) rather than the
+`google.protobuf.Timestamp` well-known type, they are encoded as decimal strings
+(e.g., `"timeUnixNano": "1544712660300000000"`), not as RFC 3339 formatted strings.
 
 The client and the server MUST set "Content-Type: application/json" request and
 response headers when sending JSON Protobuf encoded payload.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -482,11 +482,8 @@ Note that according to [Protobuf specs](
 https://developers.google.com/protocol-buffers/docs/proto3#json) 64-bit integer
 numbers (`int64`, `sint64`, `uint64`, `fixed64`, `sfixed64`) in JSON-encoded
 payloads are encoded as decimal strings, and either numbers or strings are accepted
-when decoding. Because timestamp fields in OTLP (such as `timeUnixNano`,
-`startTimeUnixNano`, `endTimeUnixNano`, and `observedTimeUnixNano`) are defined as
-`fixed64` (representing nanoseconds since the Unix epoch) rather than the
-`google.protobuf.Timestamp` well-known type, they are encoded as decimal strings
-(e.g., `"timeUnixNano": "1544712660300000000"`), not as RFC 3339 formatted strings.
+when decoding. This also applies to timestamp fields (such as `timeUnixNano`,
+`startTimeUnixNano`, `endTimeUnixNano`, and `observedTimeUnixNano`) that are defined as `fixed64`.
 
 The client and the server MUST set "Content-Type: application/json" request and
 response headers when sending JSON Protobuf encoded payload.


### PR DESCRIPTION
 Add to note about int/fixed types that timestamps in OTLP are ints, not the well-known type, so they do not follow RFC 3339
 
 Fixes #460 