### PR TITLE
profiles: specify OTLP Profiles development version metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The full list of changes can be found in the compare view for the respective rel
 
 ### Added
 
+- profiles: add temporary OTLP Profiles development version metadata. [#857](https://github.com/open-telemetry/opentelemetry-proto/pull/857)
+
 ### Changed
 
 ### Fixed

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -56,6 +56,7 @@ nodes such as collectors and telemetry backends.
     + [OTLP/HTTP Connection](#otlphttp-connection)
     + [OTLP/HTTP Concurrent Requests](#otlphttp-concurrent-requests)
     + [OTLP/HTTP Default Port](#otlphttp-default-port)
+- [Profiles Development Version](#profiles-development-version)
 - [Implementation Recommendations](#implementation-recommendations)
   * [Multi-Destination Exporting](#multi-destination-exporting)
   * [Empty Telemetry Envelopes](#empty-telemetry-envelopes)
@@ -714,6 +715,65 @@ connections SHOULD be configurable.
 #### OTLP/HTTP Default Port
 
 The default network port for OTLP/HTTP is 4318.
+
+## Profiles Development Version
+
+The Profiles signal uses the `v1development` package and service while
+incompatible changes to its Protobuf schema remain possible. To let a server
+identify the Profiles development format before deserializing a request, clients
+use temporary request metadata called the Profiles development version.
+
+This mechanism applies only to the
+`opentelemetry.proto.collector.profiles.v1development.ProfilesService` service
+and the `/v1development/profiles` HTTP endpoint. The version is carried as:
+
+* `otlp-profiles-development-version` request metadata for OTLP/gRPC.
+* The `OTLP-Profiles-Development-Version` request header for OTLP/HTTP.
+
+The version value MUST be a positive base-10 integer without leading zeros.
+Version `1` is the first Profiles development version. The current version is
+documented in
+[`profiles.proto`](../opentelemetry/proto/profiles/v1development/profiles.proto).
+
+The Profiles development version MUST be incremented by one for a schema change
+that could cause a server supporting the current version to fail to decode the
+request, lose information, or interpret the request incorrectly. Compatible
+changes MUST retain the current version.
+Changing the Profiles maturity level without such an incompatible change MUST
+NOT change the version.
+
+A client that serializes version `1` MAY omit the metadata; a client that
+serializes any later version MUST send it. When sent, the metadata MUST contain
+exactly one value assigned to that format. The value applies to the entire
+Export request.
+
+An intermediary that forwards an Export request without decoding and re-encoding
+its payload MUST preserve the Profiles development version metadata. If the
+metadata is removed, a request using a later version will be treated as version
+`1` and may be decoded incorrectly.
+
+A server MAY support one or more Profiles development versions. It MUST handle
+the metadata as follows:
+
+| Request metadata | Server behavior |
+| --- | --- |
+| Absent | Treat the request as version `1` |
+| Exactly one well-formed value | Use the value as the request version |
+| Malformed or repeated value | Reject the request before deserializing it |
+
+If the identified version is unsupported, the server MUST reject the request
+before deserializing it. A server MUST NOT substitute a different version or
+partially process an unsupported request. Rejections required by this section
+MUST use `INVALID_ARGUMENT` for OTLP/gRPC or `HTTP 400 Bad Request` for
+OTLP/HTTP. The client MUST NOT retry the same payload without the metadata or
+with a different version.
+
+Servers that predate this mechanism may ignore the metadata and attempt to
+process a request using an incompatible schema.
+
+The Profiles development version metadata MUST be removed when the Profiles
+signal becomes Stable and moves to the `v1` package, service, and HTTP endpoint.
+Clients and servers MUST NOT use this metadata with the stable Profiles service.
 
 ## Implementation Recommendations
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -735,15 +735,16 @@ Version `1` is the first Profiles development version. The current version is
 documented in
 [`profiles.proto`](../opentelemetry/proto/profiles/v1development/profiles.proto).
 
-Profiles development versions are assigned to `opentelemetry-proto` releases,
-not individual changes. During release preparation, the version MUST be
-incremented by one if the release contains one or more Profiles schema changes
-that could cause a server built from the preceding release to fail to decode the
-request, lose information, or interpret the request incorrectly. The version
-MUST be incremented at most once per release. A release containing only
-compatible Profiles schema changes MUST retain the current version. Changing the
-Profiles maturity level without an incompatible change MUST NOT change the
-version.
+The Profiles development version MUST be incremented by one for each
+incompatible Profiles schema change. A schema change is incompatible when it
+could cause a server supporting the current version to fail to decode the
+request, lose information, or interpret the request incorrectly. Each increment
+MUST update the version documented in
+[`profiles.proto`](../opentelemetry/proto/profiles/v1development/profiles.proto).
+Compatible changes MUST retain the current version. Changing the Profiles
+maturity level without an incompatible change MUST NOT change the version.
+Between `opentelemetry-proto` releases, the development version may increase
+by more than one, and gaps in the version sequence may occur.
 
 A client that serializes version `1` MAY omit the metadata; a client that
 serializes any later version MUST send it. When sent, the metadata MUST contain

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -735,12 +735,15 @@ Version `1` is the first Profiles development version. The current version is
 documented in
 [`profiles.proto`](../opentelemetry/proto/profiles/v1development/profiles.proto).
 
-The Profiles development version MUST be incremented by one for a schema change
-that could cause a server supporting the current version to fail to decode the
-request, lose information, or interpret the request incorrectly. Compatible
-changes MUST retain the current version.
-Changing the Profiles maturity level without such an incompatible change MUST
-NOT change the version.
+Profiles development versions are assigned to `opentelemetry-proto` releases,
+not individual changes. During release preparation, the version MUST be
+incremented by one if the release contains one or more Profiles schema changes
+that could cause a server built from the preceding release to fail to decode the
+request, lose information, or interpret the request incorrectly. The version
+MUST be incremented at most once per release. A release containing only
+compatible Profiles schema changes MUST retain the current version. Changing the
+Profiles maturity level without an incompatible change MUST NOT change the
+version.
 
 A client that serializes version `1` MAY omit the metadata; a client that
 serializes any later version MUST send it. When sent, the metadata MUST contain

--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -43,8 +43,9 @@ option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1development";
 
 // Current OTLP Profiles development version: 1.
 //
-// Increment this value by one when an incompatible Profiles schema change
-// requires a new development version. See
+// During release preparation, increment this value by one if the release
+// contains one or more incompatible Profiles schema changes since the preceding
+// release. Increment it at most once per release. See
 // docs/specification.md#profiles-development-version.
 
 //                Relationships Diagram

--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -41,6 +41,12 @@ option java_package = "io.opentelemetry.proto.profiles.v1development";
 option java_outer_classname = "ProfilesProto";
 option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1development";
 
+// Current OTLP Profiles development version: 1.
+//
+// Increment this value by one when an incompatible Profiles schema change
+// requires a new development version. See
+// docs/specification.md#profiles-development-version.
+
 //                Relationships Diagram
 //
 // ┌──────────────────┐                      LEGEND

--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -43,10 +43,8 @@ option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1development";
 
 // Current OTLP Profiles development version: 1.
 //
-// During release preparation, increment this value by one if the release
-// contains one or more incompatible Profiles schema changes since the preceding
-// release. Increment it at most once per release. See
-// docs/specification.md#profiles-development-version.
+// Increment this value by one for each incompatible Profiles schema change.
+// See docs/specification.md#profiles-development-version.
 
 //                Relationships Diagram
 //


### PR DESCRIPTION
## Changes

Defines a temporary development-version mechanism for OTLP Profiles `v1development` requests:

- Defines `otlp-profiles-development-version` request metadata for OTLP/gRPC and the corresponding `OTLP-Profiles-Development-Version` HTTP header.
- Uses positive integer versions, with missing metadata interpreted as version`1`.
- Documents the current version in `profiles.proto` and requires incrementing it once during preparation of a release containing one or more incompatible Profiles schema changes.
- Requires later-version clients to send exactly one version value and intermediaries forwarding an encoded payload to preserve it.
- Requires receivers to reject malformed, repeated, or unsupported versions before deserializing the request, using `INVALID_ARGUMENT` for OTLP/gRPC or `HTTP 400 Bad Request` for OTLP/HTTP.
- Requires removing the mechanism when Profiles moves to the stable `v1` service.

This PR defines the protocol behavior. Collector, SDK, and backend implementations will follow separately.

## Motivation

Profiles will continue using the same `v1development` package, service, and HTTP endpoint while incompatible Alpha and Beta schema changes remain possible. Because development formats share the same endpoint, a receiver cannot identify the expected schema before decoding the request. Protobuf decoding may still succeed while silently discarding or misinterpreting data, as could happen with changes such as https://github.com/open-telemetry/opentelemetry-proto/pull/786.

Carrying the development version outside the payload allows version-aware receivers to reject unsupported formats before decoding them.

This follows the direction discussed in https://github.com/open-telemetry/sig-profiling/issues/82. 

The detailed proposal and tradeoffs are documented in [Versioning OTLP Profiles](https://docs.google.com/document/d/1ZYf5CvxphaAXHzDxnC5PQr7Petn78-EImxjNiagwzF0/edit?tab=t.0#heading=h.xf6khaboen2a).

## Compatibility and rollout

Existing clients remain compatible because requests without the metadata are treated as version `1`.

Version-aware receivers should be deployed before clients begin sending a later version. Receivers that predate this mechanism may ignore the metadata and attempt to decode an incompatible payload. The linked proposal contains the detailed rollout sequence.
